### PR TITLE
[EWL-4960] SG2 | 2-UP Promo Group on tablet

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_layout_mixin.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_layout_mixin.scss
@@ -1,9 +1,16 @@
-@mixin grid_column_layout($columns, $grid-column-gap, $grid-row-gap){
+$three-column: 3, 2, $gutter, $gutter*2;
+
+@mixin grid_column_layout($col-desktop, $col-tablet, $grid-column-gap, $grid-row-gap){
   display: grid;
   grid-column-gap: $grid-column-gap;
   grid-row-gap: $grid-row-gap;
+
+  @include breakpoint($bp-small){
+    grid-template-columns: repeat($col-tablet, 1fr);
+  }
+
   @include breakpoint($bp-med){
-    grid-template-columns: repeat($columns, 1fr);
+    grid-template-columns: repeat($col-desktop, 1fr);
   }
 
 }

--- a/styleguide/source/assets/scss/03-organisms/_promo-group.scss
+++ b/styleguide/source/assets/scss/03-organisms/_promo-group.scss
@@ -1,3 +1,3 @@
 .ama__promo-group {
-  @include grid_column_layout(3, $gutter/2, $gutter*2);
+  @include grid_column_layout($three-column...);
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4960: SG2 | 2-UP Promo Group on tablet](https://issues.ama-assn.org/browse/EWL-4960)

## Description

A group of promos are required to appear as 3-up rows on desktop, but as requested by UX, should be 2-up on tablet.

This update ensures that three column layout will turn into a two column layout when on mobile along with updated backstop reference images.

## To Test

- [ ] Pull `feature/EWL-4960-2up-promo-group-tablet` branch
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- [ ] Navigate to [Organism > Promo Group]( http://localhost:3000/?p=organisms-promo-group) while viewport is tablet width. 
- [ ] Confirm a group of promos in 2 columns appears.

## Visual Regressions
Visual regression identified in secondary button. Reference images added contain this regression. Ticket has been submitted, [EWL-4962 SG2 | Visual regression on secondary buttons](https://issues.ama-assn.org/browse/EWL-4962).

Updated reference images for the promo group backstop test have been included in this PR.


## Relevant Screenshots/GIFs

**Promo Group organism on tablet width**

![image](https://user-images.githubusercontent.com/4438120/39330888-99651cc6-4968-11e8-95b4-f3066a7ed0c2.png)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)



