### PR TITLE
 [EWL-5533] SG2 | Add icon element stying for "Link Icons"

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -203,6 +203,7 @@ a {
 .ama__link--icon,
 %ama__link--icon{
   icon {
+    display: inline-block;
     max-width: 22px;
     max-height: 22px;
     min-height: 22px;

--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -197,3 +197,17 @@ a {
     background-color: transparent;
   }
 }
+
+// Primarily used when looping through icons in D8
+// TODO: All link icon atoms should switch to using the <icon> element with appropriate class instead of hard coding the svg file
+.ama__link--icon,
+%ama__link--icon{
+  icon {
+    max-width: 22px;
+    max-height: 22px;
+    min-height: 22px;
+    vertical-align: middle;
+    min-width: 22px;
+    background-size: contain;
+  }
+}

--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -198,8 +198,6 @@ a {
   }
 }
 
-// Primarily used when looping through icons in D8
-// TODO: All link icon atoms should switch to using the <icon> element with appropriate class instead of hard coding the svg file
 .ama__link--icon,
 %ama__link--icon{
   icon {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5533: SG2 | Add icon element stying for "Link Icons"](https://issues.ama-assn.org/browse/EWL-5533)

## Description
As a developer, I should be able to use the `<icon>` element with relevant classes on Link Icon atoms just as it is used on tool icons.


## To Test
- Pull `bug/EWL-5533-style-icon-element-link-icon` branch
- Run gulp serve in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work is used in code from ama-d8 [PR #581](https://github.com/AmericanMedicalAssociation/ama-d8/pull/581) so you may need to edit your local provision var to point to a local version of the D8 `feature/EWL-5106-resource-related-links-tab-theming` branch to test.
-In your local d8 project folder, run `vagrant ssh`, `drush @one.local cim -y`, and `drush @one.local cr` to import new config files and flush all caches ensuring theme recognizes updated templates.
- Navigate to any resource page and add related links tab content as a content editor would.
- View updated page and confirm icons show as they do on the [style guide resource page](https://americanmedicalassociation.github.io/ama-style-guide-2/)

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bug/EWL-5533-style-icon-element-link-icon/html_report/index.html).

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
### This PR must be merged for [PR #581](https://github.com/AmericanMedicalAssociation/ama-d8/pull/581) to be merged.
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
