### PR TITLE
EWL-5515 - Fixes tabs on events page

### DIFF
--- a/styleguide/source/_patterns/03-organisms/page-content-tabs.twig
+++ b/styleguide/source/_patterns/03-organisms/page-content-tabs.twig
@@ -1,4 +1,4 @@
-<div class="ama__tabs ama__tabs-page-content">
+<div class="ama__tabs ama__tabs-page-content ama__events-tabs">
   <ul class="ama__tabs-navigation">
     {% for tab in pageTabs %}
       <li class="ama__tab-title--page"><a href="#{{ tab.tabId }}">{{ tab.tabTitle }}</a></li>

--- a/styleguide/source/_patterns/03-organisms/resource-tabs.twig
+++ b/styleguide/source/_patterns/03-organisms/resource-tabs.twig
@@ -1,4 +1,4 @@
-<div class="ama__tabs ama__resource-tabs">
+<div class="ama__resource-tabs">
   <ul class="ama__resource-tabs__nav">
     {% for tab in tabs %}
       <li class="{{ tab.classes }}">

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -2,34 +2,40 @@
 
 
 (function ($, Drupal) {
-    Drupal.behaviors.ama_tabs = {
-        attach: function (context, settings) {
-            var defaultActiveTab = 0;
-            var viewportWidth = window.innerWidth;
-            if (viewportWidth >= 600 && $('.ama__resource-tabs').length > 0) {
-                defaultActiveTab = 1;
-            }
-            $(".ama__tabs").tabs({
-                active: defaultActiveTab,
-                create: function () {
-                    var widget = $(this).data('ui-tabs');
-                    $(window).on('hashchange', function () {
-                        widget.option('active', widget._getIndex(location.hash));
-                    });
-                }
-            });
+  Drupal.behaviors.ama_tabs = {
+    attach: function (context, settings) {
+      var defaultActiveTab = 0;
+      var viewportWidth = window.innerWidth;
+      if (viewportWidth >= 600 && $('.ama__resource-tabs').length > 0) {
+        defaultActiveTab = 1;
+      }
 
-            // Prevent jump onclick
-            $('.ama__resource-tabs__nav a, .ama__tabs-navigation a').on('click', function (e) {
-                e.preventDefault();
-                return false;
-            });
+      $(".ama__tabs").tabs({
+        active: defaultActiveTab
+      });
 
-            //Simulate click event on actual simpleTabs tab from mobile drop down.
-            $('.ama__tabs-navigation--mobile select').on("selectmenuchange", function (event, ui) {
-                var selectedValue = ui.item.value;
-                $('a[href="#' + selectedValue + '"]').click();
-            });
+      //Resource page specific tags
+      $(".ama__resource-tabs").tabs({
+        active: defaultActiveTab,
+        create: function () {
+          var widget = $(this).data('ui-tabs');
+          $(window).on('hashchange', function () {
+            widget.option('active', widget._getIndex(location.hash));
+          });
         }
-    };
+      });
+
+      // Prevent jump onclick
+      $('.ui-tabs-anchor').on('click', function (e) {
+        e.preventDefault();
+        return false;
+      });
+
+      //Simulate click event on actual simpleTabs tab from mobile drop down.
+      $('.ama__tabs-navigation--mobile select').on("selectmenuchange", function (event, ui) {
+        var selectedValue = ui.item.value;
+        $('a[href="#' + selectedValue + '"]').click();
+      });
+    }
+  };
 })(jQuery, Drupal);


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5515: A1 | Style Guide Event Page Tabs not working as expected](https://issues.ama-assn.org/browse/EWL-5515)

## Description
Event page Agenda tab not working as expected. When I click on the day it jumps to another unexpected tab

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=pages-event
- [x] click on the Agenda tab
- [x] click Friday, January 19
- [x] observe the tab goes to the Friday agenda
- [x] visit http://localhost:3000/?p=pages-resource
- [x] click on the purple tabs on the right hand side of the page
- [x] observe the tabs still work
- [x] Did you test in IE 11? 

## Visual Regressions

N/A Functional JS changes were only made

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
