### PR TITLE
EWL-4917: Add button reset variant

### DIFF
--- a/styleguide/source/_patterns/01-atoms/button~as-reset.json
+++ b/styleguide/source/_patterns/01-atoms/button~as-reset.json
@@ -1,0 +1,10 @@
+{
+  "button": {
+    "href": "",
+    "info": "alt",
+    "text": "Reset",
+    "type": "button",
+    "style": "reset",
+    "size": ""
+  }
+}

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -15,6 +15,18 @@
       color: $white;
     }
   } //outline
+  @if($style == "reset") {
+    background-color: transparent;
+    border-color: transparent;
+    color: $purple;
+
+    &:hover {
+      background-color: transparent;
+      border-color: transparent;
+      color: $hoverPurple;
+      text-decoration: underline;
+    }
+  }
   @else {
     background-color: $purple;
     border-color: transparent;

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -14,4 +14,8 @@ button {
   &--small {
     @include ama-button("small", "");
   }
+
+  &--reset {
+    @include ama-button("", "reset");
+  }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4917: SG2 | Create "Button as Reset" variant" atom" atom](https://issues.ama-assn.org/browse/EWL-EWL-4917)

## Description
Create reset button variant

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=atoms-button-as-reset
- [ ] Observe a button without a border or background
- [ ] Observe on hover the text underline and color changing to a lighter purple

## Visual Regressions
backstop test 
No errors were found

## Relevant Screenshots/GIFs
<img width="86" alt="screen shot 2018-04-24 at 3 37 53 pm" src="https://user-images.githubusercontent.com/2271747/39212837-7a92bfea-47d5-11e8-9de3-101171fdfff2.png">

<img width="137" alt="screen shot 2018-04-24 at 3 37 20 pm" src="https://user-images.githubusercontent.com/2271747/39212808-64f30e60-47d5-11e8-9426-0003718aab2c.png">


## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
