### PR TITLE
EWL-4419 changes date atom to use h3

### DIFF
--- a/styleguide/source/_patterns/01-atoms/date-block.twig
+++ b/styleguide/source/_patterns/01-atoms/date-block.twig
@@ -1,7 +1,7 @@
 {% set month, day, year = "now"|date("F"), "now"|date("d"), "now"|date("Y") %}
 
-<div class="date-block">
+<h3 class="ama__h3 date-block">
   <span class="date-block__month">{{ dateMonth | default(month) }}</span>
   <span class="date-block__day">{{ dateDay | default(day) }},</span>
   <span class="date-block__year">{{ dateYear| default(year) }}</span>
-</div>
+</h3>

--- a/styleguide/source/assets/scss/01-atoms/_date-block.scss
+++ b/styleguide/source/assets/scss/01-atoms/_date-block.scss
@@ -1,5 +1,3 @@
 .date-block {
-  @include type($myriad-pro, $font-weight-bold);
-  @include font-size($small-font-sizes);
-  text-transform: uppercase;
+  @include gutter($margin-top-full...)
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWL-4419: SG2 | Create Date atom](https://issues.ama-assn.org/browse/EWL-4419)


## Description
`naleck Nick Aleck added a comment - 4 days ago
The article date should be an h3, per the typography document (Viewing in Chrome)`

Adjust date block to use h3

## To Test
- [ ] http://localhost:3000/?p=atoms-date-block
- [ ] Observe the date block as an h3
- [ ] http://localhost:3000/?p=pages-news
- [ ] Observe to large date block font size
## Visual Regressions

Does your work introduce any visual regressions to existing work in the Style Guide, or in a Drupal 8 environment? Please either call these out here or address them before marking your PR as `ready for review`.


## Relevant Screenshots/GIFs

<img width="1298" alt="screen shot 2018-01-26 at 3 39 03 pm" src="https://user-images.githubusercontent.com/2271747/35461834-0f66c858-02af-11e8-909c-9aca0fc6324e.png">

## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
