### PR TITLE
EWL-4884 - Fix icons not showing up in dev-assets

### DIFF
--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -282,6 +282,7 @@ gulp.task('default', ['clean:before'], function (callback) {
     'patternlab',
     'styleguide',
     'copyTwigFiles',
+    'svg2twig',
     'sass',
     'scripts',
     callback


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4884: SG2 | Gulpfile not exporting icons](https://issues.ama-assn.org/browse/EWL-4884)

## Description
The icons directory is not getting exported to our dev-assets repo. We need them to do a deploy.

## To Test
- [ ] in your local SG2 do a `gulp drupal-deploy`
- [ ] go to https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/dev-assets
- [ ] under the assets directory makes sure there is an icon directory

## Visual Regressions

N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
