### PR TITLE
Bugfix/clean up mobile ribbon styles

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_ribbon-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_ribbon-dropdown.scss
@@ -38,17 +38,22 @@
     &__icon {
       display: inline-block;
       line-height: 19px;
-      fill: $white;
       margin-left: 0.75em;
+      fill: $white;
+
       transition: all 0.3s ease;
 
       &__arrow {
         width: 10px;
       }
 
-      &__user svg {
-        height: 21px;
-        width: 23px;
+      &__user {
+        margin-left: 0;
+
+        svg {
+          height: 21px;
+          width: 23px;
+        }
       }
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/_ribbon-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_ribbon-dropdown.scss
@@ -15,7 +15,6 @@
     color: $white;
     cursor: pointer;
     outline: none;
-    min-width: 12.5em;
     padding: 15px;
     width: 100%;
     border-left: 1px solid $gray-50;
@@ -56,7 +55,7 @@
 
   &__nav {
     position: absolute;
-    left: 0;
+    right: -1px;
     top: 100%;
     max-height: 0;
     overflow: hidden;

--- a/styleguide/source/assets/scss/03-organisms/_ribbon.scss
+++ b/styleguide/source/assets/scss/03-organisms/_ribbon.scss
@@ -1,5 +1,12 @@
 .ama__ribbon {
   background-color: $purple;
+
+  @include breakpoint($bp-small max-width) {
+    .container {
+      padding: 0;
+    }
+  }
+
   & > div {
     position: relative;
     display: flex;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
N/A

## Description
Tweaks some CSS within breakpoints to clean up styling for the mobile ribbon header.

## To Test
- [ ] `gulp serve`
- [ ] Visit Pages > Topic
- [ ] Resize the ribbon header and observe that it looks better than it did

## Visual Regressions
No backstop tests exist for this element.

## Relevant Screenshots/GIFs
Before
> ![screen shot 2018-04-19 at 11 58 58 am](https://user-images.githubusercontent.com/12160398/39006565-1202d718-43c9-11e8-8544-57786dbab41b.png)

After
> ![screen shot 2018-04-19 at 11 58 09 am](https://user-images.githubusercontent.com/12160398/39006540-f3703f70-43c8-11e8-9759-486a224e8c6a.png)



## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
