### PR TITLE
EWL-4433 Fixes type size for the column teaser to be smaller

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -29,6 +29,7 @@
 
     .ama__article-stub__copy {
       @extend .col-xs-9;
+      @extend %ama__type--small;
       @include gutter($padding-left-half...);
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.


**Jira Ticket**

- [EWL-4433: SG2 | Column teaser](https://issues.ama-assn.org/browse/EWL-4433)


## Description

`naleck Nick Aleck added a comment - 3 days ago
Article titles should be in the small desktop style, per typography document (Viewing in Chrome)`

Adjust type size to be smaller (ama__type__small)

## To Test

- [ ] http://localhost:3000/?p=pages-news
- Observe the smaller font sizes for the article teasers
- [ ] http://localhost:3000/?p=molecules-article-stub-as-related
- Observe the smaller font sizes

## Visual Regressions

Does your work introduce any visual regressions to existing work in the Style Guide, or in a Drupal 8 environment? Please either call these out here or address them before marking your PR as `ready for review`.


## Relevant Screenshots/GIFs

<img width="596" alt="screen shot 2018-01-26 at 3 19 06 pm" src="https://user-images.githubusercontent.com/2271747/35461158-43e30cac-02ac-11e8-9253-da5c40fa7c57.png">


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
