### PR TITLE
Fix wayfinder arrow showing when no referrals urls are present

### DIFF
--- a/styleguide/source/_patterns/03-organisms/masthead.json
+++ b/styleguide/source/_patterns/03-organisms/masthead.json
@@ -12,6 +12,11 @@
       "text": "JAMA Network to launch fully open-access journal",
       "class": "ama__h1"
     },
+    "date": {
+      "month": "April",
+      "day": "17",
+      "year": "2018"
+    },
     "social": [
       {
         "text": "facebook",

--- a/styleguide/source/_patterns/03-organisms/masthead.twig
+++ b/styleguide/source/_patterns/03-organisms/masthead.twig
@@ -1,5 +1,5 @@
 {%  set
-  indented, link, heading, subtitle, social =
+  indented, link, heading, subtitle, date, social =
   masthead.indented ? "ama__masthead__content--indented" : "",
   masthead.link,
   masthead.heading|merge({
@@ -7,6 +7,7 @@
     "class": "ama__h1"
   }),
   masthead.subtitle,
+  masthead.date,
   masthead.social
 %}
 

--- a/styleguide/source/_patterns/05-pages/news.json
+++ b/styleguide/source/_patterns/05-pages/news.json
@@ -79,6 +79,12 @@
     "heading": {
       "text": "JAMA Network to launch fully open-access journal"
     },
+    "date":
+    {
+      "month": "April",
+      "day": "17",
+      "year": "2018"
+    },
     "social": [
       {
         "text": "facebook",

--- a/styleguide/source/assets/js/wayfinder.js
+++ b/styleguide/source/assets/js/wayfinder.js
@@ -11,15 +11,17 @@
   Drupal.behaviors.wayfinder = {
     attach: function (context, settings) {
       (function ($) {
-        // Read wayfinder cookies set from ama-assn domains
-        $.cookie.json = true;
-        var ama_wayfinder_cookie = $.cookie('ama_wayfinder_cookie');
-        if (typeof ama_wayfinder_cookie !== 'undefined' || $('.referred').length > 0) {
-          $('.ama__wayfinder--referrer a').fadeIn().css('display', 'flex');
-          $('.ama__wayfinder--referrer a').attr("href", ama_wayfinder_cookie[1]);
-          $('.ama__wayfinder--referrer a').text(ama_wayfinder_cookie[0]);
-        } else {
-          $('.ama_wayfinder_referrer--link-back').fadeOut();
+        if($.cookie('ama_wayfinder_cookie')) {
+          $.cookie.json = true;
+          // Read wayfinder cookies set from ama-assn domains
+          var ama_wayfinder_cookie = $.cookie('ama_wayfinder_cookie');
+          if (typeof ama_wayfinder_cookie !== 'undefined' || $('.referred').length > 0) {
+            $('.ama__wayfinder--referrer a').fadeIn().css('display', 'flex');
+            $('.ama__wayfinder--referrer a').attr("href", ama_wayfinder_cookie[1]);
+            $('.ama__wayfinder--referrer a').text(ama_wayfinder_cookie[0]);
+          } else {
+            $('.ama_wayfinder_referrer--link-back').fadeOut();
+          }
         }
       })(jQuery);
     }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4897: Wayfinder Arrow shows in D8](https://issues.ama-assn.org/browse/EWL-4897)

## Description
An arrow is showing in the wayfinder with no referral URL. This arrow should not show when referral URL is present

## To Test
- [ ] Configure your local environment to use you local SG2 in D8
- [ ] Pull this branch down
- [ ] Paste this in your browser url address bar: http://ama-d8.local/test/topic_1
- [ ] Observe no arrow present

## Visual Regressions
Ran `backstop test`


## Relevant Screenshots/GIFs
<img width="1259" alt="screen shot 2018-04-19 at 4 28 56 pm" src="https://user-images.githubusercontent.com/2271747/39019403-c9bdf20a-43ee-11e8-8a28-fe46a0c87f59.png">


## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
