### PR TITLE
EWL-4423 Adjust tags styling and spacing

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -1,16 +1,23 @@
 .ama__tags {
-  margin: 0;
-  padding: 0;
+  @include ama-rules(1px, "", $gray-7, solid);
+  @include ama-rules(1px, "bottom", $gray-7, solid);
+  @include gutter($margin-top-full...);
+  @include gutter($margin-bottom-full...);
+  @include gutter($padding-top-full...);
+  @include gutter($padding-bottom-full...);
   list-style-type: none;
-
-  li {
-    display: inline-block;
+  display: flex;
+  flex: 1;
+  
+  &:last-child {
+    margin-right: 0;
   }
-}
 
-.ama__tag {
-  display: inline-block;
-  padding: ($gutter / 4) ($gutter / 2);
-  background: $gray-7;
-  color: $purple;
+  .ama__tag {
+    @include gutter($margin-right-half...);
+    @include gutter-all($padding-all-half...);
+    display: block;
+    background: $gray-7;
+    color: $purple;
+  }
 }


### PR DESCRIPTION
tags uses flexbox instead of inline elements
margin and padding have been adjusted to give the tags more air

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWL-4423: Ticket Title](https://issues.ama-assn.org/browse/EWL-4423)


## Description

Adjust tags to have even padding on top and bottom along with a margin to air separate them from the the paragraph

## To Test
- [ ] http://localhost:3000/?p=molecules-tags
- Observe tags with borders on top and bottom and more space around them
- [ ] http://localhost:3000/?p=pages-news
- [ ] scroll to the bottom of the page and look for the tags list. They should be evenly spaced with a border on top and bottom

## Visual Regressions

none
<img width="964" alt="screen shot 2018-01-26 at 4 09 57 pm" src="https://user-images.githubusercontent.com/2271747/35462823-5f585990-02b3-11e8-9c54-a9bbf8b1546d.png">


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
