### PR TITLE
EWL-5169 Fix checklist js error

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -26,14 +26,14 @@
     "files" : [
       "source/assets/js/vendor/drupal-attach-behaviors.js",
       "source/assets/js/vendor/jquery.inputmask.bundle.js",
-      "source/assets/js/**/*.js"
-    ],
-    "drupalfiles" : [
       "source/assets/js/vendor/jquery.validate.js",
       "source/assets/js/vendor/fitvids.js",
       "source/assets/js/jvendor/query.cookie.js",
       "source/assets/js/vendor/jquery.ui.checkList.js",
       "source/assets/js/vendor/jquery-ui.accordion.multiple.js",
+      "source/assets/js/**/*.js"
+    ],
+    "drupalfiles" : [
       "source/assets/js/init.js",
       "source/assets/js/form-items.js",
       "source/assets/js/nav.js",


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5169: A1 | Fix checkList javascript error](https://issues.ama-assn.org/browse/EWL-5169)

## Description
jquery.ui.checkList.js is throwing a JS error preventing further javascript from executing on A1 test article page

## To Test
- [ ] setup D8 environment to use local SG2 in local.yml
- [ ] run scripts/build
- [ ] make sure you are using the AMA One theme
- [ ] switch to the `bugfix/EWL-5169-fix-checklist-js-error` branch
- [ ] visit http://ama-one.local/test/article_3
- [ ] look in the Chrome console panel for js errors that say widget is not defined or $ is not defined

## Visual Regressions

N/A

## Relevant Screenshots/GIFs
![screen shot 2018-05-29 at 4 22 44 pm](https://user-images.githubusercontent.com/2271747/40860804-548804a0-65ac-11e8-8c19-53a84cc7a371.png)


## Remaining Tasks
N/A


## Additional Notes
To test this you will need to Pull this PR in D8
https://github.com/AmericanMedicalAssociation/ama-d8/pull/477

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
