### PR TITLE
[EWL-4766] - Remove the divider when there is no metadata on an Article Stub

### DIFF
--- a/styleguide/source/_patterns/02-molecules/article-stub-metadata.twig
+++ b/styleguide/source/_patterns/02-molecules/article-stub-metadata.twig
@@ -1,2 +1,9 @@
-<span class="ama__article-stub__metadata__date">{{ metadata.date|default('Jul 28, 2017') }}</span> |
-<span class="ama__article-stub__metadata__read-time">{{ metadata.readtime|default("5 min read") }}</span>
+{% if metadata.date %}
+  <span class="ama__article-stub__metadata__date">{{ metadata.date|default('Jul 28, 2017') }}</span>
+{% endif %}
+{% if metadata.readtime %}
+  {% if metadata.date %}
+    |
+  {% endif %}
+  <span class="ama__article-stub__metadata__read-time">{{ metadata.readtime|default("5 min read") }}</span>
+{% endif %}


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- https://issues.ama-assn.org/browse/EWL-4768

## Description
Removed the divider when there is no metadata present on an Article Stub.


## To Test
- [ ] Visit http://localhost:3000/?p=molecules-article-stub
- [ ] Adjust JSON file by remove one of date and readtime.
- [ ] You should only see a divider when date and readtime are present!

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
![screen shot 2018-04-02 at 10 29 32 am](https://user-images.githubusercontent.com/231467/38200108-11b37706-3661-11e8-90e0-bac17e14ecf8.png)
![screen shot 2018-04-02 at 10 32 04 am](https://user-images.githubusercontent.com/231467/38200144-302da08a-3661-11e8-85e0-19a78d076f06.png)



## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
