### PR TITLE
[EWL-4682] TOPICs | Remove unnecessary <div> around Membership Block

### DIFF
--- a/styleguide/source/_patterns/03-organisms/membership.json
+++ b/styleguide/source/_patterns/03-organisms/membership.json
@@ -6,7 +6,7 @@
       "class": "ama__h2"
     },
     "link": "http://www.google.com",
-    "paragraph" : {
+    "paragraph": {
       "text": "This could be a paragraph, or it could be an unordered list. Lorem ipsum dolor sit amet."
     }
   }

--- a/styleguide/source/_patterns/03-organisms/membership.twig
+++ b/styleguide/source/_patterns/03-organisms/membership.twig
@@ -1,9 +1,9 @@
 {% set
   link, button, paragraph, heading =
-  link ? link : membership.link,
-  button ? button : membership.button,
-  paragraph ? paragraph : membership.paragraph,
-  heading ? heading : membership.heading
+  membership.link,
+  membership.button,
+  membership.paragraph,
+  membership.heading
 %}
 
 {% if button %}

--- a/styleguide/source/_patterns/03-organisms/membership.twig
+++ b/styleguide/source/_patterns/03-organisms/membership.twig
@@ -1,26 +1,27 @@
-{% set heading, paragraph, button = membership.heading, membership.paragraph, membership.button %}
+{% set
+  link, button, paragraph, heading =
+  link ? link : membership.link,
+  button ? button : membership.button,
+  paragraph ? paragraph : membership.paragraph,
+  heading ? heading : membership.heading
+%}
 
-{% block startMembershipLink %}
-  {% if not button %}
-    <a href="{{ membership.link }}" class="ama__membership--link ama__link--black">
-  {% endif %}
-{% endblock %}
-
-<div class="ama__membership {{ class }}">
-  {% block membershipHeading %}
-   {% include '@atoms/heading.twig' %}
-  {% endblock %}
-
-  {% block membershipDescription %}
-    {% include '@atoms/paragraph.twig' %}
-  {% endblock %}
-
-  {% block membershipButton %}
-    {% if button %}
-      {% include '@atoms/button.twig' %}
+{% if button %}
+<div class="ama__membership">
+  {% else %}
+  <a href="{{ link }}" class="ama__membership">
     {% endif %}
-  {% endblock %}
+
+    {% include '@atoms/heading.twig' %}
+    {% include '@atoms/paragraph.twig' %}
+
+    {% if button %}
+      {% include '@atoms/button.twig' with {"style" : "primary"} %}
+    {% endif %}
+
+    {% if button %}
 </div>
-{% block EndMembershipLink %}
-  {% if not button %}</a>{% endif %}
-{% endblock %}
+{% else %}
+  </a>
+{% endif %}
+

--- a/styleguide/source/_patterns/03-organisms/membership~with-cta.json
+++ b/styleguide/source/_patterns/03-organisms/membership~with-cta.json
@@ -10,8 +10,7 @@
       "text": "This could be a paragraph, or it could be an unordered list. Lorem ipsum dolor sit amet."
     },
     "button": {
-      "text": "This is CTA text.",
-      "style": "primary"
+      "text": "This is CTA text."
     }
   }
 }

--- a/styleguide/source/_patterns/05-pages/news.json
+++ b/styleguide/source/_patterns/05-pages/news.json
@@ -272,8 +272,7 @@
       "text": "This could be a paragraph, or it could be an unordered list. Lorem ipsum dolor sit amet."
     },
     "button": {
-      "text": "This is CTA text.",
-      "style": "primary"
+      "text": "This is CTA text."
     }
   },
   "articleStubAsInline": {

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -29,14 +29,12 @@
   }
 }
 
-.ama__membership--link {
+a.ama__membership {
   display: block;
+  text-decoration: none;
 
   &:hover {
     color: $black;
-  }
-
-  .ama__membership:hover {
-    background: darken($gray-50, 5%);
+    background: darken($gray-7, 8%); // from UX - #d9d9d9
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4682: TOPICs | Remove unnecessary `<div>` around Membership Block](https://issues.ama-assn.org/browse/EWL-4682)

## Description
**This is the SG2 counterpart to https://github.com/AmericanMedicalAssociation/ama-d8/pull/300 and the two should be merged/reviewed concurrently.**

Refactors the Membership block:
- Removes the capability to use block extends for better SG2:d8 parity
- Refactors the block so that its conditional logic for displaying as a link vs. a div does not produce a wrapping `<div>` (which was messing with theming in d8)
- Hard-codes `style: primary` into the template to force that styling on the button, per requirements, as this should not be configurable
- Fixes the hover styling (changed from a darker gray to a UX-approved lighter gray, to match the promo).


## To Test
- [ ] `gulp serve`
- [ ] Navigate to http://localhost:3000/?p=organisms-membership and observe that it functions properly.
- [ ] Navigate to http://localhost:3000/?p=organisms-membership-with-cta and observe that it functions properly.
- [ ] Verify that the Membership blocks look correct on the following pages:
-- http://localhost:3000/?p=pages-news
-- http://localhost:3000/?p=pages-press-release
-- http://localhost:3000/?p=pages-topic

## Visual Regressions
![screen shot 2018-03-07 at 11 14 30 am](https://user-images.githubusercontent.com/12160398/37106987-c6aacf24-21f8-11e8-9a99-ee8cd02fe7fc.png)
No visual regressions to report for items with an existing test scenario. I didn't need to update any reference images.

## Relevant Screenshots/GIFs
There should be no visual change to the Membership block.

![screen shot 2018-03-07 at 11 20 26 am](https://user-images.githubusercontent.com/12160398/37107297-936433fc-21f9-11e8-8c65-eb66f1fbcab0.png)
![screen shot 2018-03-07 at 11 20 16 am](https://user-images.githubusercontent.com/12160398/37107298-9372b760-21f9-11e8-96c8-4d22111ce7ed.png)



## Remaining Tasks
- [x] Flag that thing about headings and top-levels in .json objects (@designerneil is going to look into a solution that doesn't require stripping the top level from `foo.json`)
- [x] Flag that thing about Membership needing to be a molecule and not an organism
- [x] Backstop test and update refs if needed
- [ ] Flag that thing about should we have two separate block types for AMAOne or nah

## Additional Notes

N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
