### PR TITLE
[EWL-5306] SG2 | Fix Event Listing Page Templates

### DIFF
--- a/styleguide/source/_patterns/04-templates/two-column-left.twig
+++ b/styleguide/source/_patterns/04-templates/two-column-left.twig
@@ -2,7 +2,7 @@
   {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page header content'}}%}
 {% endblock %}
 
-<div class="ama__layout--two-column--left {{ class }}">
+<div class="ama__layout--two-column--left container {{ class }}">
   {# Keeping tabindex for accessibility purposes #}
   <section class="ama__layout--two-column--left__content-top">
     {% block contentTop %}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5306: SG2 | Fix Broken Molecule Twig Templates](https://issues.ama-assn.org/browse/EWL-5306)

## Description
The container class is missing on SG2 Event Listing page. This update adds the container class into the Two Column Left template.


## To Test
- Pull `bugfix/EWL-5306-fix-missing-event-listing-class` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Navigate to the [event listing page](http://localhost:3000/?p=pages-event-listing) and confirm you see proper horizontal spacing from the container class.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5306-fix-missing-event-listing-class/html_report/index.html).


## Relevant Screenshots/GIFs
![image](https://user-images.githubusercontent.com/4438120/42908755-7047ea78-8aa7-11e8-8ed4-380800a36f60.png)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
