### PR TITLE
EWL-4420 Adjust bio image to have a max of 80px

### DIFF
--- a/styleguide/source/_patterns/02-molecules/inline-bio.json
+++ b/styleguide/source/_patterns/02-molecules/inline-bio.json
@@ -3,7 +3,7 @@
     "image": {
       "alt": "Steven J Stack",
       "src": "https://www.ama-assn.org/sites/default/files/styles/medium/public/media-browser/public/people/steven-stack.jpg?itok=r6UW84zq",
-      "height": "175",
+      "height": "80",
       "width": ""
     },
     "heading": {

--- a/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
@@ -15,7 +15,8 @@
     @include breakpoint($bp-small) {
       display: inline-block;
       float: left;
-      max-width: 154px;
+      max-width: 80px;
+      max-height: 80px;
       margin-right: 30px;
     }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWL-4420: SG2 | Create Inline Bio in SG2](https://issues.ama-assn.org/browse/EWL-4420)


## Description

`naleck Nick Aleck added a comment - 4 days ago
Author's photo should be 80 x 80 pixels (Viewing in Chrome)`

Adjusts css and json file to ensure the bio image is always a max of 80px

## To Test

- [ ] http://localhost:3000/?p=organisms-article-header
- [ ] Observe the bio image with a width of 80px 
- [ ] http://localhost:3000/?p=pages-news
- [ ] Observe the bio image with a width of 80px 

## Visual Regressions

none


## Relevant Screenshots/GIFs

<img width="1242" alt="screen shot 2018-01-26 at 3 44 26 pm" src="https://user-images.githubusercontent.com/2271747/35461998-d05d99b0-02af-11e8-8f89-c448ad9adeee.png">


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
