### PR TITLE
EWL-5526 people bio feedback

### DIFF
--- a/styleguide/source/_patterns/02-molecules/content-with-label.twig
+++ b/styleguide/source/_patterns/02-molecules/content-with-label.twig
@@ -1,5 +1,10 @@
 <dt>
-  {{ contentWithLabel.dt }}
+  {% if contentWithLabel.dt.link %}
+    {% set link = contentWithLabel.dt.link %}
+    {% include '@atoms/link/link.twig' %}
+  {% else %}
+    {{ contentWithLabel.dt }}
+  {% endif %}
   {% if contentWithLabel.gated %}
     <span class="as-gated"></span>
   {% endif %}

--- a/styleguide/source/_patterns/03-organisms/bio-image-with-body.json
+++ b/styleguide/source/_patterns/03-organisms/bio-image-with-body.json
@@ -31,7 +31,14 @@
           },
           {
             "gated": "Members Only",
-            "dt": "Conflict of interest:",
+            "dt": "@atoms/link/link.twig",
+            "link": {
+              "title": "Conflict of Interest",
+              "href": "#",
+              "text": "Lorem ipsum dolor sit amet.",
+              "target": "_self",
+              "class": "ama__link"
+            },
             "dd": ""
           }
         ]

--- a/styleguide/source/_patterns/05-pages/people-bio.json
+++ b/styleguide/source/_patterns/05-pages/people-bio.json
@@ -54,16 +54,21 @@
         {
           "contentWithLabelList": [
             {
-              "dt": "Specialty:",
-              "dd": "Anesthesiology"
+              "dt": "Anesthesiology, Family Practice"
             },
             {
               "dt": "Term:",
-              "dd": "May 2017 - June 2018"
+              "dd": "2022-2024"
             },
             {
               "dt": "Email:",
-              "dd": "john.doe@ama-assn.org"
+              "dd": {
+                "link": {
+                  "href": "#",
+                  "text": "john.doe@ama-assn.org",
+                  "class": "ama__link ama__link--purple"
+                }
+              }
             },
             {
               "dt": "Endorsement:",
@@ -88,20 +93,22 @@
               "dd": {
                 "link": {
                   "href": "#",
-                  "text": "AMA Affiliated Group"
+                  "text": "AMA Affiliated Group",
+                  "class": "ama__link ama__link--purple"
                 }
               }
             },
             {
               "dt": "Term:",
-              "dd": "May 2017 - June 2018"
+              "dd": "2022-2024"
             },
             {
               "dt": "Email:",
               "dd": {
                 "link": {
                   "href": "#",
-                  "text": "john.doe@ama-assn.org"
+                  "text": "john.doe@ama-assn.org",
+                  "class": "ama__link ama__link--purple"
                 }
               }
             },
@@ -133,7 +140,8 @@
               "dd": {
                 "link": {
                   "href": "#",
-                  "text": "john.doe@ama-assn.org"
+                  "text": "john.doe@ama-assn.org",
+                  "class": "ama__link ama__link--purple"
                 }
               }
             },

--- a/styleguide/source/_patterns/05-pages/people-bio.json
+++ b/styleguide/source/_patterns/05-pages/people-bio.json
@@ -54,7 +54,8 @@
         {
           "contentWithLabelList": [
             {
-              "dt": "Anesthesiology, Family Practice"
+              "dt": "Specialty:",
+              "dd": "Anesthesiology, Family Practice"
             },
             {
               "dt": "Term:",
@@ -80,7 +81,15 @@
             },
             {
               "gated": "Members Only",
-              "dt": "Conflict of interest:",
+              "dt": {
+                "link":
+                {
+                  "title": "Link to something",
+                  "href": "#",
+                  "text": "Conflict of Interest",
+                  "target": "_self"
+                }
+              },
               "dd": ""
             }
           ]

--- a/styleguide/source/assets/scss/02-molecules/_content-with-label.scss
+++ b/styleguide/source/assets/scss/02-molecules/_content-with-label.scss
@@ -6,6 +6,7 @@ dl {
 dt {
   font-weight: 600;
   text-transform: capitalize;
+  margin-right: $gutter/4;
 
   .as-gated {
     &:before {
@@ -23,7 +24,7 @@ dt {
 }
 
 dd {
-  margin: 0 0 $gutter/2;
+  margin: 0;
 
   span {
     display: block;
@@ -54,6 +55,5 @@ dd {
 
   dd {
     float: left;
-    margin-left: $gutter/4;
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5526: A1 | Style Guide - People Bio Feedback](https://issues.ama-assn.org/browse/EWL-5526)

## Description

Update the people bio page with UX Feedback

- Links within the profile should have purple hover effect with underline on default
- Clarification: Specialty will fill in with their actual specialty and will not say “Specialty” For instance it will read:“Family Practice” not “Specialty: Family Practice”
- Term should be “Term:” and when content is entered should read: “Term: 2022-2024”
- Affiliation should be a link to another group page, not just text. ie: Academic Physicians
- "Conflict of Interest" should be a link for the download

Feedback notes can be found here:
https://docs.google.com/spreadsheets/d/1oRKGgOD_hSRrp0CIM1XFIS4PjEHE1-ELxVijV3pbHV8/edit#gid=0

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-people-bio
- [ ] verify all the items from the description are completed
- [ ] Did you test in IE 11?

## Visual Regressions
All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5526-people-bio-feedback/html_report/index.html

## Relevant Screenshots/GIFs
<img width="1299" alt="screen shot 2018-07-19 at 4 11 32 pm" src="https://user-images.githubusercontent.com/2271747/42970251-6ecd6caa-8b6e-11e8-929f-eb05a1bb9dff.png">


## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
