### PR TITLE
EWL-5589 main navigation stub

### DIFF
--- a/styleguide/source/_patterns/03-organisms/main-navigation.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.json
@@ -1,0 +1,5 @@
+{
+  "mainNavigation": {
+
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/main-navigation.md
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.md
@@ -1,0 +1,14 @@
+### Description
+The main navigation is present on every page, and contains the main logo, search and account.
+
+[EWL-5589](https://issues.ama-assn.org/browse/EWL-5589)
+
+### Use Case
+
+
+### Variables
+~~~
+{
+  "mainNavigation": {
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -1,0 +1,4 @@
+<div class="ama__main-navigation">
+  <div class="container">
+  </div>
+</div>

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -1,0 +1,4 @@
+.ama__main-navigation {
+  background-color: $purple;
+  color: $white;
+}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5589: SG2 | Create "Main Navigation" Organism Stub](https://issues.ama-assn.org/browse/EWL-5589)

## Description
Add main navigation organism stub

## To Test
- [ ] ` gulp serve`
- [ ] in the SG2 menu click on organisms > main navigation
- [ ] observe a blank page 
- [ ] use the chrome inspector and see that the page contains a div with a class of ama__main-navigation with a container it
- [ ] Did you test in IE 11?

## Visual Regressions
All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5589-main-nav-stub/html_report/index.html


## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
