### PR TITLE
EWL-4936: add image tool icon to resource tabs

### DIFF
--- a/styleguide/source/_patterns/03-organisms/resource-tabs.json
+++ b/styleguide/source/_patterns/03-organisms/resource-tabs.json
@@ -129,6 +129,13 @@
                 "level": "3",
                 "class": "ama__h3"
               },
+              "link": {
+                "href": "#",
+                "title": "a link to a thing three",
+                "text": "Link to this image",
+                "class": "ama__link--icon ama__link--no-underline",
+                "iconLeft": "@atoms/media/icons/svg/icon-image-gold.twig"
+              },
               "image": {
                 "alt": "alt text",
                 "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",

--- a/styleguide/source/_patterns/03-organisms/resource-tabs.twig
+++ b/styleguide/source/_patterns/03-organisms/resource-tabs.twig
@@ -32,17 +32,19 @@
           {% set heading = mediaItem.heading %}
           {% include '@atoms/heading/heading.twig' %}
 
+          {% if mediaItem.link %}
+            {% set link = mediaItem.link %}
+            {% include '@atoms/link/link.twig' %}
+          {% endif %}
+
           {% if mediaItem.image %}
             {% set image = mediaItem.image %}
             {% include '@atoms/image/image.twig' %}
-          {% elseif mediaItem.link %}
-            {% set link = mediaItem.link %}
-            {% include '@atoms/link/link.twig' %}
+          {% endif %}
 
-            {% if mediaItem.video %}
-              {% set video = mediaItem.video %}
-              {% include '@atoms/video.twig' %}
-            {% endif %}
+          {% if mediaItem.video %}
+            {% set video = mediaItem.video %}
+            {% include '@atoms/video.twig' %}
           {% endif %}
 
           {% if mediaItem.subtext %}

--- a/styleguide/source/_patterns/05-pages/resource.json
+++ b/styleguide/source/_patterns/05-pages/resource.json
@@ -129,6 +129,13 @@
               "level": "3",
               "class": "ama__h3"
             },
+            "link": {
+              "href": "#",
+              "title": "a link to a thing three",
+              "text": "Link to this image",
+              "class": "ama__link--icon ama__link--no-underline",
+              "iconLeft": "@atoms/media/icons/svg/icon-image-gold.twig"
+            },
             "image": {
               "alt": "alt text",
               "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-4936: Create "Resource Tabs" Organism](https://issues.ama-assn.org/browse/EWL-4936)

## Description
Update the resource tabs so that you can see the Image tool link in the media section


## To Test
- [ ] `gulp serve`
- [ ] Click "Pages" in the menu
- [ ] Observe you see "Resource"
- [ ] Click "Resource"
- [ ] Observe you see the Media tab
- [ ] If you do not see the Media tab, click the Media tab to display the contents
- [ ] Observe you see the image tool icon link above the image
- [ ] Did you test in IE 11? Yes.

## Visual Regressions
This should only show changes to the resource tabs.


## Relevant Screenshots/GIFs
<img width="564" alt="screen shot 2018-07-23 at 4 21 34 pm" src="https://user-images.githubusercontent.com/1653723/43103668-7f166304-8e94-11e8-9a3a-a1f6fb4de1f5.png">


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
