### PR TITLE
SG2 | Update templates dependent on old info card as speaker

### DIFF
--- a/styleguide/source/_patterns/03-organisms/page-content-tabs.json
+++ b/styleguide/source/_patterns/03-organisms/page-content-tabs.json
@@ -161,116 +161,113 @@
       "tabTitle": "Speakers",
       "tabId": "speakers",
       "tabContent": {
-        "infoCard1": {
-          "type": "event",
-          "heading": {
-            "text": null
-          },
-          "image": {
-            "alt": "placeholder",
-            "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
-            "height": "",
-            "width": ""
-          },
-          "paragraphs": [
-            {
+        "eventSpeakers": [
+          {
+            "type": "event",
+            "heading": {
+              "text": null
+            },
+            "image": {
+              "alt": "placeholder",
+              "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
+              "height": "",
+              "width": ""
+            },
+            "paragraphs": [{
               "text": "Robert J Mills"
             },
-            {
-              "text": "AMA Media & Editorial"
+              {
+                "text": "AMA Media & Editorial"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "fax: (312) 464-5970"
+              }],
+            "link": {
+              "title": "Email Media Contact",
+              "href": "mailto:robert.mills@ama-assn.org",
+              "text": "robert.mills@ama-assn.org",
+              "target": "_self"
             },
-            {
-              "text": "ph: (312) 464-5970"
+            "blurb": [
+              {
+                "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet, commodi corporis, doloremque ea facilis hic illo maiores, mollitia quia quos soluta tenetur ullam veritatis? Natus nemo nobis perferendis ratione vel."
+              }
+            ]
+          },
+          {
+            "type": "event",
+            "heading": {
+              "text": null
             },
-            {
-              "text": "ph: (312) 464-5970"
+            "image": {
+              "alt": "placeholder",
+              "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
+              "height": "",
+              "width": ""
             },
-            {
-              "text": "fax: (312) 464-5970"
-            }
-          ],
-          "link": {
-            "title": "Email Media Contact",
-            "href": "mailto:robert.mills@ama-assn.org",
-            "text": "robert.mills@ama-assn.org",
-            "target": "_self"
-          },
-          "blurb": [
-            {
-              "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet, commodi corporis, doloremque ea facilis hic illo maiores, mollitia quia quos soluta tenetur ullam veritatis? Natus nemo nobis perferendis ratione vel."
-            }
-          ]
-        },
-        "infoCard2": {
-          "type": "event",
-          "heading": {
-            "text": null
-          },
-          "image": {
-            "alt": "placeholder",
-            "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
-            "height": "",
-            "width": ""
-          },
-          "paragraphs": [
-            {
+            "paragraphs": [{
               "text": "Robert J Mills"
             },
-            {
-              "text": "AMA Media & Editorial"
-            },
-            {
-              "text": "ph: (312) 464-5970"
-            },
-            {
-              "text": "ph: (312) 464-5970"
-            },
-            {
-              "text": "fax: (312) 464-5970"
+              {
+                "text": "AMA Media & Editorial"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "fax: (312) 464-5970"
+              }],
+            "link": {
+              "title": "Email Media Contact",
+              "href": "mailto:robert.mills@ama-assn.org",
+              "text": "robert.mills@ama-assn.org",
+              "target": "_self"
             }
-          ],
-          "link": {
-            "title": "Email Media Contact",
-            "href": "mailto:robert.mills@ama-assn.org",
-            "text": "robert.mills@ama-assn.org",
-            "target": "_self"
+
+          },
+          {
+            "type": "event",
+            "heading": {
+              "text": null
+            },
+            "image": {
+              "alt": "placeholder",
+              "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
+              "height": "",
+              "width": ""
+            },
+            "paragraphs": [{
+              "text": "Robert J Mills"
+            },
+              {
+                "text": "AMA Media & Editorial"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "fax: (312) 464-5970"
+              }],
+            "link": {
+              "title": "Email Media Contact",
+              "href": "mailto:robert.mills@ama-assn.org",
+              "text": "robert.mills@ama-assn.org",
+              "target": "_self"
+            }
           }
-        },
-        "infoCard3": {
-          "type": "event",
-          "heading": {
-            "text": null
-          },
-          "image": {
-            "alt": "placeholder",
-            "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
-            "height": "",
-            "width": ""
-          },
-          "paragraphs": [
-            {
-              "text": "Robert J Mills"
-            },
-            {
-              "text": "AMA Media & Editorial"
-            },
-            {
-              "text": "ph: (312) 464-5970"
-            },
-            {
-              "text": "ph: (312) 464-5970"
-            },
-            {
-              "text": "fax: (312) 464-5970"
-            }
-          ],
-          "link": {
-            "title": "Email Media Contact",
-            "href": "mailto:robert.mills@ama-assn.org",
-            "text": "robert.mills@ama-assn.org",
-            "target": "_self"
-          }
-        },
+        ],
         "articleStubAsInline": {
           "heading": {
             "text": "Example Label Text for an Inline Article Stub"

--- a/styleguide/source/_patterns/03-organisms/page-content-tabs.twig
+++ b/styleguide/source/_patterns/03-organisms/page-content-tabs.twig
@@ -36,14 +36,9 @@
     <h3 class="ama__accordion-tab">{{ pageTabs[2].tabTitle }}</h3>
     <div id="{{ pageTabs[2].tabId }}" class="ama__tabs--content">
 
-      {% set infoCard = pageTabs[2].tabContent['infoCard1'] %}
-      {% include '@molecules/info-card.twig' %}
+      {% set eventSpeakers = pageTabs[2].tabContent['eventSpeakers'] %}
+      {% include '@organisms/event-speakers.twig' %}
 
-      {% set infoCard = pageTabs[2].tabContent['infoCard2'] %}
-      {% include '@molecules/info-card.twig' %}
-
-      {% set infoCard = pageTabs[2].tabContent['infoCard3'] %}
-      {% include '@molecules/info-card.twig' %}
 
       {% set articleStubAsInline = pageTabs[2].tabContent['articleStubAsInline'] %}
       {% include '@molecules/article-stub-as-inline.twig' %}

--- a/styleguide/source/_patterns/05-pages/event.json
+++ b/styleguide/source/_patterns/05-pages/event.json
@@ -205,110 +205,113 @@
       "tabTitle":"Speakers",
       "tabId": "speakers",
       "tabContent": {
-        "infoCard1": {
-          "type": "event",
-          "heading": {
-            "text": null
-          },
-          "image": {
-            "alt": "placeholder",
-            "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
-            "height": "",
-            "width": ""
-          },
-          "paragraphs": [{
-            "text": "Robert J Mills"
-          },
-            {
-              "text": "AMA Media & Editorial"
+        "eventSpeakers": [
+          {
+            "type": "event",
+            "heading": {
+              "text": null
             },
-            {
-              "text": "ph: (312) 464-5970"
+            "image": {
+              "alt": "placeholder",
+              "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
+              "height": "",
+              "width": ""
             },
-            {
-              "text": "ph: (312) 464-5970"
+            "paragraphs": [{
+              "text": "Robert J Mills"
             },
-            {
-              "text": "fax: (312) 464-5970"
-            }],
-          "link": {
-            "title": "Email Media Contact",
-            "href": "mailto:robert.mills@ama-assn.org",
-            "text": "robert.mills@ama-assn.org",
-            "target": "_self"
+              {
+                "text": "AMA Media & Editorial"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "fax: (312) 464-5970"
+              }],
+            "link": {
+              "title": "Email Media Contact",
+              "href": "mailto:robert.mills@ama-assn.org",
+              "text": "robert.mills@ama-assn.org",
+              "target": "_self"
+            },
+            "blurb": [
+              {
+                "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet, commodi corporis, doloremque ea facilis hic illo maiores, mollitia quia quos soluta tenetur ullam veritatis? Natus nemo nobis perferendis ratione vel."
+              }
+            ]
           },
-          "blurb": [
-            {
-              "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet, commodi corporis, doloremque ea facilis hic illo maiores, mollitia quia quos soluta tenetur ullam veritatis? Natus nemo nobis perferendis ratione vel."
+          {
+            "type": "event",
+            "heading": {
+              "text": null
+            },
+            "image": {
+              "alt": "placeholder",
+              "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
+              "height": "",
+              "width": ""
+            },
+            "paragraphs": [{
+              "text": "Robert J Mills"
+            },
+              {
+                "text": "AMA Media & Editorial"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "fax: (312) 464-5970"
+              }],
+            "link": {
+              "title": "Email Media Contact",
+              "href": "mailto:robert.mills@ama-assn.org",
+              "text": "robert.mills@ama-assn.org",
+              "target": "_self"
             }
-          ]
-        },
-        "infoCard2": {
-          "type": "event",
-          "heading": {
-            "text": null
+
           },
-          "image": {
-            "alt": "placeholder",
-            "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
-            "height": "",
-            "width": ""
-          },
-          "paragraphs": [{
-            "text": "Robert J Mills"
-          },
-            {
-              "text": "AMA Media & Editorial"
+          {
+            "type": "event",
+            "heading": {
+              "text": null
             },
-            {
-              "text": "ph: (312) 464-5970"
+            "image": {
+              "alt": "placeholder",
+              "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
+              "height": "",
+              "width": ""
             },
-            {
-              "text": "ph: (312) 464-5970"
+            "paragraphs": [{
+              "text": "Robert J Mills"
             },
-            {
-              "text": "fax: (312) 464-5970"
-            }],
-          "link": {
-            "title": "Email Media Contact",
-            "href": "mailto:robert.mills@ama-assn.org",
-            "text": "robert.mills@ama-assn.org",
-            "target": "_self"
+              {
+                "text": "AMA Media & Editorial"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "ph: (312) 464-5970"
+              },
+              {
+                "text": "fax: (312) 464-5970"
+              }],
+            "link": {
+              "title": "Email Media Contact",
+              "href": "mailto:robert.mills@ama-assn.org",
+              "text": "robert.mills@ama-assn.org",
+              "target": "_self"
+            }
           }
-        },
-        "infoCard3": {
-          "type": "event",
-          "heading": {
-            "text": null
-          },
-          "image": {
-            "alt": "placeholder",
-            "src": "https://via.placeholder.com/320x320/027DBC/ffffff",
-            "height": "",
-            "width": ""
-          },
-          "paragraphs": [{
-            "text": "Robert J Mills"
-          },
-            {
-              "text": "AMA Media & Editorial"
-            },
-            {
-              "text": "ph: (312) 464-5970"
-            },
-            {
-              "text": "ph: (312) 464-5970"
-            },
-            {
-              "text": "fax: (312) 464-5970"
-            }],
-          "link": {
-            "title": "Email Media Contact",
-            "href": "mailto:robert.mills@ama-assn.org",
-            "text": "robert.mills@ama-assn.org",
-            "target": "_self"
-          }
-        },
+        ],
         "articleStubAsInline": {
           "heading": {
             "text": "Example Label Text for an Inline Article Stub"


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5123: SG2 | Update templates dependent on old info card as speaker](https://issues.ama-assn.org/browse/EWL-5123)

## Description
When viewing an event page or page content tabs organism, the speakers tab should utilize the new event speakers organism.

This update refactors templates and json to use the new event speakers organism.


## To Test

- Pull `bugfix/EWL-5123-update-event-page-content-tabs-speakers` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Navigate to [Organism > Page Content Tabs](http://localhost:3000/?p=page-content-tabs-organisms) or [Page > Event](http://localhost:3000/?p=event-pages).
- Confirm speakers tab looks good.


## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)