### PR TITLE
[EWL-4889] Rivendell | Empty "ama__article-stub__copy" in Lead News block

### DIFF
--- a/styleguide/source/_patterns/02-molecules/article-stub.twig
+++ b/styleguide/source/_patterns/02-molecules/article-stub.twig
@@ -58,8 +58,10 @@ articleStub.video ? "ama__article-stub--video"
 
   {{ _self.title(articleStub) }}
 
+  {% if not articleStub.related %}
   <div class="ama__article-stub__copy">
     {{ _self.description(articleStub) }}
     {{ _self.metadata(articleStub) }}
   </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4889: Rivendell | Empty "ama__article-stub__copy" in Lead News block](https://issues.ama-assn.org/browse/EWL-4889)

## Description
Adds a conditional in `article-stub.twig` so that the `.ama__article-stub__copy` wrapper doesn't get rendered for certain view modes.

## To Test
- [ ] `gulp` and sync this branch with your local d8
- [ ] Visit a Topic page and locate a Lead News block that doesn't have a description or metadata. Inspect it and verify that an `.ama__article-stub__copy` empty wrapper <div> does not show up there.

## Visual Regressions

- [x]  **Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.


## Relevant Screenshots/GIFs
...


## Remaining Tasks
...

## Additional Notes
...

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
