### PR TITLE
EWL-5440: Create "Org Nav" Organism

### DIFF
--- a/styleguide/backstop.json
+++ b/styleguide/backstop.json
@@ -847,6 +847,14 @@
       ]
     },
     {
+      "label": "org nav",
+      "url": "http://localhost:3000/patterns/03-organisms-category-nav/03-organisms-org-nav.html",
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-category-nav/03-organisms-org-nav.html",
+      "selectors": [
+        ".ama__org-nav"
+      ]
+    },
+    {
       "label": "templates-one-column",
       "url": "http://localhost:3000/patterns/04-templates-one-column/04-templates-one-column.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-one-column/04-templates-one-column.html",

--- a/styleguide/source/_patterns/03-organisms/category-nav.json
+++ b/styleguide/source/_patterns/03-organisms/category-nav.json
@@ -20,7 +20,7 @@
       {
         "text": "Adovcacy",
         "href": "http://www.yahoo.com"
-      },
+      }
     ]
   }
 }

--- a/styleguide/source/_patterns/03-organisms/org-nav.json
+++ b/styleguide/source/_patterns/03-organisms/org-nav.json
@@ -1,0 +1,22 @@
+{
+  "orgNav": {
+    "links": [
+      {
+        "text": "Board of Trustees",
+        "href": "http://www.google.com"
+      },
+      {
+        "text": "House of Delegates",
+        "href": "http://www.yahoo.com"
+      },
+      {
+        "text": "Councils & Committees",
+        "href": "http://www.yahoo.com"
+      },
+      {
+        "text": "Member Groups",
+        "href": "http://www.yahoo.com"
+      }
+    ]
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/org-nav.md
+++ b/styleguide/source/_patterns/03-organisms/org-nav.md
@@ -1,0 +1,25 @@
+---
+el: ".ama__org-nav"
+title: "Org Nav"
+---
+
+As a user, I want to find specific information about AMA organizational groups.
+
+[EWL-5440](https://issues.ama-assn.org/browse/EWL-5440)
+
+### Variables
+~~~
+{
+   "orgNav": {
+     "links": [
+       {
+         "text":
+           string / required
+         "href":
+           string / required (url)
+       },
+       // repeat for each link.
+     ]
+   }
+}
+~~~

--- a/styleguide/source/_patterns/03-organisms/org-nav.twig
+++ b/styleguide/source/_patterns/03-organisms/org-nav.twig
@@ -1,0 +1,9 @@
+<div class="ama__org-nav">
+  <ul>
+    {% for link in orgNav.links %}
+      <li>
+        {% include "@atoms/link/link.twig" %}
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -21,7 +21,27 @@
         {
           "text": "Adovcacy",
           "href": "http://www.yahoo.com"
+        }
+      ]
+    },
+    "orgNav": {
+      "links": [
+        {
+          "text": "Board of Trustees",
+          "href": "http://www.google.com"
         },
+        {
+          "text": "House of Delegates",
+          "href": "http://www.yahoo.com"
+        },
+        {
+          "text": "Councils & Committees",
+          "href": "http://www.yahoo.com"
+        },
+        {
+          "text": "Member Groups",
+          "href": "http://www.yahoo.com"
+        }
       ]
     }
   }

--- a/styleguide/source/_patterns/05-pages/homepage.twig
+++ b/styleguide/source/_patterns/05-pages/homepage.twig
@@ -1,5 +1,8 @@
 {% extends '@templates/one-column.twig' %}
 
-{% block contentTop %}
-  {% include '@organisms/category-nav.twig' with { productNav : homepage.catNav } %}
+{% block pageContent %}
+  <div class="ama__homepage__navs">
+    {% include '@organisms/category-nav.twig' with { catNav : homepage.catNav } %}
+    {% include '@organisms/org-nav.twig' with { orgNav : homepage.orgNav } %}
+  </div>
 {% endblock %}

--- a/styleguide/source/assets/scss/03-organisms/_category-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-nav.scss
@@ -2,7 +2,7 @@
   display: none;
   
   @include breakpoint($bp-small) {
-    display block;
+    display: block;
   }
   
   li {

--- a/styleguide/source/assets/scss/03-organisms/_org-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_org-nav.scss
@@ -1,0 +1,18 @@
+.ama__org-nav {
+  max-width: 33.33%;
+  text-align: right;
+
+  li {
+    display: inline-block;
+
+    a {
+      color: $purple;
+      text-transform: uppercase;
+      text-decoration: none;
+      margin: 0 ($gutter / 2);
+      font-size: .778em;
+      line-height: 2.214em;
+      font-weight: 600;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -1,2 +1,8 @@
 .ama__homepage {
+  &__navs {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid $gray-7;
+    justify-content: space-between;
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-5440: Create Org Nav Organism](https://issues.ama-assn.org/browse/EWL-5440)

## Description
Create Org Nav Organism and add it to the Homepage


## To Test
- [ ] `gulp serve`
- [ ] Click "Organisms" in the menu
- [ ] Observe you see "Org Nav"
- [ ] Click "Org Nav"
- [ ] Observe you see a list of AMA organizations as links
- [ ] Observe each link is uppercase, `$purple`, Myriad Pro Semibold, 14/31
- [ ] Observe the nav is max-width 33.33%
- [ ] Click "Pages" in the menu
- [ ] Click "Homepage"
- [ ] Observe you see the org nav to the right of the category nav on the page
- [ ] Did you test in IE 11?

## Visual Regressions
I have added a new backstop scenario for the org nav

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5440-org-nav/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="331" alt="screen shot 2018-07-11 at 6 35 10 pm" src="https://user-images.githubusercontent.com/1653723/42604778-1ce28d10-853a-11e8-88e8-3ee1eaae84f2.png">


## Remaining Tasks
N/A


## Additional Notes
This PR includes the work from PR #342 and should not be reviewed and merged until that work has been merged.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
