### PR TITLE
add topic class to topic page body

### DIFF
--- a/styleguide/source/_patterns/05-pages/topic.json
+++ b/styleguide/source/_patterns/05-pages/topic.json
@@ -1,4 +1,5 @@
 {
+  "bodyClass": "ama__topic",
   "ribbon": {
     "ribbonDropdown": {
       "triggerText": "American Medical Association",

--- a/styleguide/source/_patterns/05-pages/topic.md
+++ b/styleguide/source/_patterns/05-pages/topic.md
@@ -1,0 +1,19 @@
+---
+el: ".ama-topic"
+title: "Topic"
+---
+*note* this pattern uses a typography and color scheme that are now deprecated (via a `.ama-topic` class on the body and corresponding CSS overrides.) 
+
+An example of a Topic page, which may include:
+- Lead News block 
+- Sidebar block
+- Tools block
+- Membership block
+- Promo block
+
+In addition to these variable/CMS-driven content blocks, this page also includes a Ribbon and Footer.
+
+### Variables
+~~~
+TBD
+~~~

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -66,7 +66,7 @@ strong,
 }
 
 // Typography for topic pages
-body.topic {
+body.ama-topic {
   /* stylelint-disable property-no-vendor-prefix */
   -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
@@ -77,56 +77,56 @@ body.topic {
   //Topic Headers
 
   h1,
-  .topic__h1,
-  %topic__h1 {
+  .ama-topic__h1,
+  %ama-topic__h1 {
     @include type($kepler-std, $font-weight-semibold);
     @include font-size($h1-topic-font-sizes);
   }
 
   h2,
-  .topic__h2,
-  %topic__h2 {
+  .ama-topic__h2,
+  %ama-topic__h2 {
     @include type($kepler-std, $font-weight-semibold);
     @include font-size($h2-topic-font-sizes);
   }
 
   h3,
-  .topic__h3,
-  %topic__h3 {
+  .ama-topic__h3,
+  %ama-topic__h3 {
     @include type($kepler-std, $font-weight-semibold);
     @include font-size($h3-topic-font-sizes);
   }
 
   h4,
-  .topic__h4,
-  %topic__h4 {
+  .ama-topic__h4,
+  %ama-topic__h4 {
     @include type($myriad-pro, $font-weight-bold);
     @include font-size($h4-topic-font-sizes);
   }
 
   h5,
-  .topic__h5,
-  %topic__h5 {
+  .ama-topic__h5,
+  %ama-topic__h5 {
     @include type($myriad-pro, $font-weight-bold);
     @include font-size($h5-topic-font-sizes);
   }
 
   h6,
-  .topic__h6,
-  %topic__h6 {
+  .ama-topic__h6,
+  %ama-topic__h6 {
     @include type($myriad-pro, $font-weight-bold);
     @include font-size($h6-topic-font-sizes);
   }
 
   small,
-  .topic__type--small,
-  %topic__type--small {
+  .ama-topic__type--small,
+  %ama-topic__type--small {
     @include type($myriad-pro, $font-weight-bold);
     @include font-size($small-topic-font-sizes);
   }
 
-  .topic__type--italic,
-  %topic__type--italic {
+  .ama-topic__type--italic,
+  %ama-topic__type--italic {
     @include type($myriad-pro, $font-weight-bold);
     @include font-size($small-topic-font-sizes);
     font-style: italic;

--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -68,7 +68,7 @@ a {
 }
 
 //Topic page links
-body.topic {
+body.ama-topic {
   a {
     color: $topic_black;
     text-decoration: none;
@@ -86,8 +86,8 @@ body.topic {
   }
 }
 
-.topic__link--black,
-%topic__link--black {
+.ama-topic__link--black,
+%ama-topic__link--black {
   &:link,
   &:visited {
     color: $topic_black;
@@ -101,9 +101,9 @@ body.topic {
   }
 }
 
-.ama__link--white,
+.ama-ama__link--white,
 %link--white,
-.topic__link--white {
+.ama-topic__link--white {
   &:link,
   &:visited {
     color: $topic_white;
@@ -117,9 +117,9 @@ body.topic {
   }
 }
 
-.ama__link--blue,
+.ama-ama__link--blue,
 %link--blue,
-.topic__link--blue {
+.ama-topic__link--blue {
   &:link,
   &:visited {
     color: $topic_blue;

--- a/styleguide/source/assets/scss/01-atoms/_page-title.scss
+++ b/styleguide/source/assets/scss/01-atoms/_page-title.scss
@@ -1,6 +1,6 @@
 // Sets up the font styles for the page title atom
 .ama__page-title {
-  @extend %topic__h1;
+  @extend %ama-topic__h1;
   @include gutter($padding-top-full...);
   @include gutter($padding-bottom-full...);
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4388: Migrate Lead News Block](https://issues.ama-assn.org/browse/EWL-4388) (I branched off the work in this PR from the branch I was working on for that ticket. Please do not change the ticket status based on the merging of this PR!)


## Description

- Adds the `.ama-topic` class to the Topic page pattern in order to provide the ability to override styling (so we can style the page/child patterns using the deprecated color/type scheme).
- Adds a pattern info file to the Topic page pattern with some basic info that we should update as we add things to the topic page.
- Renames some CSS classes in accordance with the name change.

## To Test

- [ ] Pages > Topic - verify that the `body` element has a class `.topic`
- [ ] Pages > Topic - open Pattern Info - verify that it's there and contains a basis for useful information
- [ ] `gulp serve` and make sure there aren't any errors from things I missed whilst renaming the classes (I searched the code base, but `.topic` wasn't a super useful search term!)

## Visual Regressions

Visual regression testing isn't in place yet.

## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
