### PR TITLE
EWL-5586 add white site logo

### DIFF
--- a/styleguide/source/_patterns/01-atoms/site-logo/site-logo-as-jama.md
+++ b/styleguide/source/_patterns/01-atoms/site-logo/site-logo-as-jama.md
@@ -1,4 +1,0 @@
-### Description
-An SVG of the JAMA logo to be inlcuded in patterns.
-
-[EWL-5031](https://issues.ama-assn.org/browse/EWL-5031)

--- a/styleguide/source/_patterns/01-atoms/site-logo/site-logo-as-jama.twig
+++ b/styleguide/source/_patterns/01-atoms/site-logo/site-logo-as-jama.twig
@@ -1,5 +1,0 @@
-<span class="logo logo-outer {{ class }}">
-  <img src="{{ logo.image|default('../../assets/images/brand/logo-jama.svg') }}"
-       class="logo"
-       alt="{{ logo.alt|default('American Medical Association') }}" />
-</span>

--- a/styleguide/source/_patterns/01-atoms/site-logo/site-logo.json
+++ b/styleguide/source/_patterns/01-atoms/site-logo/site-logo.json
@@ -1,0 +1,8 @@
+{
+  "siteLogo": {
+    "src": "../../assets/images/brand/logo.svg",
+    "href": "#",
+    "imageClass": "logo",
+    "alt": "American Medical Association"
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/site-logo/site-logo.twig
+++ b/styleguide/source/_patterns/01-atoms/site-logo/site-logo.twig
@@ -1,5 +1,8 @@
-<a href="{{ logo.href|default(link|first) }}" class="logo logo-outer {{ class }}">
-  <img src="{{ logo.image|default('../../assets/images/brand/logo.svg') }}"
-       class="logo"
-       alt="{{ logo.alt|default('American Medical Association') }}" />
+{% set logoSource = siteLogo.reversed ? siteLogo.reversed.src : siteLogo.src %}
+
+<a href="{{ siteLogo.href }}" class="{{ siteLogo.class }}">
+  <img src="{{ logoSource }}" class="{{ siteLogo.imageClass }}" alt="{{ siteLogo.alt }}" />
 </a>
+
+
+

--- a/styleguide/source/_patterns/01-atoms/site-logo/site-logo~as-jama.json
+++ b/styleguide/source/_patterns/01-atoms/site-logo/site-logo~as-jama.json
@@ -1,0 +1,8 @@
+{
+  "siteLogo": {
+    "src": "../../assets/images/brand/logo-jama.svg",
+    "href": "#",
+    "imageClass": "logo",
+    "alt": "American Medical Association"
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/site-logo/site-logo~as-white.json
+++ b/styleguide/source/_patterns/01-atoms/site-logo/site-logo~as-white.json
@@ -1,0 +1,11 @@
+{
+  "siteLogo": {
+    "src": "../../assets/images/brand/logo.svg",
+    "href": "#",
+    "imageClass": "logo",
+    "alt": "American Medical Association",
+    "reversed": {
+      "src": "../../assets/images/brand/logo-reversed.svg"
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/main-navigation.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.json
@@ -1,5 +1,14 @@
 {
   "mainNavigation": {
-
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo.svg",
+      "href": "#",
+      "class": "ama__site-logo",
+      "imageClass": "logo",
+      "alt": "American Medical Association",
+      "reversed": {
+        "src": "../../assets/images/brand/logo-reversed.svg"
+      }
+    }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -1,4 +1,5 @@
 <div class="ama__main-navigation">
   <div class="container">
+    {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : mainNavigation.siteLogo } %}
   </div>
 </div>

--- a/styleguide/source/assets/scss/01-atoms/_icons.scss
+++ b/styleguide/source/assets/scss/01-atoms/_icons.scss
@@ -1,5 +1,6 @@
 /* Define the Sassy Map called $icons */
 $icons: (
+    ama-logo
     alert,
     arrow,
     audio,

--- a/styleguide/source/assets/scss/01-atoms/_site_logo.scss
+++ b/styleguide/source/assets/scss/01-atoms/_site_logo.scss
@@ -1,0 +1,8 @@
+.ama__site-logo {
+  height: 45px;
+
+  .logo {
+    height: 45px;
+    width: 110px;
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -1,4 +1,9 @@
 .ama__main-navigation {
   background-color: $purple;
   color: $white;
+
+  .container {
+    display: flex;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5586: SG2 | Create "Site Logo as White" variant](https://issues.ama-assn.org/browse/EWL-5586)

## Description
Add white AMA site logo icon

## To Test
- [x] `gulp serve`
- [x] in the SG2 menu click site logo > site logo as white
- [x] observe a blank page
- [x]  in the SG2 menu click site logo > site logo
- [x] observe a purple AMA logo
- [x] visit http://localhost:3000/?p=organisms-main-navigation
- [x] observe a white logo on a purple ribbon
- [x] Did you test in IE 11?

## Visual Regressions
All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5586-site-logo-whitehtml_report/index.html

## Relevant Screenshots/GIFs
<img width="399" alt="screen shot 2018-07-23 at 5 04 49 pm" src="https://user-images.githubusercontent.com/2271747/43105440-87fca0c2-8e9a-11e8-816d-453846404225.png">

## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
