### PR TITLE
SG2 | Vertical alignment top for tools icons

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tool.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tool.scss
@@ -5,7 +5,7 @@
   @extend %ama__link--no-underline;
   $c: &; //Sets the parent selector as a variable to be used later
   display: flex;
-  align-items: center;
+  align-items: top;
   width: 100%;
 
   &:hover {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4874: SG2 | Vertical alignment top for tools icons](https://issues.ama-assn.org/browse/EWL-4874)

## Description
Topic pages have sidebars which contain a tool bar block. When tool bar content contains multiple lines of text, the associated icon should vertically align top. Currently when in the `develop` branch of ama-d8 and directly consuming the css from the local develop branch of ama-style-guide-2, the tools block icons are vertically aligned center.

This update provides a fix to this issue by changing the flex `align-items` property to `flex-start`. 


## To Test

- [ ] Pull `develop` branch for ama-d8 and ama-style-guide-2.
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- [ ] Run `vagrant up` in ama-d8 to spin up the local ama-d8 site.
- [ ] SSH into vagrant and run `scripts\refresh-local` to get prod database. Using the test data will also suffice.
- [ ] Ensure Rivendell theme is enabled.
- [ ] Navigate to any topic page in ama-d8 and view tools block in the left aside. Note that the icons are vertically aligned to the center of each row of content.
- [ ] Pull `bugfix/EWL-4874-vertical-alignment-tool-icons`.
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide.
- [ ] Inside vagrant run `drush @ama-d8.local cr` to clear caches in ama-d8.
- [ ] Navigate to any topic page in ama-d8 and view tools block in the left aside. Icons should now be vertical aligned to the top of each row of content.


## Visual Regressions

When testing via backstop there is only one fail from the membership molecule. Please note that this PR is before the branch fixing backstop reference images for tool section. Reference PR located at https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/175 for more information on changes. If merged before testing this PR, multiple regressions will show for toolbar molecules.



## Relevant Screenshots/GIFs

**Example topic page tool icons with vertical alignment centered, `develop` branch**

<img width="239" alt="d8-topicpage-toolsblock-iconvcentered" src="https://user-images.githubusercontent.com/4438120/38894514-0dac8fb4-4253-11e8-9cf7-c467b5990412.png">



**Example topic page tool icons with vertical aligned with top of div `bugfix/EWL-4874-vertical-alignment-tool-icons`**

<img width="239" alt="d8-topicpage-toolsblock-iconvtop" src="https://user-images.githubusercontent.com/4438120/38894524-149fed7a-4253-11e8-96f5-a37c3d00286b.png">



## Remaining Tasks
N/A


## Additional Notes
N/A


