### PR TITLE
EWL-5527 homepage feedback

### DIFF
--- a/styleguide/source/_patterns/01-atoms/section-title.twig
+++ b/styleguide/source/_patterns/01-atoms/section-title.twig
@@ -1,1 +1,1 @@
-<h2 class="ama__section-title">{{ sectionTitle.text | raw }}</h2>
+<h2 class="ama__section-title {{ sectionTitle.class }}">{{ sectionTitle.text | raw }}</h2>

--- a/styleguide/source/_patterns/02-molecules/jama/jama.twig
+++ b/styleguide/source/_patterns/02-molecules/jama/jama.twig
@@ -2,7 +2,6 @@
 
 <div class="ama__jama {{ homepage }}">
   {% include "@atoms/site-logo/site-logo-as-jama.twig" %}
-  <div class="ama__rule ama__rule--horizontal"></div>
   <span class="ama__jama__title">
     {% if jama.title.icon is not empty %}
       <icon class="ama__icon {{ jama.title.icon }}"></icon>

--- a/styleguide/source/_patterns/02-molecules/member-feature-rail.json
+++ b/styleguide/source/_patterns/02-molecules/member-feature-rail.json
@@ -101,7 +101,7 @@
       "href": "#",
       "text": "View more from this series",
       "target": "_self",
-      "class": "ama__link ama__link--purple ama__member-feature-rail__view-all-link"
+      "class": "ama__link ama__link--purple ama__link--homepage-viewall"
     }
   }
 }

--- a/styleguide/source/_patterns/02-molecules/partner-promo.twig
+++ b/styleguide/source/_patterns/02-molecules/partner-promo.twig
@@ -1,7 +1,7 @@
 {% set image = partnerPromo.image %}
-{% set homepage = partnerPromo.homepage ? "ama__partner-promo--homepage" : "" %}
+{% set homepage = partnerPromo.homepage ? "ama__partner-promo ama__partner-promo--homepage" : "ama__partner-promo " %}
 
-<div class="ama__partner-promo {{ homepage }}">
+<div class="{{ homepage }}">
   {% if image.src is not empty %}
     <div class="ama__partner-promo__image">
       {% include '@atoms/image/image.twig' %}

--- a/styleguide/source/_patterns/02-molecules/product.json
+++ b/styleguide/source/_patterns/02-molecules/product.json
@@ -7,7 +7,7 @@
     "heading": {
       "level": "4",
       "text": "JAMA Network",
-      "class": "ama__h4 ama__h4--homepage"
+      "class": "ama__h4 ama__h4--homepage ama__product__text__header"
     },
     "paragraph" : {
       "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.",

--- a/styleguide/source/_patterns/02-molecules/product.twig
+++ b/styleguide/source/_patterns/02-molecules/product.twig
@@ -8,7 +8,9 @@
     %}
   {% endif %}
   <div class="ama__product__text">
-    {% include '@atoms/heading/heading.twig' with { heading : product.heading }%}
+    <a class="ama__link ama__link--purple" href="{{ product.link.href }}">
+      {% include '@atoms/heading/heading.twig' with { heading : product.heading }%}
+    </a>
     {% include '@atoms/paragraph.twig' with { paragraph : product.paragraph }%}
     {% include '@atoms/link/link.twig' with { link : product.link }%}
   </div>

--- a/styleguide/source/_patterns/02-molecules/subscribe-promo.json
+++ b/styleguide/source/_patterns/02-molecules/subscribe-promo.json
@@ -24,7 +24,7 @@
       "info": "alt",
       "text": "Subscribe",
       "type": "button",
-      "style": "secondary",
+      "style": "ama__button  ama__button--homepage",
       "size": ""
     }
   }

--- a/styleguide/source/_patterns/02-molecules/subscribe-promo.json
+++ b/styleguide/source/_patterns/02-molecules/subscribe-promo.json
@@ -24,7 +24,7 @@
       "info": "alt",
       "text": "Subscribe",
       "type": "button",
-      "style": "ama__button  ama__button--homepage",
+      "style": "homepage-secondary",
       "size": ""
     }
   }

--- a/styleguide/source/_patterns/02-molecules/subscribe-promo.json
+++ b/styleguide/source/_patterns/02-molecules/subscribe-promo.json
@@ -24,7 +24,7 @@
       "info": "alt",
       "text": "Subscribe",
       "type": "button",
-      "style": "homepage-secondary",
+      "style": "secondary",
       "size": ""
     }
   }

--- a/styleguide/source/_patterns/03-organisms/category-nav.json
+++ b/styleguide/source/_patterns/03-organisms/category-nav.json
@@ -3,23 +3,28 @@
     "links": [
       {
         "text": "About",
-        "href": "http://www.google.com"
+        "href": "http://www.google.com",
+        "class": "ama__link ama__link--homepage"
       },
       {
         "text": "Delivery Care",
-        "href": "http://www.yahoo.com"
+        "href": "http://www.yahoo.com",
+        "class": "ama__link ama__link--homepage"
       },
       {
         "text": "Practice Management",
-        "href": "http://www.yahoo.com"
+        "href": "http://www.yahoo.com",
+        "class": "ama__link ama__link--homepage"
       },
       {
         "text": "Education",
-        "href": "http://www.yahoo.com"
+        "href": "http://www.yahoo.com",
+        "class": "ama__link ama__link--homepage"
       },
       {
         "text": "Adovcacy",
-        "href": "http://www.yahoo.com"
+        "href": "http://www.yahoo.com",
+        "class": "ama__link ama__link--homepage"
       }
     ]
   }

--- a/styleguide/source/_patterns/03-organisms/four-up-lists.json
+++ b/styleguide/source/_patterns/03-organisms/four-up-lists.json
@@ -47,7 +47,7 @@
           "href": "#",
           "text": "View all Topics",
           "target": "_self",
-          "class": "ama__link ama__link--no-underline ama__link--purple"
+          "class": "ama__link--homepage-viewall"
         }
       ]
     },
@@ -98,7 +98,7 @@
           "href": "#",
           "text": "View all Topics",
           "target": "_self",
-          "class": "ama__link ama__link--no-underline ama__link--purple"
+          "class": "ama__link--homepage-viewall"
         }
       ]
     },
@@ -149,7 +149,7 @@
           "href": "#",
           "text": "View all Topics",
           "target": "_self",
-          "class": "ama__link ama__link--no-underline ama__link--purple"
+          "class": "ama__link--homepage-viewall"
         }
       ]
     },
@@ -200,7 +200,7 @@
           "href": "#",
           "text": "View all Topics",
           "target": "_self",
-          "class": "ama__link ama__link--no-underline ama__link--purple"
+          "class": "ama__link--homepage-viewall"
         }
       ]
     }

--- a/styleguide/source/_patterns/03-organisms/four-up-lists.twig
+++ b/styleguide/source/_patterns/03-organisms/four-up-lists.twig
@@ -1,4 +1,10 @@
-<div class="ama__four-up-links">
+{% if homepage.fourUpLists %}
+  {% set classes = "ama__four-up-links ama__homepage__four-up-links" %}
+{% else %}
+  {% set classes = "ama__four-up-links neil" %}
+{% endif %}
+
+<div class="{{ classes }}">
   {% for linkList in fourUpLists %}
     {% include "@molecules/link-list.twig" %}
   {% endfor %}

--- a/styleguide/source/_patterns/03-organisms/org-nav.json
+++ b/styleguide/source/_patterns/03-organisms/org-nav.json
@@ -3,19 +3,23 @@
     "links": [
       {
         "text": "Board of Trustees",
-        "href": "http://www.google.com"
+        "href": "http://www.google.com",
+        "class": "ama__link ama__link--purple"
       },
       {
         "text": "House of Delegates",
-        "href": "http://www.yahoo.com"
+        "href": "http://www.yahoo.com",
+        "class": "ama__link ama__link--purple"
       },
       {
         "text": "Councils & Committees",
-        "href": "http://www.yahoo.com"
+        "href": "http://www.yahoo.com",
+        "class": "ama__link ama__link--purple"
       },
       {
         "text": "Member Groups",
-        "href": "http://www.yahoo.com"
+        "href": "http://www.yahoo.com",
+        "class": "ama__link ama__link--purple"
       }
     ]
   }

--- a/styleguide/source/_patterns/05-pages/category.json
+++ b/styleguide/source/_patterns/05-pages/category.json
@@ -873,7 +873,7 @@
             "info": "alt",
             "text": "Lorem ipsum",
             "type": "button",
-            "style": "primary",
+            "style": "promo",
             "size": ""
           }
         },

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -636,7 +636,7 @@
             "href": "#",
             "text": "View all Topics",
             "target": "_self",
-            "class": "ama__link ama__link--no-underline ama__link--purple"
+            "class": "ama__link--homepage-viewall"
           }
         ]
       },
@@ -687,7 +687,7 @@
             "href": "#",
             "text": "View all Topics",
             "target": "_self",
-            "class": "ama__link ama__link--no-underline ama__link--purple"
+            "class": "ama__link--homepage-viewall"
           }
         ]
       },
@@ -738,7 +738,7 @@
             "href": "#",
             "text": "View all Topics",
             "target": "_self",
-            "class": "ama__link ama__link--no-underline ama__link--purple"
+            "class": "ama__link--homepage-viewall"
           }
         ]
       },
@@ -789,7 +789,7 @@
             "href": "#",
             "text": "View all Topics",
             "target": "_self",
-            "class": "ama__link ama__link--no-underline ama__link--purple"
+            "class": "ama__link--homepage-viewall"
           }
         ]
       }
@@ -944,7 +944,7 @@
           "href": "#",
           "text": "View more from this series",
           "target": "_self",
-          "class": "ama__link ama__member-feature-rail__view-all-link"
+          "class": "ama__link ama__link--purple ama__link--homepage-viewall"
         }
       },
       "heroStory": {

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -10,7 +10,7 @@
         "info": "alt",
         "text": "Register Now",
         "type": "button",
-        "style": "homepage--secondary",
+        "style": "homepage-secondary",
         "size": ""
       },
       "link": {
@@ -834,7 +834,7 @@
         "info": "alt",
         "text": "Learn More",
         "type": "button",
-        "style": "homepage--secondary",
+        "style": "homepage-secondary",
         "size": ""
       }
     },

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -31,9 +31,9 @@
         },
         "image": {
           "alt": "alt text",
-          "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
-          "height": "600",
-          "width": "800"
+          "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36",
+          "height": "574",
+          "width": "876"
         },
         "headingLevel": "h2",
         "video": "",
@@ -62,9 +62,9 @@
         },
         "image": {
           "alt": "alt text",
-          "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
-          "height": "600",
-          "width": "800"
+          "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36",
+          "height": "574",
+          "width": "876"
         },
         "headingLevel": "h5",
         "video": "",
@@ -93,9 +93,9 @@
         },
         "image": {
           "alt": "alt text",
-          "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
-          "height": "600",
-          "width": "800"
+          "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36",
+          "height": "574",
+          "width": "876"
         },
         "headingLevel": "h5",
         "video": "",
@@ -173,19 +173,23 @@
       "links": [
         {
           "text": "Board of Trustees",
-          "href": "http://www.google.com"
+          "href": "http://www.google.com",
+          "class": "ama__link ama__link--purple"
         },
         {
           "text": "House of Delegates",
-          "href": "http://www.yahoo.com"
+          "href": "http://www.yahoo.com",
+          "class": "ama__link ama__link--purple"
         },
         {
           "text": "Councils & Committees",
-          "href": "http://www.yahoo.com"
+          "href": "http://www.yahoo.com",
+          "class": "ama__link ama__link--purple"
         },
         {
           "text": "Member Groups",
-          "href": "http://www.yahoo.com"
+          "href": "http://www.yahoo.com",
+          "class": "ama__link ama__link--purple"
         }
       ]
     },
@@ -257,12 +261,12 @@
         {
           "image": {
             "alt": "alt text",
-            "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|300x200&s=36"
+            "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36"
           },
           "heading": {
             "level": "4",
             "text": "JAMA Network",
-            "class": "ama__h4 ama__h4--homepage"
+            "class": "ama__h4 ama__h4--homepage ama__product__text__header"
           },
           "paragraph": {
             "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.",
@@ -279,12 +283,12 @@
         {
           "image": {
             "alt": "alt text",
-            "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|300x200&s=36"
+            "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36"
           },
           "heading": {
             "level": "4",
             "text": "CPT",
-            "class": "ama__h4 ama__h4--homepage"
+            "class": "ama__h4 ama__h4--homepage ama__product__text__header"
           },
           "paragraph": {
             "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.",
@@ -301,12 +305,12 @@
         {
           "image": {
             "alt": "alt text",
-            "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|300x200&s=36"
+            "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36"
           },
           "heading": {
             "level": "4",
             "text": "FRIEDA",
-            "class": "ama__h4 ama__h4--homepage"
+            "class": "ama__h4 ama__h4--homepage ama__product__text__header"
           },
           "paragraph": {
             "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.",
@@ -323,12 +327,12 @@
         {
           "image": {
             "alt": "alt text",
-            "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|300x200&s=36"
+            "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36"
           },
           "heading": {
             "level": "4",
             "text": "AMA Insurance",
-            "class": "ama__h4 ama__h4--homepage"
+            "class": "ama__h4 ama__h4--homepage ama__product__text__header"
           },
           "paragraph": {
             "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.",
@@ -345,7 +349,7 @@
         {
           "image": {
             "alt": "alt text",
-            "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|300x200&s=36"
+            "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36"
           },
           "heading": {
             "level": "4",
@@ -367,12 +371,12 @@
         {
           "image": {
             "alt": "alt text",
-            "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|300x200&s=36"
+            "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36"
           },
           "heading": {
             "level": "4",
             "text": "AMA Ed Hub",
-            "class": "ama__h4 ama__h4--homepage"
+            "class": "ama__h4 ama__h4--homepage ama__product__text__header"
           },
           "paragraph": {
             "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.",
@@ -392,23 +396,28 @@
       "links": [
         {
           "text": "About",
-          "href": "http://www.google.com"
+          "href": "http://www.google.com",
+          "class": "ama__link ama__link--homepage"
         },
         {
-          "text": "Delivery Care",
-          "href": "http://www.yahoo.com"
+          "text": "Delivering Care",
+          "href": "http://www.yahoo.com",
+          "class": "ama__link ama__link--homepage"
         },
         {
           "text": "Practice Management",
-          "href": "http://www.yahoo.com"
+          "href": "http://www.yahoo.com",
+          "class": "ama__link ama__link--homepage"
         },
         {
           "text": "Education",
-          "href": "http://www.yahoo.com"
+          "href": "http://www.yahoo.com",
+          "class": "ama__link ama__link--homepage"
         },
         {
           "text": "Adovcacy",
-          "href": "http://www.yahoo.com"
+          "href": "http://www.yahoo.com",
+          "class": "ama__link ama__link--homepage"
         }
       ]
     },
@@ -554,7 +563,7 @@
         "info": "alt",
         "text": "Subscribe",
         "type": "button",
-        "style": "secondary",
+        "style": "ama__button  ama__button--homepage",
         "size": ""
       }
     },
@@ -574,6 +583,10 @@
       "paragraph" : {
         "text": ""
       }
+    },
+    "fourUpListsHeading": {
+      "text": "Explore Topics",
+      "class": "ama__homepage__section-title"
     },
     "fourUpLists": [
       {
@@ -840,9 +853,9 @@
             },
             "image": {
               "alt": "alt text",
-              "src": "http://via.placeholder.com/800x600x186?l=3:2|800x600&s=36",
-              "height": "600",
-              "width": "800"
+              "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36",
+              "height": "574",
+              "width": "876"
             },
             "headingLevel": "h5",
             "video": "",
@@ -871,9 +884,9 @@
             },
             "image": {
               "alt": "alt text",
-              "src": "http://via.placeholder.com/800x600x186?l=3:2|800x600&s=36",
-              "height": "600",
-              "width": "800"
+              "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36",
+              "height": "574",
+              "width": "876"
             },
             "headingLevel": "h5",
             "video": "",
@@ -902,9 +915,9 @@
             },
             "image": {
               "alt": "alt text",
-              "src": "http://via.placeholder.com/800x600x186?l=3:2|800x600&s=36",
-              "height": "600",
-              "width": "800"
+              "src": "http://via.placeholder.com/876x574x186?l=2:3|876x574&s=36",
+              "height": "574",
+              "width": "876"
             },
             "headingLevel": "h5",
             "video": "",
@@ -955,10 +968,17 @@
         },
         "image": {
           "alt": "alt text",
-          "src": "http://via.placeholder.com/800x600x186?l=3:2|800x600&s=36",
-          "height": "600",
-          "width": "800"
+          "src": "http://via.placeholder.com/876x574x186?l=2:3|876x564&s=36",
+          "height": "574",
+          "width": "876"
         }
+      }
+    },
+    "mission": {
+      "heading": {
+        "level": "1",
+        "text": "The American Medical Association promotes the art and science of medicine and the betterement of public health lorem ipsum alsus",
+        "class": "ama__h1 ama__homepage__mission-header"
       }
     }
   }

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -572,7 +572,7 @@
       "style": "background",
       "heading": {
         "level": "1",
-        "text": "Your AMA membership is about to expire",
+        "text": "Your AMA membership  is about to expire",
         "class": "ama__h1"
       },
       "link": "http://www.google.com",

--- a/styleguide/source/_patterns/05-pages/homepage.twig
+++ b/styleguide/source/_patterns/05-pages/homepage.twig
@@ -21,6 +21,7 @@
   {% include '@molecules/jama/jama.twig' with { jama : homepage.jama } %}
   {% include '@molecules/subscribe-promo.twig' with { subscribePromo : homepage.subscribePromo } %}
   {% include '@organisms/member-feature.twig' with { memberFeature : homepage.memberFeature } %}
+  {% include '@atoms/section-title.twig' with { sectionTitle : homepage.fourUpListsHeading } %}
   {% include '@organisms/four-up-lists.twig' with { fourUpLists : homepage.fourUpLists } %}
   <div class="ama__homepage__promos">
     {% include '@molecules/partner-promo.twig' with { partnerPromo : homepage.partnerPromo } %}
@@ -29,4 +30,5 @@
   {% include '@organisms/upcoming-events.twig' with { upcomingEvents : homepage.upcomingEvents } %}
   {% include '@organisms/your-products.twig' with { yourProducts : homepage.yourProducts } %}
   {% include '@organisms/upcoming-events.twig' %}
+  {% include '@atoms/heading/heading.twig' with { heading : homepage.mission.heading }%}
 {% endblock %}

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
@@ -10,7 +10,6 @@
   text-align: center;
   text-decoration: none;
   vertical-align: middle;
-  text-transform: uppercase;
 
   &:hover {
     border-color: $purple;

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
@@ -10,11 +10,7 @@
   text-align: center;
   text-decoration: none;
   vertical-align: middle;
-  /* stylelint-disable property-no-vendor-prefix */
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  /* stylelint-enable */
-  transition: all 0.4s ease;
+  text-transform: uppercase;
 
   &:hover {
     border-color: $purple;

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -37,7 +37,7 @@
       background-color: $hoverPurple;
       border-color: transparent;
       color: $white;
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
   // homepage secondary
@@ -50,19 +50,20 @@
       background-color: $white;
       border-color: transparent;
       color: $hoverPurple;
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
   @else if($style == "promo") {
     background-color: $orange;
     border-color: transparent;
     color: $black;
+    text-transform: uppercase;
 
     &:hover {
       background-color: $hoverOrange;
       border-color: transparent;
       color: $black;
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
   @else {

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -32,6 +32,7 @@
     background-color: $homepagePurple;
     border-color: transparent;
     color: $white;
+    text-transform: uppercase;
 
     &:hover {
       background-color: $hoverPurple;
@@ -44,7 +45,8 @@
   @else if($style == "homepage-secondary") {
     background-color: $white;
     border-color: transparent;
-    color: $homepagePurple;
+    color: $purple;
+    text-transform: uppercase;
 
     &:hover {
       background-color: $white;
@@ -57,7 +59,6 @@
     background-color: $orange;
     border-color: transparent;
     color: $black;
-    text-transform: uppercase;
 
     &:hover {
       background-color: $hoverOrange;

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
@@ -109,3 +109,10 @@ $small-font-sizes--homepage: (
     medium: (.778em, 1.072),
     large : (.778em, 1.072)
 );
+
+$viewall-font-sizes--homepage: (
+    null  : (0.778em, 1.072),
+    small : (0.778em, 1.072),
+    medium: (0.778em, 1.072),
+    large : (0.778em, 1.072)
+);

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -21,10 +21,10 @@ button {
 
   &--homepage {
     @include ama-button("", "homepage");
+  }
 
-    &--secondary {
-      @include ama-button("", "homepage-secondary");
-    }
+  &--homepage-secondary {
+    @include ama-button("", "homepage-secondary");
   }
 
   &--promo {

--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -198,6 +198,31 @@ a {
   }
 }
 
+.ama__link--homepage-viewall,
+%ama__link--homepage-viewall {
+  @include font-size($viewall-font-sizes--homepage);
+  @include type($myriad-pro, $font-weight-semibold);
+  text-decoration: none;
+  font-style: italic;
+
+  span {
+    text-decoration: none;
+  }
+
+  &:link,
+  &:visited {
+    color: $purple;
+  }
+  // if the default link style changes this will need to include color: black; text-decoration: none;
+  &:active,
+  &:hover,
+  &:focus {
+    color: $purple;
+    text-decoration: underline;
+    background-color: transparent;
+  }
+}
+
 .ama__link--icon,
 %ama__link--icon{
   icon {

--- a/styleguide/source/assets/scss/02-molecules/_alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_alert.scss
@@ -1,11 +1,15 @@
 .ama__alert {
+  display: none;
   background-color: $homepagePurple;
   padding: $gutter / 2;
   color: $white;
   width: 100%;
-  display: flex;
   align-items: center;
   flex-direction: column;
+
+  @include breakpoint($bp-small) {
+    display: flex;
+  }
 
   @include breakpoint($bp-med) {
     background-image: url('../icons/svg/icon-homepage-alert.svg');

--- a/styleguide/source/assets/scss/02-molecules/_jama.scss
+++ b/styleguide/source/assets/scss/02-molecules/_jama.scss
@@ -1,4 +1,5 @@
 .ama__jama {
+  @include gutter($margin-bottom-full...);
   clear: both;
 
   @include breakpoint($bp-med max-width) {
@@ -14,7 +15,7 @@
     display: block;
 
     &.ama__jama__link--sign-up {
-      margin-top: $gutter / 8;
+      @include gutter($margin-top-half...);
       color: $hoverRed;
 
       &:hover {
@@ -34,12 +35,8 @@
   }
 
   .ama__rule {
-    margin-top: $gutter * .75;
-
-    &:first-of-type {
-      margin-top: $gutter / 4;
-      border-color: $hoverRed;
-    }
+    @include gutter($margin-top-full...);
+    border-color: $gray-50;
   }
 
   // Styles the Image Href with Text variant.
@@ -111,6 +108,12 @@
   list-style-type: none;
 
   li {
+    border-top: 1px solid $gray-50;
+
+    &:hover {
+      border-color: $hoverRed;
+    }
+
     &:last-of-type a {
       padding-bottom: 0;
     }

--- a/styleguide/source/assets/scss/02-molecules/_jama.scss
+++ b/styleguide/source/assets/scss/02-molecules/_jama.scss
@@ -57,10 +57,12 @@
     .ama__jama__links {
       display: flex;
       flex-direction: column;
+      border-top: 0;
     }
 
     .ama__jama__links li {
       @include gutter($margin-right-full...);
+      border-top: 1px solid $gray-50;
 
       &:last-child {
         margin-right: 0;
@@ -106,9 +108,10 @@
 
 .ama__jama__links {
   list-style-type: none;
+  border-top: 1px solid $gray-50;
 
   li {
-    border-top: 1px solid $gray-50;
+
 
     &:hover {
       border-color: $hoverRed;

--- a/styleguide/source/assets/scss/02-molecules/_link-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_link-list.scss
@@ -15,7 +15,9 @@
       border-bottom: 0;
 
       span {
-        @extend .ama__type--italic;
+        @extend .ama__link--purple;
+        @include gutter($margin-top-full...);
+        font-style: italic;
         font-weight: 800;
       }
     }
@@ -39,7 +41,7 @@
       background-color: transparent;
       border-radius: 0;
       text-align: center;
-      margin-bottom: 0;
+      margin: 0;
 
       .ui-icon {
         display: none;
@@ -70,6 +72,8 @@
       }
     }
 
+
+
     .ui-accordion-content {
       border: 0;
       padding: 0;
@@ -92,6 +96,8 @@
 
         span {
           @extend .ama__type--italic;
+          @extend .ama__link--purple;
+          @include gutter($margin-top-full...);
           font-weight: 800;
         }
       }

--- a/styleguide/source/assets/scss/02-molecules/_link-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_link-list.scss
@@ -93,13 +93,6 @@
 
       &:last-child {
         border-bottom: 0;
-
-        span {
-          @extend .ama__type--italic;
-          @extend .ama__link--purple;
-          @include gutter($margin-top-full...);
-          font-weight: 800;
-        }
       }
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/_member-feature-rail.scss
+++ b/styleguide/source/assets/scss/02-molecules/_member-feature-rail.scss
@@ -3,37 +3,38 @@
   @include gutter-all($padding-all-full...);
   display: grid;
   grid-template-rows: auto auto;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   grid-column-gap: $gutter;
   background: $gray-7;
 
   .ama__article-stub {
+    @include gutter($margin-bottom-full...);
     margin-top: 0;
 
-    &:nth-child(3) {
+    &:last-child {
       display: none;
     }
   }
 
-  .ama__member-feature-rail__view-all-link {
+  &__view-all-link {
+    @include gutter($margin-top-full...);
+    @extend .ama__link--purple;
+    font-weight: 800;
     grid-column: 1/-1;
-    text-align: right;
+    font-style: italic;
+    display: inline-block;
   }
 
-  @include breakpoint($bp-small) {
-    .ama__article-stub {
-      @include gutter($margin-bottom-full...);
+  @include breakpoint($bp-med) {
+    grid-template-columns: 1fr 1fr;
+  }
 
-      &:nth-child(3) {
+  @include breakpoint($bp-med) {
+    .ama__article-stub {
+      &:last-child {
         display: block;
-        margin-bottom: 0;
       }
     }
-  }
-
-  @include breakpoint($bp-small) {
-    display: flex;
-    flex-direction: column;
   }
 
   .ama__article-stub .ama__image {
@@ -65,10 +66,8 @@
     }
   }
 
-  &__view-all-link {
-    @include gutter($margin-top-full...);
-    font-weight: 600;
-    font-style: italic;
-    display: inline-block;
+  @include breakpoint($bp-small) {
+    display: flex;
+    flex-direction: column;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_member-feature-rail.scss
+++ b/styleguide/source/assets/scss/02-molecules/_member-feature-rail.scss
@@ -20,7 +20,7 @@
     @include gutter($margin-top-full...);
     @extend .ama__link--purple;
     font-weight: 800;
-    grid-column: 1/-1;
+    grid-column: 1;
     font-style: italic;
     display: inline-block;
   }

--- a/styleguide/source/assets/scss/02-molecules/_member-feature-rail.scss
+++ b/styleguide/source/assets/scss/02-molecules/_member-feature-rail.scss
@@ -16,15 +16,6 @@
     }
   }
 
-  &__view-all-link {
-    @include gutter($margin-top-full...);
-    @extend .ama__link--purple;
-    font-weight: 800;
-    grid-column: 1;
-    font-style: italic;
-    display: inline-block;
-  }
-
   @include breakpoint($bp-med) {
     grid-template-columns: 1fr 1fr;
   }

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -50,13 +50,16 @@
 
 .ama__products {
   position: relative;
-  display: flex;
-  flex-direction: column;
 
   &__wrap {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+  }
+
+  @include breakpoint($bp-small) {
+    display: flex;
+    flex-direction: column;
   }
 
   &__view-all-link {

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -50,6 +50,8 @@
 
 .ama__products {
   position: relative;
+  display: flex;
+  flex-direction: column;
 
   &__wrap {
     display: flex;

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -50,8 +50,7 @@
 
 .ama__products {
   position: relative;
-  display: flex;
-  flex-direction: column;
+  overflow: hidden;
 
   &__wrap {
     display: flex;
@@ -67,12 +66,13 @@
   &__view-all-link {
     @include font-size($small-font-sizes);
     @include gutter($margin-top-half...);
-    align-self: flex-end;
+    float: right;
 
     @include breakpoint($bp-small) {
       position: absolute;
       top: 0;
       margin-top: 0;
+      align-self: flex-end;
     }
 
     @include breakpoint($bp-med) {

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -9,6 +9,11 @@
     float: right;
   }
 
+  &__text {
+    &__header {
+      @include gutter($margin-bottom-half...);
+    }
+  }
 
   &__image {
     @include gutter($padding-right-half...);

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -50,6 +50,8 @@
 
 .ama__products {
   position: relative;
+  display: flex;
+  flex-direction: column;
 
   &__wrap {
     display: flex;
@@ -58,20 +60,20 @@
   }
 
   &__view-all-link {
-    @include gutter($margin-right-full...);
     @include font-size($small-font-sizes);
+    @include gutter($margin-top-half...);
     align-self: flex-end;
 
     @include breakpoint($bp-small) {
       position: absolute;
-      top: 10px;
-      right: 20px;
+      top: 0;
+      margin-top: 0;
     }
 
     @include breakpoint($bp-med) {
+      top: 45px;
       font-size: .778em;
       line-height: 1.571em;
-      top: 45px;
     }
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -56,6 +56,10 @@
     background: $purple;
     color: $white;
 
+    .ama__h1 {
+      font-weight: normal;
+    }
+
     button {
       display: block;
       margin: $gutter auto;

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -9,6 +9,13 @@
     padding-bottom: $gutter / 2;
   }
 
+  &__form {
+    .ama__button {
+      display: block;
+      margin: 0 auto;
+    }
+  }
+
   .ama__form-group {
     input {
       @include type($myriad-pro, $font-weight-regular);
@@ -53,9 +60,8 @@
         height: 49px;
       }
 
-
       @include breakpoint($bp-small min-width) {
-        button {
+        .ama__button {
           margin: 0 0 0 auto;
         }
       }

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -20,19 +20,6 @@
     }
   }
 
-  button {
-    font-weight: 400;
-    text-align: center;
-    margin: 0 auto;
-    display: block;
-    height: 40px;
-    padding: 0 14px;
-
-    &:hover {
-      background: $hoverPurple;
-    }
-  }
-
   &--wide {
     width: 100%;
 
@@ -66,10 +53,6 @@
         height: 49px;
       }
 
-      button {
-        @extend .ama__button--homepage;
-        height: 49px;
-      }
 
       @include breakpoint($bp-small min-width) {
         button {

--- a/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
+++ b/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
@@ -14,12 +14,16 @@
   }
 
   &__title {
+    a {
+      display: flex;
+    }
+
     svg {
+      @include gutter($margin-right-half...);
       display: none;
 
       @include breakpoint($bp-small) {
-        @include gutter($margin-right-full...);
-        display: inline-block;
+        display: block;
       }
     }
 

--- a/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
+++ b/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
@@ -62,7 +62,9 @@
 }
 
 .ama__upcoming-events {
+  @include gutter($margin-bottom-full...);
   position: relative;
+  overflow: hidden;
   
   &__header {
     display: flex;

--- a/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
+++ b/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
@@ -77,20 +77,20 @@
   }
 
   &__view-all-link {
-    @include gutter($margin-right-full...);
     @include font-size($small-font-sizes);
     float: right;
 
     @include breakpoint($bp-small) {
       position: absolute;
       top: 10px;
-      right: 20px;
+      right: 0;
     }
 
     @include breakpoint($bp-med) {
       font-size: .778em;
       line-height: 1.571em;
       top: 45px;
+      right: 20px;
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -5,12 +5,28 @@
   &__wrapper {
     @include gutter($margin-top-full...);
 
+    .ama__hero-story__media {
+      margin-top: 0;
+    }
+
     @include breakpoint($bp-small) {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
       grid-column-gap: $gutter;
       background: $gray-7;
 
+      .ama__hero-story {
+        grid-column-start: 1;
+        grid-column-end: 4;
+      }
+
+      .ama__member-feature-rail {
+        grid-column-start: 4;
+        grid-column-end: 6;
+      }
+    }
+
+    @include breakpoint($bp-med) {
       .ama__hero-story {
         grid-column-start: 1;
         grid-column-end: 4;

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -15,18 +15,17 @@
 
     @include breakpoint($bp-small) {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
       grid-column-gap: $gutter;
       background: $gray-7;
 
       .ama__hero-story {
         grid-column-start: 1;
-        grid-column-end: 4;
+        grid-column-end: 3;
       }
 
       .ama__member-feature-rail {
         grid-column-start: 4;
-        grid-column-end: 6;
       }
     }
 

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -6,6 +6,10 @@
     @include gutter($margin-top-full...);
 
     .ama__hero-story__media {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: flex-end;
       margin-top: 0;
     }
 
@@ -34,7 +38,6 @@
       }
       .ama__hero-story__media {
         margin-right: $gutter*-2;
-        display: flex;
 
         img {
           height: 100%;

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -1,60 +1,34 @@
-.ama__member-feature__wrapper {
+.ama__member-feature {
   @include gutter($margin-top-full...);
+  @include gutter($margin-bottom-full...);
 
-  @include breakpoint($bp-small) {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    grid-column-gap: $gutter;
-    background: $gray-7;
-
-    .ama__hero-story {
-      grid-column-start: 1;
-      grid-column-end: 4;
-    }
-    .ama__hero-story__media{
-      margin-right: $gutter*-2;
-      img{
-        max-width: unset;
-        width: 100%;
-      }
-    }
-
-    .ama__member-feature-rail {
-      grid-column-start: 4;
-    }
-  }
-
-  .ama__member-feature-rail {
-
-    @include breakpoint($bp-small max-width) {
-      display: grid;
-      grid-template-rows: auto auto;
-      grid-template-columns: 1fr 1fr;
-      grid-column-gap: $gutter;
-
-      .ama__article-stub {
-        margin: 0;
-      }
-
-      .ama__member-feature-rail__view-all-link {
-        grid-column-start: 2;
-        grid-column-end: 2;
-      }
-    }
-    .ama__member-feature-rail__view-all-link {
-      text-align: right;
-      color: $purple;
-      text-decoration: none;
-      font-style: italic;
-      font-size: 12px;
-      text-align: right;
-      @include breakpoint($bp-small){
-        text-align: left;
-      }
-    }
+  &__wrapper {
+    @include gutter($margin-top-full...);
 
     @include breakpoint($bp-small) {
-      display: block;
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      grid-column-gap: $gutter;
+      background: $gray-7;
+
+      .ama__hero-story {
+        grid-column-start: 1;
+        grid-column-end: 4;
+        justify-content: flex-end;
+      }
+      .ama__hero-story__media {
+        margin-right: $gutter*-2;
+        display: flex;
+
+        img {
+          height: 100%;
+          width: 100%;
+        }
+      }
+
+      .ama__member-feature-rail {
+        grid-column-start: 4;
+      }
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -21,7 +21,7 @@
 
       .ama__hero-story {
         grid-column-start: 1;
-        grid-column-end: 3;
+        grid-column-end: 4;
       }
 
       .ama__member-feature-rail {

--- a/styleguide/source/assets/scss/03-organisms/_product-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_product-nav.scss
@@ -1,5 +1,10 @@
 .ama__product-nav {
+  display: none;
   background: $hoverBlack;
+
+  @include breakpoint($bp-small) {
+    display: block;
+  }
 
   li {
     display: inline-block;

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -51,8 +51,9 @@
     @include gutter($margin-bottom-full...);
 
     .ama__article-stub {
-      @include gutter($margin-top-full...);
       @include gutter($margin-bottom-full...);
+      @include gutter($padding-bottom-full...);
+      border-bottom: 1px solid $gray-7;
 
       &:not(:first-child) {
         .ama__image {
@@ -72,6 +73,8 @@
         margin-left: 15px;
         position: relative;
         height: auto;
+        border-bottom: 0;
+        padding-bottom: 0;
 
         &:nth-last-child(2):before {
           content: "";
@@ -79,6 +82,12 @@
           position: absolute;
           top: -28px;
           width: 200%;
+        }
+
+        &:not(:first-child) {
+          .ama__image {
+            display: block;
+          }
         }
       }
 
@@ -111,7 +120,7 @@
   &__section-title {
     @include gutter($margin-bottom-full...);
 
-    @include breakpoint($bp-small) {
+    @include breakpoint($bp-med) {
       margin-bottom: 0;
     }
   }

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -1,4 +1,15 @@
 .ama__homepage {
+
+  .ama__layout--one-column__content-top {
+    display: none;
+  }
+
+  @include breakpoint($bp-small) {
+    .ama__layout--one-column__content-top {
+      display: block;
+    }
+  }
+
   &__navs {
     display: none;
 
@@ -23,11 +34,28 @@
       display: flex;
       align-items: center;
     }
+
+    @include breakpoint($bp-med) {
+      .ama__promo--homepage {
+        flex-basis: 60%;
+
+        &:last-child {
+          margin-left: -5%;
+        }
+      }
+    }
   }
 
+
   &__stubs {
-    @include breakpoint($bp-small max-width) {
-      .ama__article-stub:not(:first-child) {
+    @include gutter($margin-top-full...);
+    @include gutter($margin-bottom-full...);
+
+    .ama__article-stub {
+      @include gutter($margin-top-full...);
+      @include gutter($margin-bottom-full...);
+
+      &:not(:first-child) {
         .ama__image {
           display: none;
         }
@@ -35,19 +63,56 @@
     }
 
     @include breakpoint($bp-small) {
-      @include gutter($margin-bottom-full...);
-      @include gutter($margin-top-full...);
       display: grid;
       grid-template-columns: 1fr 1fr 1fr 1fr;
       grid-column-gap: 15px;
       grid-row-gap: 15px;
+      grid-row: 4;
 
-      .ama__article-stub:first-of-type {
-        grid-column-start: 1;
-        grid-column-end: 3;
-        grid-row-start: 1;
-        grid-row-end: 3;
+
+      .ama__article-stub {
+        position: relative;
+        height: auto;
+
+        &:not(:first-child) {
+          .ama__image {
+            display: block;
+          }
+        }
+
+        &:first-of-type {
+          grid-column-start: 1;
+          grid-column-end: 3;
+          grid-row-start: 1;
+          grid-row-end: 4;
+        }
+
+        &:nth-last-child(2):before {
+          content: "";
+          border-top: 1px solid $gray-7;
+          position: absolute;
+          top: -28px;
+          width: 200%;
+        }
       }
     }
+  }
+
+  .ama__jama__title {
+    display: none;
+  }
+
+  &__section-title {
+    @include gutter($margin-bottom-full...);
+
+    @include breakpoint($bp-small) {
+      margin-bottom: 0;
+    }
+  }
+
+  &__mission-header {
+    color: $purple;
+    @include gutter($margin-top-full...);
+    @include gutter($margin-bottom-full...);
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -62,28 +62,16 @@
     }
 
     @include breakpoint($bp-small) {
+      @include gutter($margin-bottom-full...);
+      @include gutter($margin-top-full...);
       display: grid;
       grid-template-columns: 1fr 1fr 1fr 1fr;
 
-      grid-row: 4;
-
-
       .ama__article-stub {
+        grid-row: 2;
+        margin-left: 15px;
         position: relative;
         height: auto;
-
-        &:not(:first-child) {
-          .ama__image {
-            display: block;
-          }
-        }
-
-        &:first-of-type {
-          grid-column-start: 1;
-          grid-column-end: 3;
-          grid-row-start: 1;
-          grid-row-end: 4;
-        }
 
         &:nth-last-child(2):before {
           content: "";
@@ -92,6 +80,26 @@
           top: -28px;
           width: 200%;
         }
+      }
+
+      .ama__article-stub--image {
+        grid-row: 1;
+      }
+
+      .ama__article-stub:nth-child(even) {
+        grid-column: 3;
+      }
+
+      .ama__article-stub:nth-child(odd) {
+        grid-column: 4;
+      }
+
+      .ama__article-stub:first-of-type {
+        grid-column-start: 1;
+        grid-column-end: 3;
+        grid-row-start: 1;
+        grid-row-end: 3;
+        margin: 0;
       }
     }
   }


### PR DESCRIPTION
## Ticket(s)


**Jira Ticket**
- [EWL-5527: A1 | Style Guide - People Homepage Feedback](https://issues.ama-assn.org/browse/EWL-5527)

## Description
Update homepage based on feedback from UX.

Feedback notes can be found here:
https://docs.google.com/spreadsheets/d/1oRKGgOD_hSRrp0CIM1XFIS4PjEHE1-ELxVijV3pbHV8/edit#gid=0

**Please see additional notes about buttons being all caps.**

--
- Delivery Care” should be “Delivering Care
- About, Delivering Care, Practice Mgmt, etc. and Board of Trustees, House of Delegates, etc. links have no hover interaction (Our fault, wasn’t in notes. We can talk through those)
- There should be a divider line between the top two and bottom two articles in the group of 4 on the right next to the hero story.
- Divider lines and padding missing between stories on mobile (spacing on JAMA looks great)
- JAMA component – there were supposed to be specific line breaks for each article with a red hover effect – not the consistent red line as it shows. Padding below also needs to be fine-tuned
- Buttons all have a weird hover effect. They should just go to hover purple. No underline.
- All buttons should be CAPS
- Membership Moves Medicine – padding at top and bottom need fine-tuning.
- “View More from MMM series should be Closer to the bottom of the gray background.
- Check image sizes. They should be 2:3, but I think are currently 3:4
- Explore Topics section header is missing
- “View all topics” text size should be 14, not 10 as it appears
- The promos were supposed to have an overlay. We worked through this in one of the meetings, so I’ll make sure we all understood what was supposed to happen with those.
- Your Products – besides linking “Learn More” we should also link the product titles (JAMA Network, CPT, etc.)
- Upcoming Events. If text should wrap on events, it should be aligned with the text on top and not the purple icon.
- Can spacing be increased between the product name and the description?
- The font on the membership promo should be regular – not semibold/bold
- Page is missing the mission at the bottom of the page. – This is going to be the H1
- Tablet view: Membership moves medicine should only show 2 of the highlighted stories (right now it shows all 3)
- On mobile, “view all events” should not be aligned with the “Your Products” Header. Needs padding.
- On Mobile: “View all Products” should be right aligned.
- Product names should link to products as well as “Learn More”
- As the page responds for smaller devices, instead of stacking when the window gets smaller, all menu items (Product Nav, Category Nav, organizational Nav) should go away. Once the organization nav begins to truncate.

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-homepage
- [ ] verify all the items in the description are completed
- [ ] Did you test in IE 11? Yes

## Visual Regressions
All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5527-homepage-feedback/html_report/index.html

**See Additional notes below**

## Relevant Screenshots/GIFs
<img width="1339" alt="screen shot 2018-07-19 at 4 06 07 pm" src="https://user-images.githubusercontent.com/2271747/42969998-ac7ec4a0-8b6d-11e8-8bef-7031570b6868.png">


## Remaining Tasks
N/A


## Additional Notes
### All buttons are now in CAPS as requested by UX. 
<img width="516" alt="screen shot 2018-07-19 at 4 36 16 pm" src="https://user-images.githubusercontent.com/2271747/42971493-2bb02c06-8b72-11e8-9c06-97e2d93515bc.png">

This will cause a lot of backstop failures.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
