### PR TITLE
[EWL-4934] SG2 | Correct tag detault and hover states

### DIFF
--- a/styleguide/backstop.json
+++ b/styleguide/backstop.json
@@ -70,6 +70,21 @@
       "requireSameDimensions": false
     },
     {
+      "label": "atoms-tag",
+      "url": "http://localhost:3000/patterns/01-atoms-tag/01-atoms-tag.html",
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/01-atoms-tag/01-atoms-tag.html",
+      "delay": 1000,
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "hoverSelector": ".ama__tag",
+      "postInteractionWait": 1000,
+      "selectors": [
+        ".ama__tag"
+      ],
+      "misMatchThreshold" : 1,
+      "requireSameDimensions": false
+    },
+    {
       "label": "press-release-logos",
       "url": "http://localhost:3000/patterns/02-molecules-press-release-logos/02-molecules-press-release-logos.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-press-release-logos/02-molecules-press-release-logos.html",

--- a/styleguide/backstop.json
+++ b/styleguide/backstop.json
@@ -70,21 +70,6 @@
       "requireSameDimensions": false
     },
     {
-      "label": "atoms-tag",
-      "url": "http://localhost:3000/patterns/01-atoms-tag/01-atoms-tag.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/01-atoms-tag/01-atoms-tag.html",
-      "delay": 1000,
-      "hideSelectors": [],
-      "removeSelectors": [],
-      "hoverSelector": ".ama__tag",
-      "postInteractionWait": 1000,
-      "selectors": [
-        ".ama__tag"
-      ],
-      "misMatchThreshold" : 1,
-      "requireSameDimensions": false
-    },
-    {
       "label": "press-release-logos",
       "url": "http://localhost:3000/patterns/02-molecules-press-release-logos/02-molecules-press-release-logos.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-press-release-logos/02-molecules-press-release-logos.html",

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -17,7 +17,11 @@
 .ama__tag {
   @include gutter($margin-right-half...);
   @include gutter-all($padding-all-half...);
+  text-decoration: none;
   display: block;
   background: $gray-7;
   color: $purple;
+  &:hover{
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4934: SG2 | Correct tag detault and hover states](https://issues.ama-assn.org/browse/EWL-4934)

## Description
When viewing the news article or press release pages on SG2, tags should reflect default and hover state as shown in Zeplin.

In the current release of SG2, the default state of tags are the same as the desired hover state. This should be corrected to not have a line underneath tag text when in default state

This update fixes this bug by correcting the brackets and text-decoration properties for the .ama__tag.


## To Test
- [ ] Pull `bugfix/EWL-4934-correct-tag-detault-and-hover-states` branch
- [ ] Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- [ ] Navigate to [Atom > Tag](http://localhost:3000/?p=atoms-tag) or [Molecule > Tags](http://localhost:3000/?p=molecules-tags). 
- [ ] Confirm tag has grey background and undecorated purple text in default state.
- [ ] Confirm that on hover the tag text changes to have underlined text.


## Visual Regressions

N/A


## Relevant Screenshots/GIFs

### Before: Tags Molecule -- Default state
![image](https://user-images.githubusercontent.com/4438120/39603619-b70c9e44-4eee-11e8-9560-53ffd60d5dc4.png)


### After: Tags Molecule -- Default state
![image](https://user-images.githubusercontent.com/4438120/39603671-dacdd938-4eee-11e8-9499-a6fc7659f6de.png)


## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
