### PR TITLE
EWL-5004: Radio button contains a checkmark

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_radio-button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_radio-button.scss
@@ -9,27 +9,23 @@
   &:hover {
     color: $gray-64;
   }
-}
 
-.ui-checkboxradio-label .ui-icon-background {
-  position: relative;
-  left: 2px;
-  border: 1px solid $gray-7;
-  width: 16px;
-  height: 16px;
-  background-image: none;
-  box-shadow: none;
-}
+  &.ui-checkboxradio-checked .ui-icon,
+  &.ui-checkboxradio-checked:hover .ui-icon {
+    background-color: $purple;
+    border: 1px solid $purple;
+    border-radius: 50%;
 
-.ui-checkboxradio-radio-label.ui-checkboxradio-checked .ui-icon,
-.ui-checkboxradio-radio-label.ui-checkboxradio-checked:hover .ui-icon {
-  background-color: $purple;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  border: 1px solid $white;
-}
+    &.ui-icon {
+      position: relative;
+      width: 18px;
+      height: 18px;
+      background-image: none;
+      box-shadow: none;
+    }
+  }
 
-.ui-checkboxradio-icon-space {
-  @include gutter($margin-left-half...);
+  .ui-checkboxradio-icon-space {
+    @include gutter($margin-left-half...);
+  }
 }

--- a/styleguide/source/assets/scss/01-atoms/_radio-button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_radio-button.scss
@@ -18,8 +18,8 @@
 
     &.ui-icon {
       position: relative;
-      width: 18px;
-      height: 18px;
+      width: 20px;
+      height: 20px;
       background-image: none;
       box-shadow: none;
     }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5004: Radio button should not have a checkmark in it](https://issues.ama-assn.org/browse/EWL-5004)

## Description
Radio buttons have a checkmark in it when selected. There should be no checkmark. The radio button should just be solid purple

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=atoms-radio-button
- [ ] click on one the radio buttons
- [ ] observe no checkmark inside of the circle

## Visual Regressions
ran backstop
`all passed!`


## Relevant Screenshots/GIFs
<img width="232" alt="screen shot 2018-05-08 at 4 05 47 pm" src="https://user-images.githubusercontent.com/2271747/39783121-b3115a70-52d9-11e8-8cf3-1891a1b7d514.png">


## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
