### PR TITLE
EWL-4655: Add secondary button variation

### DIFF
--- a/styleguide/source/_patterns/01-atoms/button~as-secondary.json
+++ b/styleguide/source/_patterns/01-atoms/button~as-secondary.json
@@ -1,0 +1,10 @@
+{
+  "button": {
+    "href": "",
+    "info": "alt",
+    "text": "Button",
+    "type": "button",
+    "style": "secondary",
+    "size": ""
+  }
+}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4655: Secondary Button Variant? Investigate](https://issues.ama-assn.org/browse/EWL-4655)

## Description
Secondary button variation is missing

## To Test
- [x] `gulp serve`
- [x] go to http://localhost:3000/?p=atoms-button
- [x] bring up the pattern info window
- [x] Under the variations header click on secondary
- [x] Observe a button with a purple outline and transparent background with purple text

## Visual Regressions
Run `gulp backstop`
Observe not errors
No new backstop ref images were added

## Relevant Screenshots/GIFs
<img width="173" alt="screen shot 2018-03-14 at 11 45 55 am" src="https://user-images.githubusercontent.com/2271747/37417025-46cd4e78-277d-11e8-9781-d03f82b0644e.png">


## Remaining Tasks
N/a

## Additional Notes
N/A



---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
