### PR TITLE
[EWL-4926] Add temp masthead grid classes

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -29,6 +29,18 @@
     @include breakpoint($bp-small min-width) {
       &--indented {
         grid-column: 2/5;
+
+        // Temporary to accommodate DOM in A1 Drupal theme
+        &.ama__masthead--no-border {
+          border: 0;
+        }
+
+        // Temporary to accommodate DOM in A1 Drupal theme
+        .layout__region {
+          grid-column-start: 2;
+          grid-column-end: 5;
+          @include ama-rules(1px, "bottom", $gray-64, solid);
+        }
       }
 
     }

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -7,6 +7,12 @@
     grid-template-columns: 1fr 6fr 2.5fr;
   }
 
+  // Temporary to accommodate DOM in A1 Drupal theme
+  &--grid {
+    display: block;
+  }
+
+
   &__sidebar {
     display: none;
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-4926: A1 | Theme masthead for News and Press Release pages](https://issues.ama-assn.org/browse/EWL-4926)

## Description
Adds some temporary/tech debt classes per a convo with @JaeBea @designerneil re: not being able to use theme suggestions to add wrappers to fields in Layout Builder following the advent of https://github.com/AmericanMedicalAssociation/ama-d8/pull/473.

**Required for https://github.com/AmericanMedicalAssociation/ama-d8/pull/423**


## To Test
- [ ] `gulp serve`
- [ ] Observe that Pages > Press Release and Pages > News look the same as before (this change should only be visible in the A1 Drupal theme).

## Visual Regressions

- [x] **Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

- [x] _If the new work does your work introduce visual regressions into existing work in the Style Guide (or in a Drupal 8 environment)_, either call these out here or address them before marking the PR as `ready for review`.

- [x] If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json) and have included a new or updated screenshot in [`bitmaps_reference`](ama-style-guide-2/styleguide/backstop_data/bitmaps_reference).


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
- [ ] Add to the list of tech debt.

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
