### PR TITLE
EWL-5595 highlight articles

### DIFF
--- a/styleguide/source/_patterns/02-molecules/article-stub/article-stub.md
+++ b/styleguide/source/_patterns/02-molecules/article-stub/article-stub.md
@@ -3,16 +3,18 @@ An Article Stub (renamed from Article Preview) molecule contains a topic label (
 
 Variants are managed by use of pseudo-patterns.
 
-- "Article Stub Video" is the variant of this pattern that includes a video rather than an image.
-- "Article Stub Related" is the variant of this pattern that includes an image and title.
-- "Article Stub Related No Image" is the variant of this pattern that includes a linked title.
-- "Article Stub for Homepage" is the variant of this pattern as it appears on the homepage.
-- "Article Stub as Hero for Homepage" is the variant of this pattern that appears as the hero on the hompage.
+- ["Article Stub Video"](?p=molecules-article-stub-as-video) is the variant of this pattern that includes a video rather than an image.
+- ["Article Stub Related"](?p=molecules-article-stub-as-related) is the variant of this pattern that includes an image and title.
+- ["Article Stub Related No Image"](?p=molecules-article-stub-no-image) is the variant of this pattern that includes a linked title.
+- ["Article Stub for Homepage"](?p=molecules-article-stub-for-homepage) is the variant of this pattern as it appears on the homepage.
+- ["Article Stub as Hero for Homepage"](?p=molecules-article-stub-as-hero-for-homepage) is the variant of this pattern that appears as the hero on the hompage.
+- ["Article Stub as Navigation"](?p=molecules-article-stub-as-for-navigation) is the variant of this pattern that appears in the global nav menu.
 
 [EWL-4281](https://issues.ama-assn.org/browse/EWL-4281)
 [EWL-4432](https://issues.ama-assn.org/browse/EWL-4432)
 [EWL-5436](https://issues.ama-assn.org/browse/EWL-5436)
 [EWL-5437](https://issues.ama-assn.org/browse/EWL-5437)
+[EWL-5595](https://issues.ama-assn.org/browse/EWL-5595)
 
 ### Use Case
 This produces an Artcle teaser for use if certain fields are present. Entices a user to click on a related article which exists on a separate page.

--- a/styleguide/source/_patterns/02-molecules/article-stub/article-stub.twig
+++ b/styleguide/source/_patterns/02-molecules/article-stub/article-stub.twig
@@ -5,7 +5,8 @@
   articleStub.image ? "ama__article-stub--image",
   articleStub.video ? "ama__article-stub--video",
   articleStub.categoryPage ? "ama__article-stub--category",
-  articleStub.homepage ? "ama__article-stub--homepage"
+  articleStub.homepage ? "ama__article-stub--homepage",
+  articleStub.navigation ? "ama__article-stub--navigation"
 ] %}
 
 {% set related, link, headingLevel, paragraph, metadata = articleStub.related, articleStub.link, articleStub.headingLevel, articleStub.paragraph, articleStub.metadata %}
@@ -34,6 +35,11 @@
 
   {% if articleStub.homepage.heading %}
     {% set heading = articleStub.homepage.heading %}
+    {% include "@atoms/heading/heading.twig" %}
+  {% endif %}
+
+  {% if articleStub.navigation.heading %}
+    {% set heading = articleStub.navigation.heading %}
     {% include "@atoms/heading/heading.twig" %}
   {% endif %}
 

--- a/styleguide/source/_patterns/02-molecules/article-stub/article-stub~as-for-navigation.json
+++ b/styleguide/source/_patterns/02-molecules/article-stub/article-stub~as-for-navigation.json
@@ -1,0 +1,27 @@
+{
+  "articleStub": {
+    "link": {
+      "title": "A link to Google, for example.",
+      "href": "http://www.google.com",
+      "text": "Lorem ipsum dolor sit amet."
+    },
+    "image": {
+      "alt": "alt text",
+      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+      "height": "600",
+      "width": "800"
+    },
+    "headingLevel": "h2",
+    "video": "",
+    "related": "",
+    "small": "",
+    "paragraph": {
+      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+    },
+    "metadata": {
+      "date": "",
+      "readtime": ""
+    },
+    "navigation": true
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/highlighted-articles.json
+++ b/styleguide/source/_patterns/02-molecules/highlighted-articles.json
@@ -1,0 +1,56 @@
+{
+  "highlightedArticles": {
+    "articleStubs": [
+      {
+        "link": {
+          "title": "A link to Google, for example.",
+          "href": "http://www.google.com",
+          "text": "Lorem ipsum dolor sit amet."
+        },
+        "image": {
+          "alt": "alt text",
+          "src": "http://via.placeholder.com/800x600x186?l=3:2|800x600&s=36",
+          "height": "600",
+          "width": "800"
+        },
+        "headingLevel": "h2",
+        "video": "",
+        "related": "",
+        "small": "",
+        "paragraph": {
+          "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+        },
+        "metadata": {
+          "date": "",
+          "readtime": ""
+        },
+        "navigation": true
+      },
+      {
+        "link": {
+          "title": "A link to Google, for example.",
+          "href": "http://www.google.com",
+          "text": "Lorem ipsum dolor sit amet."
+        },
+        "image": {
+          "alt": "alt text",
+          "src": "http://via.placeholder.com/800x600x186?l=3:2|800x600&s=36",
+          "height": "600",
+          "width": "800"
+        },
+        "headingLevel": "h2",
+        "video": "",
+        "related": "",
+        "small": "",
+        "paragraph": {
+          "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+        },
+        "metadata": {
+          "date": "",
+          "readtime": ""
+        },
+        "navigation": true
+      }
+    ]
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/highlighted-articles.twig
+++ b/styleguide/source/_patterns/02-molecules/highlighted-articles.twig
@@ -1,0 +1,5 @@
+<div class="ama__highlighted-articles">
+  {% for articleStub in highlightedArticles.articleStubs %}
+    {% include "@molecules/article-stub/article-stub.twig" %}
+  {% endfor %}
+</div>

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -171,4 +171,17 @@
       }
     }
   }
+
+  &--navigation {
+    @include gutter($padding-bottom-full...);
+    background-color: $gray-7;
+
+    .ama__article-stub__title a {
+      color: $purple;
+    }
+
+    .ama__article-stub__description p {
+      @include type($myriad-pro, $font-weight-bold);
+    }
+  }
 }

--- a/styleguide/source/assets/scss/02-molecules/_highlighted-articles.scss
+++ b/styleguide/source/assets/scss/02-molecules/_highlighted-articles.scss
@@ -1,0 +1,26 @@
+.ama__highlighted-articles {
+  @include gutter-all($padding-all-full...);
+  border: 1px solid $black;
+  display: none;
+  flex-direction: column;
+  background-color: $gray-7;
+  box-sizing: border-box;
+
+  @include breakpoint($bp-small) {
+    display: flex;
+    flex-direction: column;
+  }
+
+  @include breakpoint($bp-med) {
+    flex-direction: row;
+
+    .ama__article-stub {
+      @include gutter($margin-left-full...);
+      width: calc(50% - 14px);
+
+      &:first-child {
+        margin-left: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5595: Highlighed articles component
](https://issues.ama-assn.org/browse/EWL-5595)

## Description
Create Highlighed articles component  molecule

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=molecules-highlighted-articles
- [x] observe a grey box with a black border containing two article stubs in a row
- [x] resize to tablet
- [x] observe the two article stubs are stacked
- [x] resize to mobile
- [x] observe no article stubs appear
- [x] Did you test in IE 11?

## Visual Regressions
All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5595-highlight-articles/html_report/index.html

## Relevant Screenshots/GIFs
<img width="765" alt="screen shot 2018-07-25 at 10 38 47 am" src="https://user-images.githubusercontent.com/2271747/43211350-f03ed198-8ff6-11e8-8861-80144ac28028.png">
<img width="1136" alt="screen shot 2018-07-25 at 10 38 38 am" src="https://user-images.githubusercontent.com/2271747/43211351-f04babde-8ff6-11e8-928b-4402b69dfc68.png">


## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
