### PR TITLE
EWL-5512: Homepage fixes in IE11

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -13,6 +13,8 @@
   &__image {
     @include gutter($padding-right-half...);
     display: none;
+    flex: 0 0 50%;
+    height: auto;
     max-width: 50%;
   }
 

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -39,14 +39,30 @@
       @include gutter($margin-top-full...);
       display: grid;
       grid-template-columns: 1fr 1fr 1fr 1fr;
-      grid-column-gap: 15px;
-      grid-row-gap: 15px;
+
+      .ama__article-stub {
+        grid-row: 2;
+        margin-left: 15px;
+      }
+
+      .ama__article-stub--image {
+        grid-row: 1;
+      }
+
+      .ama__article-stub:nth-child(even) {
+        grid-column: 3;
+      }
+
+      .ama__article-stub:nth-child(odd) {
+        grid-column: 4;
+      }
 
       .ama__article-stub:first-of-type {
         grid-column-start: 1;
         grid-column-end: 3;
         grid-row-start: 1;
         grid-row-end: 3;
+        margin: 0;
       }
     }
   }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-5512: Your Products Broken in IE11](https://issues.ama-assn.org/browse/EWL-5512)

## Description
CSS Tweaks to the article stubs on the homepage and the "your products" section of the homepage so that they display correctly in IE11. 

**It may be helpful to test `develop` in IE11 before testing this branch in IE11 so you see the difference.**

## To Test
- [ ] `gulp serve`
- [ ] Navigate to browserstack
- [ ] Select IE11
- [ ] Navigate to SG2
- [ ] Click "Pages" in the menu
- [ ] Click "Homepage"
- [ ] Observe you see article stubs
- [ ] Observe the first one is 50% of the page width a large image and then information below
- [ ] Observe the second and third items are 25% of the page width with the image on top and information below
- [ ] Observe the fourth and fifth items are each 25% of the width below the second and third and to the left of the fourth and fifth
- [ ] Observe you see the "Your Products" section
- [ ] Observe the first and fourth items are each 50% of the width of the page with the image as the left 50% of the item and the text as the right 50% of the item
- [ ] Observe all other product pieces are 25% of the width of the page with no images

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
<img width="1168" alt="screen shot 2018-07-18 at 4 28 33 pm" src="https://user-images.githubusercontent.com/1653723/42908896-cd28fdd6-8aa7-11e8-8654-0cc2fe4a32d5.png">
<img width="1175" alt="screen shot 2018-07-18 at 4 29 22 pm" src="https://user-images.githubusercontent.com/1653723/42908897-cd4f7d3a-8aa7-11e8-8e85-8f7edd26ae27.png">


## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
