### PR TITLE
EWL-4615: Add copyTwigFiles gulp task to drupal-deploy.

### DIFF
--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -341,19 +341,6 @@ gulp.task('drupal-deploy', function () {
   runSequence('default', 'copyTwigFiles', 'publish');
 });
 
-// Function: Tagging deployed code
-// Description: After code is pushed to master using master-deploy, tag it.
-gulp.task('tag', function () {
-  return gulp.src(config.versioning.files)
-  // Fetch master so that we can tag it.
-    .pipe(shell(['git fetch origin master:master']))
-
-    // Tag it.
-    .pipe(tagversion())
-    // Push tag.
-    .pipe(shell(['git push --tags']));
-});
-
 gulp.task('set-master', function (callback) {
   // Change the deploy branch
   gutil.log('Setting branch to master.');
@@ -369,5 +356,5 @@ gulp.task('release', function (callback) {
   runSequence = require('run-sequence').use(gulp);
   // Build the style guide, publish to gh-pages, set the branch to master,
   // publish to master, then tag master.
-  runSequence('default', 'publish', 'set-master', 'tag', callback);
+  runSequence('default', 'publish', 'set-master', callback);
 });

--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -338,7 +338,7 @@ gulp.task('drupal-deploy', function () {
   // Change the deploy branch
   config.deployment.branch = "dev-assets";
   // run default to build the code and then publish it to our branch
-  runSequence('default', 'publish');
+  runSequence('default', 'copyTwigFiles', 'publish');
 });
 
 // Function: Tagging deployed code


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-4802: SG2 | Update gulp release to work as D8 expects](https://issues.ama-assn.org/browse/EWL-4802)

## Description
- Adds `copyTwigFiles` task to the `drupal-deploy` sequence, ensuring the `/twig` directory exists in `dev-assets` branch
- Removes the gulp `tag` task entirely, including reference in the `release` task sequence

Moving forward, the `dev-assets` branch of SG2 will include the `twig` directory.  Tagged releases will happen in GitHub, consistent with our other codebases.  Tags will be made against `dev-assets` as the target branch, making TWIG consumption in D8 impossible.


## To Test
- [ ] Run `gulp drupal-deploy` or `gulp release`.  Observe the `dev-assets` branch now has the `twig` directory in it.

## Visual Regressions

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_If the new work does your work introduce visual regressions into existing work in the Style Guide (or in a Drupal 8 environment)_, either call these out here or address them before marking the PR as `ready for review`.

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json) and have included a new or updated screenshot in [`bitmaps_reference`](ama-style-guide-2/styleguide/backstop_data/bitmaps_reference).

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
