### PR TITLE
removes ready selectors causing Travis to fail on backstop tests

### DIFF
--- a/styleguide/backstop.json
+++ b/styleguide/backstop.json
@@ -144,10 +144,10 @@
       "selectors": ".ama__article-stub"
     },
     {
-    "label": "article stub as title only",
-    "url": "http://localhost:3000/patterns/02-molecules-article-stub-article-stub-as-title-only/02-molecules-article-stub-article-stub-as-title-only.html",
-    "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-article-stub-article-stub-as-title-only/02-molecules-article-stub-article-stub-as-title-only.html",
-    "selectors": ".ama__article-stub"
+      "label": "article stub as title only",
+      "url": "http://localhost:3000/patterns/02-molecules-article-stub-article-stub-as-title-only/02-molecules-article-stub-article-stub-as-title-only.html",
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-article-stub-article-stub-as-title-only/02-molecules-article-stub-article-stub-as-title-only.html",
+      "selectors": ".ama__article-stub"
     },
     {
       "label": "article stub as video",
@@ -190,7 +190,6 @@
       "label": "category hero",
       "url": "http://localhost:3000/patterns/02-molecules-category-hero/02-molecules-category-hero.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-category-hero/02-molecules-category-hero.html",
-      "readySelector": ".ama__category-hero",
       "selectors": [
         ".ama__category-hero"
       ],
@@ -216,7 +215,6 @@
       "label": "checkbox group",
       "url": "http://localhost:3000/patterns/02-molecules-checkbox-group/index.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-checkbox-group/index.html",
-      "readySelector": ".ama__checkboxes",
       "selectors": [
         ".ama__checkboxes"
       ],
@@ -227,7 +225,6 @@
       "label": "display switch menu",
       "url": "http://localhost:3000/patterns/02-molecules-display-switch-menu/02-molecules-display-switch-menu.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-display-switch-menu/02-molecules-display-switch-menu.html",
-      "readySelector": ".ama__display-switch-menu",
       "selectors": [
         ".ama__display-switch-menu"
       ]
@@ -422,12 +419,6 @@
       "url": "http://localhost:3000/patterns/02-molecules-promo-promo-with-image/02-molecules-promo-promo-with-image.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-promo-promo-with-image/02-molecules-promo-promo-with-image.html",
       "selectors": ".ama__promo--background"
-    },
-    {
-      "label": "promo as homepage",
-      "url": "http://localhost:3000/patterns/02-molecules-promo-promo-as-homepage/02-molecules-promo-promo-as-homepage.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-promo-promo-as-homepage/02-molecules-promo-promo-as-homepage.html",
-      "selectors": ".ama__promo--homepage"
     },
     {
       "label": "promo",
@@ -626,60 +617,45 @@
       ]
     },
     {
-      "label": "partner promo as homepage",
-      "url": "http://localhost:3000/patterns/02-molecules-partner-promo-as-homepage/02-molecules-partner-promo-as-homepage.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/02-molecules-partner-promo-as-homepage/02-molecules-partner-promo-as-homepage.html",
-      "selectors": [
-        ".ama__partner-promo"
-      ]
-    },
-    {
       "label": "category index",
       "url": "http://localhost:3000/patterns/03-organisms-category-index/03-organisms-category-index.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-category-index/03-organisms-category-index.html",
-      "readySelector": ".ama__category-index",
       "selectors": ".ama__category-index"
     },
     {
       "label": "masthead with subtitle",
       "url": "http://localhost:3000/patterns/03-organisms-masthead-masthead-with-subtitle/03-organisms-masthead-masthead-with-subtitle.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-masthead-masthead-with-subtitle/03-organisms-masthead-masthead-with-subtitle.html",
-      "readySelector": ".ama__masthead",
       "selectors": ".ama__masthead"
     },
     {
       "label": "masthead default",
       "url": "http://localhost:3000/patterns/03-organisms-masthead-masthead/03-organisms-masthead-masthead.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-masthead-masthead/03-organisms-masthead-masthead.html",
-      "readySelector": ".ama__masthead",
       "selectors": ".ama__masthead"
     },
     {
       "label": "masthead as indented",
       "url": "http://localhost:3000/patterns/03-organisms-masthead-masthead-as-indented/03-organisms-masthead-masthead-as-indented.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-masthead-masthead-as-indented/03-organisms-masthead-masthead-as-indented.html",
-      "readySelector": ".ama__masthead",
       "selectors": ".ama__masthead"
     },
     {
       "label": "masthead as simplified",
       "url": "http://localhost:3000/patterns/03-organisms-masthead-masthead-as-simplified/03-organisms-masthead-masthead-as-simplified.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-masthead-masthead-as-simplified/03-organisms-masthead-masthead-as-simplified.html",
-      "readySelector": ".ama__masthead",
       "selectors": ".ama__masthead"
     },
     {
       "label": "masthead with subtitle as indented",
       "url": "http://localhost:3000/patterns/03-organisms-masthead-masthead-with-subtitle-as-indented/03-organisms-masthead-masthead-with-subtitle-as-indented.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-masthead-masthead-with-subtitle-as-indented/03-organisms-masthead-masthead-with-subtitle-as-indented.html",
-      "readySelector": ".ama__masthead",
       "selectors": ".ama__masthead"
     },
     {
       "label": "product nav",
       "url": "http://localhost:3000/patterns/03-organisms-product-nav/03-organisms-product-nav.html",
       "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/03-organisms-product-nav/03-organisms-product-nav.html",
-      "readySelector": ".ama__product-nav",
       "selectors": ".ama__product-nav"
     },
     {
@@ -874,74 +850,62 @@
     {
       "label": "templates-one-column",
       "url": "http://localhost:3000/patterns/04-templates-one-column/04-templates-one-column.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-one-column/04-templates-one-column.html",
-      "readySelector": ".ama__layout--one-column"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-one-column/04-templates-one-column.html"
     },
     {
       "label": "templates-two-column-right",
       "url": "http://localhost:3000/patterns/04-templates-two-column-right/04-templates-two-column-right.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-two-column-right/04-templates-two-column-right.html",
-      "readySelector": ".ama__layout--two-column--right"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-two-column-right/04-templates-two-column-right.html"
     },
     {
       "label": "templates-two-column-right-full-width",
       "url": "http://localhost:3000/patterns/04-templates-two-column-right-full-width/04-templates-two-column-right-full-width.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-two-column-right-full-width/04-templates-two-column-right-full-width.html",
-      "readySelector": ".ama__layout--two-col-right--full-width"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-two-column-right-full-width/04-templates-two-column-right-full-width.html"
     },
     {
       "label": "templates-two-column-left",
       "url": "http://localhost:3000/patterns/04-templates-two-column-left/04-templates-two-column-left.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-two-column-left/04-templates-two-column-left.html",
-      "readySelector": ".ama__layout--two-column--left"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-two-column-left/04-templates-two-column-left.html"
     },
     {
       "label": "templates-three-column",
       "url": "http://localhost:3000/patterns/04-templates-three-column/04-templates-three-column.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-three-column/04-templates-three-column.html",
-      "readySelector": ".ama__layout--three-column"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/04-templates-three-column/04-templates-three-column.html"
     },
     {
       "label": "error-page",
       "url": "http://localhost:3000/patterns/05-pages-error/05-pages-error.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-error/05-pages-error.html",
-      "readySelector": "body .ama__layout--one-column"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-error/05-pages-error.html"
     },
     {
       "label": "event-page",
       "url": "http://localhost:3000/patterns/05-pages-event/05-pages-event.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-event/05-pages-event.html",
-      "readySelector": "body .ama__layout--two-column--right"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-event/05-pages-event.html"
     },
     {
       "label": "topics-page",
       "url": "http://localhost:3000/patterns/05-pages-topic/05-pages-topic.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-topic/05-pages-topic.html",
-      "readySelector": "body .ama__layout--three-column"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-topic/05-pages-topic.html"
     },
     {
       "label": "press release",
       "url": "http://localhost:3000/patterns/05-pages-press-release/05-pages-press-release.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-press-release/05-pages-press-release.html",
-      "readySelector": "body .ama__layout--two-column--right"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-press-release/05-pages-press-release.html"
     },
     {
       "label": "news",
       "url": "http://localhost:3000/patterns/05-pages-news-news/05-pages-news-news.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-news/05-pages-news.html",
-      "readySelector": "body .ama__layout--two-column--right"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-news/05-pages-news.html"
     },
     {
       "label": "news as gated",
       "url": "http://localhost:3000/patterns/05-pages-news-news-as-gated/05-pages-news-news-as-gated.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-news-news-as-gated/05-pages-news-news-as-gated.html",
-      "readySelector": "body .ama__layout--two-column--right"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-news-news-as-gated/05-pages-news-news-as-gated.html"
     },
     {
       "label": "news with JAMA examples",
       "url": "http://localhost:3000/patterns/05-pages-news-news-with-jama-examples/05-pages-news-news-with-jama-examples.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-news-news-with-jama-examples/05-pages-news-news-with-jama-examples.html",
-      "readySelector": "body .ama__layout--two-column--right"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-news-news-with-jama-examples/05-pages-news-news-with-jama-examples.html"
     },
     {
       "label": "resource",
@@ -958,20 +922,17 @@
     {
       "label": "event listing",
       "url": "http://localhost:3000/patterns/05-pages-event-listing/05-pages-event-listing.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-event-listing/05-pages-event-listing.html",
-      "readySelector": "body .ama__layout--two-column--left"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-event-listing/05-pages-event-listing.html"
     },
     {
       "label": "category page",
       "url": "http://localhost:3000/patterns/05-pages-category/05-pages-category.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-category/05-pages-category.html",
-      "readySelector": ".ama__category"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-category/05-pages-category.html"
     },
     {
       "label": "people bio",
       "url": "http://localhost:3000/patterns/05-pages-people-bio/05-pages-people-bio.html",
-      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-people-bio/05-pages-people-bio.html",
-      "readySelector": ".container"
+      "referenceUrl": "https://americanmedicalassociation.github.io/ama-style-guide-2/patterns/05-pages-people-bio/05-pages-people-bio.html"
     },
     {
       "label": "people listing",


### PR DESCRIPTION
## Ticket(s)

N/A

## Description
Remove ready selectors in backstop.json which causes Travis to fail

The readySelectors guaranteed that the selectors were on the page before tests were run. This worked locally but failed when Travis ran backstop. My assumption is that Travis is running a headless browser that does not run jQuery or javascript of any kind or if it is the execution of the scripts is not fast enough to keep up with the tests

Visit 
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/bugfix/fix-backstop-failing-travishtml_report/index.html
See the beautiful backstop report created by Travis

## To Test
- [ ] visit http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5442-create-jama-as-homepage-variant/html_report/index.html

## Visual Regressions

Fixes backstop 

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
