### PR TITLE
[EWL-4124] SG2 | Migrate "Membership" pattern - regression fixes

### DIFF
--- a/styleguide/source/_patterns/03-organisms/membership.twig
+++ b/styleguide/source/_patterns/03-organisms/membership.twig
@@ -1,6 +1,6 @@
 {% set heading, paragraph, button = membership.heading, membership.paragraph, membership.button %}
 
-{% if button %}
+{% if not button %}
   <a href="{{ membership.link }}" class="ama__membership--link">
 {% endif %}
 
@@ -12,4 +12,4 @@
     {% include '@atoms/button.twig' %}
   {% endif %}
 </div>
-{% if button %}</a>{% endif %}
+{% if not button %}</a>{% endif %}

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -27,6 +27,10 @@
 .ama__membership--link {
   display: block;
 
+  &:hover {
+    color: $black;
+  }
+
   .ama__membership:hover {
     background: darken($topic_black-15, 5%);
   }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4124: SG2 | Migrate "Membership" pattern](https://issues.ama-assn.org/browse/EWL-4124)


## Description

Fixes:
- a regression in the Membership pattern in which the conditional for rendering the block either as a link or with a CTA button was reversed.
- a regression in the hover text color (was showing up as blue when it should be black)


## To Test

- [ ] Organisms > Membership - verify that it displays as a link (no CTA button) with a hover state
- [ ] Organisms > Membership with CTA - verify that it displays as a normal div and has a CTA button that links correctly to the destination from the data. Only the button should have a hover state.

## Visual Regressions

no visual regression testing is in place yet.

## Relevant Screenshots/GIFs

![screen shot 2018-01-22 at 12 01 33 pm](https://user-images.githubusercontent.com/12160398/35236188-048f4aea-ff6c-11e7-8bd2-f6a249e4589a.png)


## Remaining Tasks

N/A


## Additional Notes

This PR is required in order for https://github.com/AmericanMedicalAssociation/ama-d8/pull/231 to be merged.
