### PR TITLE
moves the ul list bullets from outside to inside on hub pages

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -29,6 +29,7 @@
 
   &__list {
     @include gutter-all($padding-all-full...);
+    list-style-position: inside;
     margin: inherit;
 
     ul {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- Hotfix

## Description
Move ul list bullets from outside to inside for hub page

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=viewall-molecules-hub
- [ ] observe the bullets now are on the inside of the divs

## Visual Regressions
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/hotfix/remove-bullets-hub-lists/html_report/index.html



## Relevant Screenshots/GIFs
Before:
<img width="1041" alt="screen shot 2018-07-20 at 2 07 23 pm" src="https://user-images.githubusercontent.com/2271747/43020630-4699920a-8c26-11e8-9618-fbd8484784b1.png">

After:
<img width="1215" alt="screen shot 2018-07-20 at 2 05 41 pm" src="https://user-images.githubusercontent.com/2271747/43020559-03414ade-8c26-11e8-989a-c56fa1f2e1e3.png">


## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
