### PR TITLE
EWL-4617: Fix social share hover state

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_social-share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_social-share.scss
@@ -23,7 +23,8 @@ $social-icons: (
     width: 31px;
 
     &:hover {
-      background-image: url("../../assets/icons/svg/icon-" + $name + "-hover.svg");
+      background: url("../../assets/icons/svg/icon-" + $name + "-hover.svg");
+      background-size: 31px;
     }
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4617: SG2 | Correct the hover styling for the Social Share icons](https://issues.ama-assn.org/browse/EWL-4617)

## Description
The social share organism doesn't have the correct hover state. 

Current: On hover The social icons has a purple background with a blue icon
Expected: Only the icons should turn blue on hover and the background should remain transparent

## To Test
- [ ] `gulp serve`
- [ ] Go the the SG2 menu and look for organisms > social share
- [ ] Hover over the icons
- [ ] Observe that only the icons turn blue and the background remain transparent

## Visual Regressions
Ran `gulp backstop` while gulp serve was running.
No visual regressions were noted.


## Relevant Screenshots/GIFs
<img width="247" alt="screen shot 2018-02-26 at 5 07 27 pm" src="https://user-images.githubusercontent.com/2271747/36701071-8b17cf58-1b17-11e8-981c-aa92e8de8ff5.png">


## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
