### PR TITLE
[EWL-4876] Topics | Mobile header overflow

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_ribbon-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_ribbon-dropdown.scss
@@ -15,7 +15,6 @@
     color: $white;
     cursor: pointer;
     outline: none;
-    min-width: 12.5em;
     padding: 15px;
     width: 100%;
     border-left: 1px solid $gray-50;
@@ -56,7 +55,7 @@
 
   &__nav {
     position: absolute;
-    left: 0;
+    right: -1px;
     top: 100%;
     max-height: 0;
     overflow: hidden;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4876: Topics | Mobile header overflow](https://issues.ama-assn.org/browse/EWL-4876)

## Description
Tweaks some CSS so that the user menu in the ribbon doesn't flow outside the page at mobile breakpoints.

## To Test
- [ ] `gulp serve`
- [ ] Visit Pages > Topic. Resize to small/mobile width. Confirm that the user menu is visible on the right-hand side, and that the menu expands and is visible and not cut off by the viewport edge.

## Visual Regressions
No backstop tests exist for this element.


## Relevant Screenshots/GIFs
<img width="459" alt="screen shot 2018-04-18 at 5 04 04 pm" src="https://user-images.githubusercontent.com/12160398/38960543-8478989a-432a-11e8-9aaa-005bcce632a4.png">

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
