### PR TITLE
[NO TICKET] Update standards doc based on FED meeting conversations (2/6-2/8/2018)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,7 @@ If you would like to include commits from a different branch that has not been m
 
 * **All Pull Requests must follow the [Pull Request Template](PULL_REQUEST_TEMPLATE.md)**.
 * Encapsulate your work in the smallest discrete chunks possible.
+* Before creating a PR, run visual regression tests locally to ensure the work does not introduce any bugs into the codebase.
 * The title must be a simple imperative sentence; examples,
     * Good: Add Symfony code style documentation.
     * Bad: Adding Symfony code style documentation. [bad because it is declarative]
@@ -64,6 +65,7 @@ Commits must be atomic: the commit must be an indivisible and irreducible change
 ## Submitting work for review
 When you have finished development work on a ticket:
 
+1. Run visual regression tests locally to ensure the new work does not introduce any bugs into the codebase.
 1. In JIRA, change the ticket status from `In Progress` to `Development Complete`.
 1. Submit your PR to Github.
 1. Make sure that under "Assignees" you have assigned yourself to the PR.
@@ -83,8 +85,9 @@ When you have finished development work on a ticket:
     - Functionality: build your local environment. Check for expected behavior. The developer must have left some instructions for testing; follow these.
     - Visual QA: make sure nothing looks terribly broken. It's also usually a good idea to check against any style guide patterns linked in the "style guide" section of the PR template if applicable. Check responsive behavior. (Currently in our process, browser testing will be handled later.)
     - Code quality: follow [SG2 Standards](../docs/standards.md)! They're great! Individual repos have their own code standards, so be aware of those as well (Style Guide has a /docs folder, for Drupal follow Drupal best practices, etc.)
-5. On your local machine merge `develop` into the branch to preview how the branch will interact with the rest of the code base once merged. It's not necessary to push the merge commit. Repeat steps 3-4.
-6. Use the "Review" workflow features in GitHub to leave your review.
+5. Run visual regression tests locally to ensure the new code does not introduce any bugs.
+6. On your local machine merge `develop` into the branch to preview how the branch will interact with the rest of the code base once merged. It's not necessary to push the merge commit. Repeat steps 3-5.
+7. Use the "Review" workflow features in GitHub to leave your review.
     - If changes are requested or the PR is not ready to merge:
         - Change the label to 'question`.
         - Change Jira ticket/s status from `Development Complete` to `In Progress` to indicate that the developer still needs to make changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,14 @@ Explain the technical implementation of the work done.
 - [ ] Add detailed steps for reviewers to test this feature.
 
 ## Visual Regressions
-Does your work introduce any visual regressions to existing work in the Style Guide, or in a Drupal 8 environment? Please either call these out here or address them before marking your PR as `ready for review`.
+
+**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.
+
+_If the new work does your work introduce visual regressions into existing work in the Style Guide (or in a Drupal 8 environment)_, either call these out here or address them before marking the PR as `ready for review`.
 
 If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json) and have included a new or updated screenshot in [`bitmaps_reference`](ama-style-guide-2/styleguide/backstop_data/bitmaps_reference).
 
-For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in confluence.
+For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.
 
 
 ## Relevant Screenshots/GIFs

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -210,8 +210,10 @@ All `pattern.md` files must include the following elements:
 - Sass rules:
 - A sass file for new patterns (?)
 - Units of measurement
-- Color names
 - Globbing is fine as long as source maps are still included
+
+#### Color Naming
+Upon changes to the color palette, color variables should be named according to the new color palette provided by the UX team (which should include names).
 
 ### Javascript
 - JS approach

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -49,6 +49,7 @@ In order to maintain the traceability of our branches we **always** merge and **
 - Review the [Guidelines for Contributing](../.github/CONTRIBUTING.md)
 - Leave clear and descriptive testing instructions; examples,
     - [Good PR](https://github.com/AmericanMedicalAssociation/AMA-Corporate-site/pull/1262)
+- Run visual regression tests locally to ensure that the work does not introduce new bugs.
 
 ## PatternLab Standards
 ### How patterns are organized:

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -209,11 +209,15 @@ All `pattern.md` files must include the following elements:
 - Utilize extends whenever possible
 - Sass rules:
 - A sass file for new patterns (?)
-- Units of measurement
 - Globbing is fine as long as source maps are still included
 
 #### Color Naming
 Upon changes to the color palette, color variables should be named according to the new color palette provided by the UX team (which should include names).
+
+#### Units of Measurement
+- Pixel dimensions are used for rules under five pixels
+- Pixel dimensions are used for dimensions that are fixed.
+- Font sizing is in `em`s
 
 ### Javascript
 - JS approach

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -71,7 +71,7 @@ A molecule should include most of the markup and pull in atoms as necessary. Not
 
 #### Organisms
 An organism should be a section of a page, therefore if a component is visually a section of the page. Organisms should be very little markup, it should be mostly wrappers around molecules or atoms; examples,
-    - [Article Header](https://americanmedicalassociation.github.io/ama-style-guide-2/?p=organisms-article-header)
+    - [Masthead](https://americanmedicalassociation.github.io/ama-style-guide-2/?p=organisms-masthead)
 
 #### Templates
 Templates will be used for the general layouts (e.g. regions of the page) but not molecules. These pages exist to show what a page layout will look like but does not include any patterns for any specific pages; examples,


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
N/A

## Description
Update standards documents with decisions made during FED meetings (2/6/2018 and 2/8/2018). These updates include standards around color naming, units of measurement, and running visual regression testing when contributing to the codebase. 

## To Test
- [ ] Review the `docs/standards.md`
  - [ ] Observe you see a declaration for "Color names"
    - [ ] Observe that declaration indicates that color names should come from UX
  - [ ] Observe you see a declaration for "Units of Measurement"
    - [ ] Observe that declaration indicates that `px` should be used for small and fixed sizes
    - [ ] Observe that declaration indicates that `em` should be used for font sizes
  - [ ] Observe that within the "Guidelines for Contributing" you now see "Run visual regression tests locally..."
- [ ] Review `PULL_REQUEST_TEMPLATE.md`
  - [ ] Observe in the "Visual Regressions" section you now see "Before proceeding: run visual regression tests locally..."
- [ ] Review `CONTRIBUTING.md`
  - [ ] Observe you see "Before creating a PR, run visual regression tests locally..."
  - [ ] Observe in the "Submitting work for review" section the first step is "Run visual regression tests locally..."
  - [ ] Observe in the "Reviewing a PR" section there is now a step for "Run visual regression tests locally..."


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
