### PR TITLE
[EWL-4843] Visual Regression in Promo Patterns in current develop branch

### DIFF
--- a/styleguide/source/_patterns/02-molecules/promo.twig
+++ b/styleguide/source/_patterns/02-molecules/promo.twig
@@ -9,7 +9,7 @@
 %}
 
 {% if button %}
-  <div {{ setAttributes('ama__promo', attributes) }}>
+  <div class="ama__promo ama__promo--{{ style }}">
 {% else %}
   <a href="{{ link }}" class="ama__promo ama__promo--{{ style }}">
 {% endif %}

--- a/styleguide/source/_patterns/05-pages/topic.twig
+++ b/styleguide/source/_patterns/05-pages/topic.twig
@@ -1,4 +1,5 @@
 {% extends '@templates/three-column.twig' %}
+
 {% block header %}
   {% include '@organisms/ribbon.twig' %}
   {% include '@organisms/wayfinder.twig' %}

--- a/styleguide/source/_patterns/05-pages/topic.twig
+++ b/styleguide/source/_patterns/05-pages/topic.twig
@@ -1,5 +1,4 @@
 {% extends '@templates/three-column.twig' %}
-
 {% block header %}
   {% include '@organisms/ribbon.twig' %}
   {% include '@organisms/wayfinder.twig' %}


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-4843: Visual Regression in Promo Patterns in current develop branch](https://issues.ama-assn.org/browse/EWL-4843)

## Description
The promo molecule with CTA on topic pages in `dev-assets` has a 1px border around its content. In the current `develop` branch a visual regression has been introduced in which the promo molecule with CTA does not have that border on the topic page.

This update corrects the visual regression by applying a dynamic style class along with the "ama--promo" class. This style, which adds a border or color background, is determined when adding the promo molecule to a topic page in Drupal.

## To Test
- [ ] Pull `develop` branch.
- [ ] Run `gulp serve` to ensure a local version of style guide is running
- [ ] Navigate to topic page, http://localhost:3000/?p=pages-topic.
- [ ] Scroll down and  confirm promo molecule with CTA  in left sidebar does not have a border.
- [ ] Pull `bugfix/EWL-4843-visual-regression-promo-patterns` branch.
- [ ] Run `gulp serve` to ensure a local version of style guide is running
- [ ] Navigate to topic page, http://localhost:3000/?p=pages-topic.
- [ ] Scroll down and confirm promo molecule with CTA in left sidebar has border.
- [ ] In new browser tab go to topic page on `dev-assets` version of style guide, https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-topic.
- [ ] Confirm topic page from local `bugfix/EWL-4843-visual-regression-promo-patterns` branch matches `dev-assets`.


## Visual Regressions

When testing there should be no visual regressions from this branch.


## Relevant Screenshots/GIFs
**Screenshot with visual regression in `develop`**

![page-topics--partial-page-screenshot-with-regression](https://user-images.githubusercontent.com/4438120/38627641-1535ac6c-3d75-11e8-9dfc-dd7f781cea2f.png)

**Screenshot without visual regression in `bugfix/EWL-4843-visual-regression-promo-patterns`**

![page-topics--partial-page-screenshot](https://user-images.githubusercontent.com/4438120/38584553-482a0954-3cdc-11e8-9224-e2f234916812.png)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
