### PR TITLE
[EWL-4510] Add ama__link--black class to link

### DIFF
--- a/styleguide/source/_patterns/03-organisms/membership.twig
+++ b/styleguide/source/_patterns/03-organisms/membership.twig
@@ -2,7 +2,7 @@
 
 {% block startMembershipLink %}
   {% if not button %}
-    <a href="{{ membership.link }}" class="ama__membership--link">
+    <a href="{{ membership.link }}" class="ama__membership--link ama__link--black">
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- https://issues.ama-assn.org/browse/EWL-4510

## Description
Remove underlines from links on Membership by adding `ama__link--black` class to links.

## To Test
- [ ] Visit http://localhost:3000/?p=organisms-membership
- [ ] Verify that the link is not underlined.
- [ ] Verify that the link has the `ama__link--black` class.

## Visual Regressions
- [ ] Run `gulp test` and verify everything passes.


## Relevant Screenshots/GIFs
![screen shot 2018-02-15 at 4 24 48 pm](https://user-images.githubusercontent.com/231467/36281756-d650f53e-126c-11e8-9acb-6148583aebe1.png)



## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
