### PR TITLE
Updates the inline-block so it would have more padding around it

### DIFF
--- a/styleguide/source/_patterns/02-molecules/inline-block-copy.twig
+++ b/styleguide/source/_patterns/02-molecules/inline-block-copy.twig
@@ -1,12 +1,11 @@
 {% set heading, paragraph, button = inlineBlockCopy.heading, inlineBlockCopy.paragraph, inlineBlockCopy.button %}
 
-<div class="ama__inline-block-copy">
+<div class="ama__inline-block-copy col-xs-12 col-sm-4">
   <div class="ama__rule"></div>
-  <div class="ama__inline-block-copy--content">
+  <div class="ama__inline-block-copy__content">
     {% include "@atoms/heading.twig" %}
     {% include "@atoms/paragraph.twig" %}
     {% include "@atoms/button.twig" %}
   </div>
   <div class="ama__rule"></div>
 </div>
-

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
@@ -2,9 +2,9 @@
 $myriad-pro: "myriad-pro", "Helvetica", "Arial", "Open Sans", sans-serif;
 
 // Font weight variables
-$font-weight-regular: 100;
-$font-weight-semibold: 400;
-$font-weight-bold: 600;
+$font-weight-regular: 400;
+$font-weight-semibold: 600;
+$font-weight-bold: 900;
 
 $breakpoints: (
     small : 37.5em, // 600px

--- a/styleguide/source/assets/scss/02-molecules/_inline-block-copy.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-block-copy.scss
@@ -1,13 +1,24 @@
 .ama__inline-block-copy {
-  @extend .col-xs-4;
-  @include gutter($margin-all-half...);
-  float: left;
+  @include gutter($margin-right-full...);
+  @include gutter($margin-top-full...);
+  @include gutter($margin-bottom-full...);
+  float: none;
 
-  &--content {
-    @include gutter($padding-all-half...);
+  @include breakpoint($bp-xs min-width) {
+    float: left;
   }
 
-  .ama__h2 {
-    margin-top: 0;
+  .ama__rule {
+    margin: 0;
+  }
+
+  &__content {
+    @include gutter($padding-right-full...);
+    @include gutter($padding-top-full...);
+    @include gutter($padding-bottom-full...);
+  }
+
+  .ama__button {
+    @include gutter($margin-top-full...);
   }
 }

--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -14,7 +14,7 @@
 
   @include breakpoint($bp-small min-width) {
     grid-column: 1 / 4;
-    grid-row: 1 / 4;
+    grid-row: 1;
   }
 
   @include breakpoint($bp-med min-width) {
@@ -31,12 +31,6 @@
     grid-row: 2;
     -ms-grid-row: 2;
 
-    @include breakpoint($bp-small min-width) {
-      grid-column: 4;
-      grid-row: 1 / 3;
-      -ms-grid-row: 1;
-    }
-
     @include breakpoint($bp-med min-width) {
       grid-column: 1;
       grid-row: 1 / 4;
@@ -49,11 +43,6 @@
     @include gutter($padding-left-full...);
     grid-column: 1 / 5;
     grid-row: 3 / 4;
-
-    @include breakpoint($bp-small min-width) {
-      grid-column: 4;
-      grid-row: 3 / 4;
-    }
 
     @include breakpoint($bp-med min-width) {
       grid-column: 3;


### PR DESCRIPTION
Margin around the block

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWL-4429: Fix typography and padding](https://issues.ama-assn.org/browse/EWL-4429)


## Description

```
Nick Aleck added a comment - 3 days ago
Topic Promo –

body font should be 400 weight
there needs to be increased padding around the promo (Viewing in Chrome)
```

Addresses the margin and typography weight

## To Test

- [ ] http://localhost:3000/?p=molecules-inline-block-copy 
- [ ] Observe font weight
- [ ] http://localhost:3000/?p=pages-news
- [ ] Observe margin around the inline block content

## Visual Regressions

none

## Relevant Screenshots/GIFs

<img width="817" alt="screen shot 2018-01-26 at 2 10 44 pm" src="https://user-images.githubusercontent.com/2271747/35458637-b91c350c-02a2-11e8-9e77-0c9dee2b4986.png">

## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
