### PR TITLE
EWL-5587 button as secondary small

### DIFF
--- a/styleguide/source/_patterns/01-atoms/button/button~as-secondary-small.json
+++ b/styleguide/source/_patterns/01-atoms/button/button~as-secondary-small.json
@@ -1,0 +1,10 @@
+{
+  "button": {
+    "href": "",
+    "info": "alt",
+    "text": "Button",
+    "type": "button",
+    "style": "secondary",
+    "size": "small"
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/main-navigation.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.json
@@ -12,6 +12,22 @@
     },
     "menuIcon": {
       "text": "Menu"
+    },
+    "joinButton": {
+      "href": "",
+      "info": "alt",
+      "text": "Join",
+      "type": "button",
+      "style": "secondary",
+      "size": "small"
+    },
+    "renewButton": {
+      "href": "",
+      "info": "alt",
+      "text": "Renew",
+      "type": "button",
+      "style": "secondary",
+      "size": "small"
     }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -2,5 +2,9 @@
   <div class="container">
     {% include '@atoms/menu-icon.twig' with { menuIcon : mainNavigation.menuIcon } %}
     {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : mainNavigation.siteLogo } %}
+    <div class="ama__main-navigation__button-container">
+      {% include '@atoms/button/button.twig' with { button : mainNavigation.joinButton } %}
+      {% include '@atoms/button/button.twig' with { button : mainNavigation.renewButton } %}
+    </div>
   </div>
 </div>

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -14,7 +14,8 @@
       background-color: $purple;
       color: $white;
     }
-  } //outline
+  }
+  //outline
   @else if($style == "reset") {
     background-color: transparent;
     border-color: transparent;
@@ -75,7 +76,20 @@
     }
   }
 
-  @if($size == "small") {
+  @if($size == "small" and $style == "secondary") {
+    @include type($myriad-pro, $font-weight-regular);
+    @include font-size($button-font-sizes--menu);
+    padding: $gutter/6 $gutter/2;
+    background-color: $white;
+    border-color: $purple;
+    color: $purple;
+
+    &:hover {
+      background-color: $purple;
+      color: $white;
+    }
+  }
+  @else if($size == "small") {
     @include gutter-all($padding-all-half...);
   }
   @elseif ($size == "block") {

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
@@ -106,6 +106,13 @@ $small-font-sizes: (
 $small-font-sizes--homepage: (
     null  : (0.7em, 1.072),
     small : (0.7em, 1.072),
-    medium: (.778em, 1.072),
-    large : (.778em, 1.072)
+    medium: (0.778em, 1.072),
+    large : (0.778em, 1.072)
+);
+
+$button-font-sizes--menu: (
+    null  : (0.889em, 1.072),
+    small : (0.889em, 1.072),
+    medium: (0.889em, 1.072),
+    large : (0.889em, 1.072)
 );

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -144,3 +144,9 @@ strong,
   @include type($myriad-pro, $font-weight-bold);
   @include font-size($p-font-sizes);
 }
+
+.ama__menu--button,
+%ama__menu--button {
+  @include type($myriad-pro, $font-weight-regular);
+  @include font-size($button-font-sizes--menu);
+}

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -35,3 +35,7 @@ button {
     }
   }
 }
+
+.ama__button--small.ama__button--secondary  {
+  @include ama-button("small", "secondary");
+}

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -17,6 +17,16 @@
     text-align: center;
   }
 
+  &__button-container {
+    @include gutter($margin-left-full...);
+    @include gutter($margin-right-full...);
+    display: none;
+
+    @include breakpoint($bp-med min-width) {
+      display: block;
+    }
+  }
+
   @include breakpoint($bp-med min-width) {
     .ama__site-logo {
       flex-grow: 0;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5587: SG2 | Create "Button as Secondary Small" variant](https://issues.ama-assn.org/browse/EWL-5587)

## Description
Add button as secondary small variant

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=atoms-button-as-secondary-small
- [x] observe a small button with a white background, purple border and text
- [x] visit http://localhost:3000/?p=organisms-main-navigation
- [x] observe a purple ribbon with a hamburger menu, logo and two small secondary buttons
- [x] Did you test in IE 11?

## Visual Regressions

All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5587-button-as-secondary/html_report/index.html


## Relevant Screenshots/GIFs
<img width="571" alt="screen shot 2018-07-24 at 1 53 21 pm" src="https://user-images.githubusercontent.com/2271747/43159776-f34a708a-8f48-11e8-8c29-884e27c0a46b.png">

## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
