### PR TITLE
EWL-5433: Add $homepagePurple to color palette

### DIFF
--- a/styleguide/source/_patterns/00-base/colors.json
+++ b/styleguide/source/_patterns/00-base/colors.json
@@ -53,5 +53,16 @@
     "meta": {
       "description": ""
     }
+  },
+  "homepage": {
+    "items": [
+      {
+        "name": "$homepagePurple",
+        "value": "#7229D1"
+      }
+    ],
+    "meta": {
+      "description": ""
+    }
   }
 }

--- a/styleguide/source/_patterns/00-base/colors.twig
+++ b/styleguide/source/_patterns/00-base/colors.twig
@@ -11,6 +11,19 @@
   {% endfor %}
 </ul>
 
+<h2>Homepage colors</h2>
+<ul class="sg-colors">
+  {% for item in homepage.items %}
+    <li>
+      <div class="sg-swatch" style="background: {{item.value}};"></div>
+      <div class="sg-info">
+        <span>{{item.value}}</span> <br/>
+        <code>{{item.name}}</code>
+      </div>
+    </li>
+  {% endfor %}
+</ul>
+
 <h2>Topic Page Colors (deprecated)</h2>
 <ul class="sg-colors">
   {% for item in topic.items %}

--- a/styleguide/source/_patterns/00-base/colors.twig
+++ b/styleguide/source/_patterns/00-base/colors.twig
@@ -24,19 +24,6 @@
   {% endfor %}
 </ul>
 
-<h2>Topic Page Colors (deprecated)</h2>
-<ul class="sg-colors">
-  {% for item in topic.items %}
-    <li>
-      <div class="sg-swatch" style="background: {{item.value}};"></div>
-      <div class="sg-info">
-        <span>{{item.value}}</span> <br/>
-        <code>{{item.name}}</code>
-      </div>
-    </li>
-  {% endfor %}
-</ul>
-
 {% if meta %}
   <p>
     <small>{{ meta.description }}</small>

--- a/styleguide/source/assets/scss/00-base/_colors.scss
+++ b/styleguide/source/assets/scss/00-base/_colors.scss
@@ -21,3 +21,6 @@ $red: #E90C26;
 $green: #4D8406;
 
 $light-blue: #d9f2fc;
+
+//homepage Colors
+$homepagePurple: #7229D1;

--- a/styleguide/source/assets/scss/00-base/_colors.scss
+++ b/styleguide/source/assets/scss/00-base/_colors.scss
@@ -22,5 +22,5 @@ $green: #4D8406;
 
 $light-blue: #d9f2fc;
 
-//homepage Colors
+//Homepage Colors
 $homepagePurple: #7229D1;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-5433: Add `$homepagePurple` to color palette](https://issues.ama-assn.org/browse/EWL-5433)

## Description
Add a new color variable for the new homepage color. 

## To Test
- [ ] `gulp serve`
- [ ] Click "Base" in the menu
- [ ] Click "Colors" in the dropdown
- [ ] Observe you see the heading "Homepage Colors"
- [ ] Observe you see a new purple swatch for `#7229D1`
- [ ] Did you test in IE 11?

## Visual Regressions
There are no screenshots to update since we aren't checking the color palette for visual regressions. All tests pass.


## Relevant Screenshots/GIFs
<img width="276" alt="screen shot 2018-07-06 at 12 37 08 pm" src="https://user-images.githubusercontent.com/1653723/42392710-53d89c58-8119-11e8-9890-ad0fa1e72db7.png">



## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
