### PR TITLE
[EWL-4724] SG2/D8 | Fix heading text for the Footer to work in D8

### DIFF
--- a/styleguide/source/_patterns/03-organisms/footer.json
+++ b/styleguide/source/_patterns/03-organisms/footer.json
@@ -1,7 +1,4 @@
 {
-  "heading": {
-    "text": "The AMA promotes the art and science of medicine and the betterment of public health."
-  },
   "menus": {
     "utility": [
       {

--- a/styleguide/source/_patterns/03-organisms/footer.twig
+++ b/styleguide/source/_patterns/03-organisms/footer.twig
@@ -1,4 +1,7 @@
-{% set heading = heading|merge({ "level": "2", "class": "ama__h2 ama__mission-statement" }) %}
+{% set heading = {
+  "text": "The AMA promotes the art and science of medicine and the betterment of public health.",
+  "level": "2",
+  "class": "ama__h2 ama__mission-statement" } %}
 
 <footer class="ama__footer">
   <div class="container ama__footer__container">


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4724: SG2/D8 | Fix heading text for the Footer to work in D8](https://issues.ama-assn.org/browse/EWL-4724)

## Description
Removes the mission statement text from `footer.json` to `footer.twig` because A) it was causing errors in d8 and B) we don't need to make it configurable. 


## To Test
- [ ] `gulp serve`
- [ ] Go to Pages > Topic and observe that you can see the mission statement text in the footer and that the styling looks correct.
- [ ] symlink your local SG2 to your local d8 and test there; observe that you can load a Topic node using the Rivendell theme and that the styling looks correct.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![screen shot 2018-03-12 at 4 47 24 pm](https://user-images.githubusercontent.com/12160398/37311393-0f289176-2615-11e8-9ca0-de76b5b1aa39.png)


## Remaining Tasks
- [x] Test in d8.


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
