### PR TITLE
EWL-4525: Tool title hover state does not have an underline 

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tool.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tool.scss
@@ -2,14 +2,15 @@
   @include gutter($padding-top-half...);
   @include gutter($padding-bottom-half...);
   @include ama-rules(1px, "", $gray-64, solid);
+  $c: &; //Sets the parent selector as a variable to be used later
   display: flex;
   align-items: center;
   width: 100%;
-  
+
   &:hover {
     text-decoration: none;
 
-    &__text p {
+    #{$c}__text p {
       text-decoration: underline;
     }
   }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4525: SG2 | Tools organism padding and text styles incorrect](https://issues.ama-assn.org/browse/EWL-4525)

## Description
This PR fixes an regression in the tools title styles. The hover state did not have an underline.

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=organisms-tools
- [x] hover over the tools titles
- [x] observe the titles with underlines when the cursor is over the text

## Visual Regressions
Ran `gulp backstop` no errors were found.

## Relevant Screenshots/GIFs
<img width="295" alt="screen shot 2018-03-27 at 11 38 01 am" src="https://user-images.githubusercontent.com/2271747/37981449-56522b1c-31b3-11e8-981a-bb6a16929529.png">


## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
