### PR TITLE
[EWL-4640] - Remove purple background on aside links

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -17,6 +17,15 @@ a {
   }
 }
 
+aside {
+  a {
+    &:hover,
+    &:focus {
+      background: none; 
+    }
+  }
+}
+
 .ama__link--black,
 %ama__link--black {
   @include type($myriad-pro, $font-weight-regular);

--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -5,11 +5,6 @@ a {
   text-decoration: underline;
   outline: 0;
 
-  &:hover,
-  &:focus {
-    background-color: $hoverPurple;
-  }
-
   svg {
     height: 22px;
     width: 22px;
@@ -17,13 +12,13 @@ a {
   }
 }
 
-aside {
-  a {
-    &:hover,
-    &:focus {
-      background: none; 
-    }
-  }
+*[class*="__page-content"] {
+ a {
+   &:hover,
+   &:focus {
+     background-color: $hoverPurple;
+   }
+ }
 }
 
 .ama__link--black,


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- https://issues.ama-assn.org/browse/EWL-4640

## Description
Remove the purple background 'on hover' for links in the aside (sidebar) links.


## To Test
- [ ] Visit `http://localhost:3000/?p=pages-news` and verify that links in the aside do not have a purple background when hovering.

## Visual Regressions
Oddly enough no visual regression by BackstopJS.


## Relevant Screenshots/GIFs
![screen shot 2018-02-28 at 5 23 32 pm](https://user-images.githubusercontent.com/231467/36816621-561b3fd8-1cac-11e8-8e1f-12ce1e920d5d.png)



## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
