### PR TITLE
[EWL-4432] rename "Topic Article Preview" to "Article Stub"

### DIFF
--- a/styleguide/source/_patterns/02-molecules/article-preview.json
+++ b/styleguide/source/_patterns/02-molecules/article-preview.json
@@ -1,25 +1,23 @@
 {
-  "topic_article_preview": {
-    "patternLab": true,
-    "title_only": "",
-    "link": {
-      "title": "Link to something",
-      "href": "#",
-      "text": "Lorem ipsum dolor sit amet.",
-      "class": "ama__link-black",
-      "target": "_self"
-    },
-    "image": {
-      "alt": "alt text",
-      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
-      "height": "600",
-      "width": "800"
-    },
-    "video": "",
-    "related": "",
-    "small": "",
-    "paragraph": {
-      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
-    }
+  "title_only": "",
+  "link": {
+    "title": "Link to something",
+    "href": "#",
+    "text": "Lorem ipsum dolor sit amet.",
+    "class": "ama__link-black",
+    "target": "_self"
+  },
+  "image": {
+    "alt": "alt text",
+    "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+    "height": "600",
+    "width": "800"
+  },
+  "video": "",
+  "related": "",
+  "small": "",
+  "class": "",
+  "paragraph": {
+    "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
   }
 }

--- a/styleguide/source/_patterns/02-molecules/article-preview.twig
+++ b/styleguide/source/_patterns/02-molecules/article-preview.twig
@@ -1,9 +1,9 @@
 {% set patternLab = topic_article_preview.patternLab %}
-{% set link = topic_article_preview.title %}
 {% set classes = [
   topic_article_preview.related ? "ama__topic_article-preview--related",
   topic_article_preview.small ? "ama__topic_article-preview--small"
 ] %}
+{% set link = title %}
 
 {#Topic media#}
 {% macro topic_mediaType(topic_article_preview) %}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4432: Article and Four Up Teaser](https://issues.ama-assn.org/browse/EWL-4432)


## Description

We needed to rename the article patterns to be more general so that they can be used across AMAOne. However, we did not want to break the existing d8 implementation with Twig templates existing in SG2, so this PR duplicates all of the Article Preview patterns and renames them to Article Stub. There will be a future PR/ticket in which the Article Preview patterns get marked as deprecated/removed when d8 is refactored to use Stubs.


## To Test
See that these patterns/variants look visually the same as their Article Preview counterparts:
- [x] Molecules > Article Stub
- [x] Molecules > Article Stub as Inline
- [x] Molecules > Article Stub Related
- [x] Molecules > Article Stub Small Image
- [x] Molecules > Article Stub Title Only
- [x] Molecules > Article Stub Video


## Visual Regressions

no regression testing is in place yet.


## Relevant Screenshots/GIFs

n/a


## Remaining Tasks

n/a


## Additional Notes

n/a

