### PR TITLE
EWL-4527: Add margin to the article-inline-stub

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -52,9 +52,12 @@
   }
 
   &--inline {
+    @include gutter($padding-top-full...);
+    @include gutter($padding-bottom-full...);
+    @include gutter($margin-top-full...);
+    @include gutter($margin-bottom-full...);
     border: solid #eee;
     border-width: 1px 0;
-    padding: $gutter 0;
   }
 
   &--inline__label {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4527: SG2 | Article stub as inline molecule needs more spacing around it](https://issues.ama-assn.org/browse/EWL-4527)

## Description
UX has asked for a margin around the article stub as inline block so it's more prominent on the page and it doesn't touch the elements around it.

## To Test
- [x] `gulp serve`
- [x] go to the SG2 menu > molecules > article stub as inline
- [x] notice that the molecule has margins on the top and bottom
- [x] go to the SG2 menu > pages > news
- [x] scroll down "Example Label Text for an Inline Article Stub" in the main body
- [x] observe how the molecule has margins around it

## Visual Regressions
run `gulp backstop `


## Relevant Screenshots/GIFs
<img width="706" alt="screen shot 2018-02-12 at 2 58 57 pm" src="https://user-images.githubusercontent.com/2271747/36119347-4580b2c4-1005-11e8-8c3f-73d8a1d194a8.png">


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
