### PR TITLE
EWL-5595 create article stub as navigation variant

### DIFF
--- a/styleguide/source/_patterns/02-molecules/article-stub/article-stub.md
+++ b/styleguide/source/_patterns/02-molecules/article-stub/article-stub.md
@@ -3,16 +3,18 @@ An Article Stub (renamed from Article Preview) molecule contains a topic label (
 
 Variants are managed by use of pseudo-patterns.
 
-- "Article Stub Video" is the variant of this pattern that includes a video rather than an image.
-- "Article Stub Related" is the variant of this pattern that includes an image and title.
-- "Article Stub Related No Image" is the variant of this pattern that includes a linked title.
-- "Article Stub for Homepage" is the variant of this pattern as it appears on the homepage.
-- "Article Stub as Hero for Homepage" is the variant of this pattern that appears as the hero on the hompage.
+- ["Article Stub Video"](?p=molecules-article-stub-as-video) is the variant of this pattern that includes a video rather than an image.
+- ["Article Stub Related"](?p=molecules-article-stub-as-related) is the variant of this pattern that includes an image and title.
+- ["Article Stub Related No Image"](?p=molecules-article-stub-no-image) is the variant of this pattern that includes a linked title.
+- ["Article Stub for Homepage"](?p=molecules-article-stub-for-homepage) is the variant of this pattern as it appears on the homepage.
+- ["Article Stub as Hero for Homepage"](?p=molecules-article-stub-as-hero-for-homepage) is the variant of this pattern that appears as the hero on the hompage.
+- ["Article Stub as Navigation"](?p=molecules-article-stub-as-for-navigation) is the variant of this pattern that appears in the global nav menu.
 
 [EWL-4281](https://issues.ama-assn.org/browse/EWL-4281)
 [EWL-4432](https://issues.ama-assn.org/browse/EWL-4432)
 [EWL-5436](https://issues.ama-assn.org/browse/EWL-5436)
 [EWL-5437](https://issues.ama-assn.org/browse/EWL-5437)
+[EWL-5595](https://issues.ama-assn.org/browse/EWL-5595)
 
 ### Use Case
 This produces an Artcle teaser for use if certain fields are present. Entices a user to click on a related article which exists on a separate page.

--- a/styleguide/source/_patterns/02-molecules/article-stub/article-stub.twig
+++ b/styleguide/source/_patterns/02-molecules/article-stub/article-stub.twig
@@ -5,7 +5,8 @@
   articleStub.image ? "ama__article-stub--image",
   articleStub.video ? "ama__article-stub--video",
   articleStub.categoryPage ? "ama__article-stub--category",
-  articleStub.homepage ? "ama__article-stub--homepage"
+  articleStub.homepage ? "ama__article-stub--homepage",
+  articleStub.navigation ? "ama__article-stub--navigation"
 ] %}
 
 {% set related, link, headingLevel, paragraph, metadata = articleStub.related, articleStub.link, articleStub.headingLevel, articleStub.paragraph, articleStub.metadata %}
@@ -34,6 +35,11 @@
 
   {% if articleStub.homepage.heading %}
     {% set heading = articleStub.homepage.heading %}
+    {% include "@atoms/heading/heading.twig" %}
+  {% endif %}
+
+  {% if articleStub.navigation.heading %}
+    {% set heading = articleStub.navigation.heading %}
     {% include "@atoms/heading/heading.twig" %}
   {% endif %}
 

--- a/styleguide/source/_patterns/02-molecules/article-stub/article-stub~as-for-navigation.json
+++ b/styleguide/source/_patterns/02-molecules/article-stub/article-stub~as-for-navigation.json
@@ -1,0 +1,27 @@
+{
+  "articleStub": {
+    "link": {
+      "title": "A link to Google, for example.",
+      "href": "http://www.google.com",
+      "text": "Lorem ipsum dolor sit amet."
+    },
+    "image": {
+      "alt": "alt text",
+      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+      "height": "600",
+      "width": "800"
+    },
+    "headingLevel": "h2",
+    "video": "",
+    "related": "",
+    "small": "",
+    "paragraph": {
+      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+    },
+    "metadata": {
+      "date": "",
+      "readtime": ""
+    },
+    "navigation": true
+  }
+}

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -171,4 +171,17 @@
       }
     }
   }
+
+  &--navigation {
+    @include gutter($padding-bottom-full...);
+    background-color: $gray-7;
+
+    .ama__article-stub__title a {
+      color: $purple;
+    }
+
+    .ama__article-stub__description p {
+      @include type($myriad-pro, $font-weight-bold);
+    }
+  }
 }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5595: SG2 | Create "Article Stub as for Navigation" variant](https://issues.ama-assn.org/browse/EWL-5595)

## Description
Create article stub as for navigation

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=molecules-article-stub-as-for-navigation
- [x] observe an article stub with a gray background, image, title and decription
- [x] observe the title is purple and the description is bold
- [x] Did you test in IE 11?

## Visual Regressions
All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5594-article-stub-navigation/html_report/index.html


## Relevant Screenshots/GIFs
<img width="1125" alt="screen shot 2018-07-24 at 4 50 23 pm" src="https://user-images.githubusercontent.com/2271747/43168116-b11b7600-8f61-11e8-8149-d23804e521d0.png">


## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
