### PR TITLE
EWL-5446: Create "section title" atom

### DIFF
--- a/styleguide/source/_patterns/01-atoms/section-title.json
+++ b/styleguide/source/_patterns/01-atoms/section-title.json
@@ -1,0 +1,5 @@
+{
+  "sectionTitile": {
+    "text": "Example Text for a Section Title"
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/section-title.md
+++ b/styleguide/source/_patterns/01-atoms/section-title.md
@@ -1,0 +1,18 @@
+---
+title: Section Title
+---
+
+### Description
+A bit of text that can act as heading for a section of the homepage. It is a `<h2>`.
+
+[EWL-5446](https://issues.ama-assn.org/browse/EWL-5446)
+
+### Variant options
+none
+
+### Variables
+~~~
+{
+  "text": string/required
+}
+~~~

--- a/styleguide/source/_patterns/01-atoms/section-title.twig
+++ b/styleguide/source/_patterns/01-atoms/section-title.twig
@@ -1,0 +1,1 @@
+<h2 class="ama__section-title">{{ sectionTitile.text | raw }}</h2>

--- a/styleguide/source/assets/scss/01-atoms/_section-title.scss
+++ b/styleguide/source/assets/scss/01-atoms/_section-title.scss
@@ -1,0 +1,11 @@
+// Sets up the font styles for the page title atom
+.ama__section-title {
+  @extend %ama__h2--homepage;
+
+  @include breakpoint($bp-small max-width){
+    background-color: $purple;
+    color: $white;
+    font-size: .9em;
+    line-height: 1.5em;
+  }
+}


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-5446: Ticket Title](https://issues.ama-assn.org/browse/EWL-5446)

## Description
Create an atom for the homepage section title styling.

## To Test
- [ ] `gulp serve`
- [ ] Navigate to SG2
- [ ] Click "Atoms" in the menu
- [ ] Observe you see "Section Title"
- [ ] Click "Section Title"
- [ ] Observe you see a heading and it is Myriad Pro Regular, light gray, 40/40 on Desktop
- [ ] Observe you see a heading and it is Myriad Pro Regular, white on a `$purple` background, 18/27 on mobile
- [ ] Did you test in IE 11? Yes.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
<img width="445" alt="screen shot 2018-07-09 at 9 50 07 am" src="https://user-images.githubusercontent.com/1653723/42457624-8a7976f6-835d-11e8-9a59-1c505ef67b62.png">
<img width="554" alt="screen shot 2018-07-09 at 9 49 59 am" src="https://user-images.githubusercontent.com/1653723/42457625-8a93f5a8-835d-11e8-88c9-11eb4265eb93.png">



## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
