### PR TITLE
[EWL-4862] Margins between blocks in the side columns on the Topics Page is inconsistent

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_three_column.scss
+++ b/styleguide/source/assets/scss/04-templates/_three_column.scss
@@ -47,6 +47,12 @@
   &--primary,
   &--secondary {
     @include child-top-gutters($gutter);
+
+    & > div[class*="ama__"], div:not([class*="ama__"]) > div[class*="ama__"] {
+      & + div[class*="ama__"] {
+        @include gutter($margin-top-full...);
+      }
+    }
   }
 
   &--primary {


### PR DESCRIPTION
…ent when viewed in D8.

## Ticket(s)

**Jira Ticket**
- [EWL-4862: Margins between blocks in the side columns on the Topics Page is inconsistent](https://issues.ama-assn.org/browse/EWL-4862)

## Description
Topic pages have sidebars which contain consecutive blocks of content. A vertical margin of 28px should exist between each consecutive block of content. Currently when in the develop branch of ama-d8 and directly consuming the css from the local develop branch of ama-style-guide-2, content blocks on the topic page have no vertical margin between each other.

This update provides a fix to this bug, adding a 28px margin-top to consecutive blocks of aside content via a pre-existing, custom, scss gutter mixin. The code will apply only to a three column layout where direct children of asides or direct children nested within wrapping divs in asides contain the fragment “ama__” in its class attribute.


## To Test

- [ ] Pull `develop` branch for ama-d8 and ama-style-guide-2.
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- [ ] Run `vagrant up` in ama-d8 to spin up the local ama-d8 site.
- [ ] SSH into vagrant and run `scripts\refresh-local` to get prod database. Using the test data will also suffice.
- [ ] Ensure Rivendell theme is enabled.
- [ ] Navigate to any topic page in ama-d8 and view aside content blocks. These blocks will not have vertical margins between them.
- [ ] Pull `bugfix/EWL-4862-margins-between-blocks-topic-page`.
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide.
- [ ] Inside vagrant run `drush @ama-d8.local cr` to clear caches in ama-d8.
- [ ] Navigate to any topic page in ama-d8 and view aside content blocks. They should now have vertical margins between them.


## Visual Regressions

When testing via backstop only 7 fails should show and those failures come from differences in the exact date displayed for membership block molecules.


## Relevant Screenshots/GIFs

**Example topic page with vertical margin issues on `develop` branches**

![topic-page--margin-issues--marked](https://user-images.githubusercontent.com/4438120/38702354-1236287e-3e66-11e8-986f-cc607416b944.png)


**Example topic page with vertical margins fixed on `bugfix/EWL-4862-margins-between-blocks-topic-page`**

![topic-page--margin-fixed-marked](https://user-images.githubusercontent.com/4438120/38702384-25a5d21a-3e66-11e8-895c-4ad7ef0a677c.png)


## Remaining Tasks
N/A


## Additional Notes
This fix may need revisiting if ama-d8 integrates layout builder.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
