### PR TITLE
[EWL-4885] D8 | Promo blocks missing IPE

### DIFF
--- a/styleguide/source/_patterns/02-molecules/promo.twig
+++ b/styleguide/source/_patterns/02-molecules/promo.twig
@@ -9,9 +9,9 @@
 %}
 
 {% if button %}
-  <div class="ama__promo ama__promo--{{ style }}">
-{% else %}
-  <a href="{{ link }}" class="ama__promo ama__promo--{{ style }}">
+<div {{ attributes.addClass('ama__promo ama__promo--'~ style) }}>
+    {% else %}
+  <a href="{{ link }}" {{ attributes.addClass('ama__promo ama__promo--'~ style) }}>
 {% endif %}
 
   {% block image %}

--- a/styleguide/source/_patterns/02-molecules/promo.twig
+++ b/styleguide/source/_patterns/02-molecules/promo.twig
@@ -8,10 +8,12 @@
   promo.heading ? promo.heading|merge({level: "2", class: "ama__h2"})
 %}
 
+{% set classes = "ama__promo--#{style}" %}
+
 {% if button %}
-<div {{ attributes.addClass('ama__promo ama__promo--'~ style) }}>
+<div {{ setAttributes(classes, attributes) }}>
     {% else %}
-  <a href="{{ link }}" {{ attributes.addClass('ama__promo ama__promo--'~ style) }}>
+  <a href="{{ link }}" {{ setAttributes(classes, attributes) }}>
 {% endif %}
 
   {% block image %}

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -9,10 +9,12 @@
   text-decoration: none;
 
   &--background {
+    @extend .ama__promo;
     background: $gray-7;
   }
 
   &--border {
+    @extend .ama__promo;
     border: solid 1px $gray-50;
   }
 
@@ -51,6 +53,7 @@
 
 a.ama__promo { // styling for when this pattern renders as a link.
   &--background {
+    @extend .ama__promo;
     &:hover {
       background: darken($gray-7, 8%); // from UX - #d9d9d9
       color: black;
@@ -58,6 +61,7 @@ a.ama__promo { // styling for when this pattern renders as a link.
   }
 
   &--border {
+    @extend .ama__promo;
     &:hover {
       background: $gray-7;
       color: black;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4885: D8 | Promo blocks missing IPE](https://issues.ama-assn.org/browse/EWL-4885)

## Description
When an editor wishes to change content on a page, they should see contextual links above each block of content allowing them to edit, delete, or move individual blocks of content. Currently promo blocks do not have the expected contextual links.

This update provides a fix to this bug, adding the attributes variable to the wrapping tag for the promo block molecule. Additional classes are added with the setAttributes() function.


## To Test

- [ ] Pull `develop` branch for ama-d8 and ama-style-guide-2.
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- [ ] Run `vagrant up` in ama-d8 to spin up the local ama-d8 site.
- [ ] SSH into vagrant and run `scripts\refresh-local` to get prod database. Using the test data will also suffice.
- [ ] Log in to site and ensure Rivendell theme is enabled.
- [ ] Navigate to any topic page in ama-d8 and click on manage content. The promo blocks will not show contextual links, unlike all other blocks on the page.
- [ ] Pull `bugfix/EWL-4885-d8-promo-blocks-missing-ipe`.
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide.
- [ ] Inside vagrant run `drush @ama-d8.local cr` to clear caches in ama-d8.
- [ ] Navigate to any topic page in ama-d8 and edit content blocks. They should now have contextual links.


## Visual Regressions

N/A


## Relevant Screenshots/GIFs

**Example topic page without contextual links on `develop` branches**
<img width="1016" alt="d8-topicspage-editscreen" src="https://user-images.githubusercontent.com/4438120/39006646-50e74aa4-43c9-11e8-9c23-54b40a3c5e46.png">



**Example topic page with contextual links fixed **

<img width="984" alt="d8-topicspage-editscreen--fixed" src="https://user-images.githubusercontent.com/4438120/39006654-5549499e-43c9-11e8-98cb-76935aa560b2.png">


## Remaining Tasks
N/A


## Additional Notes
There is a bug with twig that won't allow multiple class names to pass cleanly to the custom setAttributes function. The temporary fix was to extend the ama__promo class to the ama__promo-border and ama__promo-background classes.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
