### PR TITLE
EWL-4419 SG2 | Create Date atom 

### DIFF
--- a/styleguide/source/_patterns/01-atoms/date-block.md
+++ b/styleguide/source/_patterns/01-atoms/date-block.md
@@ -1,0 +1,16 @@
+### Description
+The date block is used in list items to display a date. 
+It contains the month, date, and year.
+If no date is entered the date will default to the current month, day and year.
+
+### Variables
+~~~
+header {
+  dateMonth:
+    type: string / optional 
+  dateDay:
+    type: string / optional
+  dateYear:
+    type: string / optional
+}
+~~~

--- a/styleguide/source/_patterns/01-atoms/date-block.twig
+++ b/styleguide/source/_patterns/01-atoms/date-block.twig
@@ -1,0 +1,7 @@
+{% set month, day, year = "now"|date("F"), "now"|date("d"), "now"|date("Y") %}
+
+<div class="date-block">
+  <span class="date-block__month">{{ dateMonth | default(month) }}</span>
+  <span class="date-block__day">{{ dateDay | default(day) }},</span>
+  <span class="date-block__year">{{ dateYear| default(year) }}</span>
+</div>

--- a/styleguide/source/assets/scss/01-atoms/_date-block.scss
+++ b/styleguide/source/assets/scss/01-atoms/_date-block.scss
@@ -1,0 +1,5 @@
+.date-block {
+  @include type($myriad-pro, $font-weight-bold);
+  @include font-size($small-font-sizes);
+  text-transform: uppercase;
+}


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWL-4419: Date Atom](https://issues.ama-assn.org/browse/EWL-4419)


## Description

Adds date atom. Will default to current day if nothings is filled in.

## To Test

- [ ]  http://localhost:3000/?p=atoms-date-block
- [ ] Observe a date block with the current date


## Visual Regressions

Does it it match SG1?


## Relevant Screenshots/GIFs

<img width="204" alt="screen shot 2018-01-16 at 4 51 00 pm" src="https://user-images.githubusercontent.com/2271747/35016274-74ed4aa0-fadd-11e7-9d11-ee0f801d5807.png">

## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
