### PR TITLE
EWL-5597 create user dropdown menu

### DIFF
--- a/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-usermenu-outline.twig
+++ b/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-usermenu-outline.twig
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 80.7 83.8" style="enable-background:new 0 0 80.7 83.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-miterlimit:10;}
+</style>
+<g>
+	<circle class="st0" cx="40.7" cy="27.9" r="23.8"/>
+	<path class="st0" d="M40.2,51.7c-17.1,0-31.4,11.9-35.1,27.9l70.2,0C71.6,63.7,57.3,51.7,40.2,51.7z"/>
+</g>
+</svg>

--- a/styleguide/source/_patterns/02-molecules/sign-in-dropdown.json
+++ b/styleguide/source/_patterns/02-molecules/sign-in-dropdown.json
@@ -1,0 +1,92 @@
+{
+  "signInDropdown": {
+    "text": "John Smithe",
+    "menuGroups": [
+      {
+        "group": [
+          {
+            "link":
+            {
+              "title": "John Smitherson  MD",
+              "href": "#",
+              "text": "John Smitherson  MD",
+              "target": "_self",
+              "class": "ama__link ama__link--no-underline"
+            }
+          }
+        ]
+      },
+      {
+        "group": [
+          {
+            "link":
+            {
+              "title": "Join/Renew",
+              "href": "#",
+              "text": "Join/Renew",
+              "target": "_self",
+              "class": "ama__link ama__link--no-underline"
+            }
+          },
+          {
+            "link":
+            {
+              "title": "Member Benefits",
+              "href": "#",
+              "text": "Member Benefits",
+              "target": "_self",
+              "class": "ama__link ama__link--no-underline"
+            }
+          }
+        ]
+      },
+      {
+        "group": [
+          {
+            "link": {
+              "title": "AMA Account",
+              "href": "#",
+              "text": "AMA Account",
+              "target": "_self",
+              "class": "ama__link ama__link--no-underline"
+            }
+          },
+          {
+            "link":
+            {
+              "title": "Email Preferences",
+              "href": "#",
+              "text": "Email Preferences",
+              "target": "_self",
+              "class": "ama__link ama__link--no-underline"
+            }
+          },
+          {
+            "link":
+            {
+              "title": "Billing Information",
+              "href": "#",
+              "text": "Billing Information",
+              "target": "_self",
+              "class": "ama__link ama__link--no-underline"
+            }
+          }
+        ]
+      },
+      {
+        "group": [
+          {
+            "link":
+            {
+              "title": "Sign Out",
+              "href": "#",
+              "text": "Sign Out",
+              "target": "_self",
+              "class": "ama__link ama__link--no-underline"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/sign-in-dropdown.md
+++ b/styleguide/source/_patterns/02-molecules/sign-in-dropdown.md
@@ -1,0 +1,15 @@
+### Description
+User dropdown menu with links to user specific pages
+
+[EWL-5597](https://issues.ama-assn.org/browse/EWL-5597)
+
+### Use Case
+
+
+### Variables
+~~~
+  {
+    "userDropdown": {
+    }
+  }
+~~~

--- a/styleguide/source/_patterns/02-molecules/sign-in-dropdown.twig
+++ b/styleguide/source/_patterns/02-molecules/sign-in-dropdown.twig
@@ -1,0 +1,17 @@
+<div id="ama__sign-in-dropdown" class="ama__sign-in-dropdown">
+  <i class="icon--usermenu ama__sign-in-dropdown__user-icon"></i>
+  <span class="ama__sign-in-dropdown__text">{{ signInDropdown.text }}</span>
+  <i class="ama__sign-in-dropdown__caret"></i>
+  <div class="ama__sign-in-dropdown__menu">
+    {% for menuGroups in signInDropdown.menuGroups %}
+      <ul class="ama__sign-in-dropdown__menu__group">
+        {% for item in menuGroups.group %}
+          {% set link = item.link %}
+          <li>
+            {% include "@atoms/link/link.twig" %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
+  </div>
+</div>

--- a/styleguide/source/_patterns/02-molecules/sign-in-dropdown.twig
+++ b/styleguide/source/_patterns/02-molecules/sign-in-dropdown.twig
@@ -1,5 +1,5 @@
 <div id="ama__sign-in-dropdown" class="ama__sign-in-dropdown">
-  <i class="icon--usermenu ama__sign-in-dropdown__user-icon"></i>
+  <i class="icon--usermenu-outline ama__sign-in-dropdown__user-icon"></i>
   <span class="ama__sign-in-dropdown__text">{{ signInDropdown.text }}</span>
   <i class="ama__sign-in-dropdown__caret"></i>
   <div class="ama__sign-in-dropdown__menu">

--- a/styleguide/source/_patterns/03-organisms/main-navigation.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.json
@@ -29,6 +29,14 @@
       "style": "secondary",
       "size": "small"
     },
+    "joinRenewLink":
+    {
+      "title": "Join / Renew",
+      "href": "#",
+      "text": "Join / Renew",
+      "target": "_self",
+      "class": "ama__link ama__link--white ama__link--no-underline"
+    },
     "signInDropdown": {
       "text": "John Smithe",
       "menuGroups": [

--- a/styleguide/source/_patterns/03-organisms/main-navigation.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.json
@@ -28,6 +28,96 @@
       "type": "button",
       "style": "secondary",
       "size": "small"
+    },
+    "signInDropdown": {
+      "text": "John Smithe",
+      "menuGroups": [
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "John Smitherson  MD",
+                "href": "#",
+                "text": "John Smitherson  MD",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "Join/Renew",
+                "href": "#",
+                "text": "Join/Renew",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Member Benefits",
+                "href": "#",
+                "text": "Member Benefits",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link": {
+                "title": "AMA Account",
+                "href": "#",
+                "text": "AMA Account",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Email Preferences",
+                "href": "#",
+                "text": "Email Preferences",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Billing Information",
+                "href": "#",
+                "text": "Billing Information",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "Sign Out",
+                "href": "#",
+                "text": "Sign Out",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -6,5 +6,6 @@
       {% include '@atoms/button/button.twig' with { button : mainNavigation.joinButton } %}
       {% include '@atoms/button/button.twig' with { button : mainNavigation.renewButton } %}
     </div>
+    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -2,11 +2,14 @@
   <div class="container">
     {% include '@atoms/menu-icon.twig' with { menuIcon : mainNavigation.menuIcon } %}
     {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : mainNavigation.siteLogo } %}
-    <div class="ama__main-navigation__button-container">
+    <div class="ama__main-navigation__join--buttons">
       {% include '@atoms/button/button.twig' with { button : mainNavigation.joinButton } %}
       {% include '@atoms/button/button.twig' with { button : mainNavigation.renewButton } %}
     </div>
-    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
+    <div class="ama__main-navigation__join--links">
+      {% include '@atoms/link/link.twig' with { link : mainNavigation.joinRenewLink } %}
+    </div>
     {% include '@molecules/global-search.twig' with { globalSearch : mainNavigation.globalSearch } %}
+    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
   </div>
 </div>

--- a/styleguide/source/assets/icons/svg/icon-usermenu-outline.svg
+++ b/styleguide/source/assets/icons/svg/icon-usermenu-outline.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 80.7 83.8" style="enable-background:new 0 0 80.7 83.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-miterlimit:10;}
+</style>
+<g>
+	<circle class="st0" cx="40.7" cy="27.9" r="23.8"/>
+	<path class="st0" d="M40.2,51.7c-17.1,0-31.4,11.9-35.1,27.9l70.2,0C71.6,63.7,57.3,51.7,40.2,51.7z"/>
+</g>
+</svg>

--- a/styleguide/source/assets/js/global-search.js
+++ b/styleguide/source/assets/js/global-search.js
@@ -1,0 +1,37 @@
+(function ($, Drupal) {
+  Drupal.behaviors.ama_search = {
+    attach: function (context, settings) {
+      var searchInput = $('.ama__global-search .ama__search__field--in-body input');
+      var mobileSearch = $('.ama__global-search--mobile');
+
+      function switchSearch() {
+        if (searchInput.css('display') === 'none' && mobileSearch.css('display') === 'none') {
+          mobileSearch.fadeIn();
+        }
+        else if (searchInput.css('display') === 'block') {
+          $(this).submit();
+        }
+        else {
+          mobileSearch.fadeOut();
+        }
+      }
+
+      $('.ama__search__field__button').click(function () {
+        switchSearch();
+      });
+
+      $( window ).resize(function() {
+        mobileSearch.hide();
+      });
+
+      $('#ama__sign-in-dropdown').click(function () {
+        var userMenu = $('.ama__sign-in-dropdown__menu');
+        if(userMenu.css('display') === 'none') {
+          $(userMenu).slideDown();
+        } else {
+          $(userMenu).slideUp();
+        }
+      });
+    }
+  };
+})(jQuery, Drupal);

--- a/styleguide/source/assets/scss/01-atoms/_icons.scss
+++ b/styleguide/source/assets/scss/01-atoms/_icons.scss
@@ -41,6 +41,7 @@ $icons: (
     show,
     triangle,
     usermenu,
+    usermenu-outline,
     valid,
     video,
     viewless,

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -30,7 +30,7 @@
   }
 
   &--in-body {
-    @include breakpoint($bp-small) {
+    @include breakpoint($bp-large) {
       width: 75%;
     }
 

--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -26,14 +26,15 @@
       }
     }
     .ama__search__field__button {
-      border-left: 1px solid $gray-50 ;
-      border-right: 1px solid $gray-50 ;
-      height: 45px;
-      width: 45px;
+      border-left: 1px solid $gray-50;
+      height: 70px;
+      width: 70px;
       outline: none;
 
       @include breakpoint($bp-small) {
         border: 2px solid $white;
+        height: 45px;
+        width: 45px;
       }
 
       svg {

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -2,31 +2,39 @@
   position: relative;
   background-color: $purple;
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
   color: $white;
   height: 70px;
-  width: 40px;
+  width: 70px;
   align-items: center;
   border-left: 1px solid $gray-50;
 
   @include breakpoint($bp-small) {
+    justify-content: flex-end;
+    border-left: 0;
+  }
+
+  @include breakpoint($bp-med) {
     width: 200px;
     border-left: 0;
   }
 
   &__user-icon {
-    @include gutter($margin-left-half...);
     background-size: 24px 25px;
     min-height: 24px;
     min-width: 25px;
     max-height: 24px;
     max-width: 25px;
+
+    @include breakpoint($bp-small) {
+      @include gutter($margin-left-half...);
+    }
   }
 
   &__text {
     display: none;
 
-    @include breakpoint($bp-small) {
+    @include breakpoint($bp-large) {
       @include gutter($margin-left-half...);
       display: flex;
       flex-grow: 1;

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -1,0 +1,81 @@
+.ama__sign-in-dropdown {
+  position: relative;
+  background-color: $purple;
+  display: flex;
+  justify-content: flex-end;
+  color: $white;
+  height: 70px;
+  min-width: 40px;
+  align-items: center;
+  border-left: 1px solid $gray-50;
+
+  @include breakpoint($bp-small) {
+    border-left: 0;
+    min-width: 200px;
+  }
+
+  &__user-icon {
+    @include gutter($margin-left-half...);
+    background-size: 24px 25px;
+    min-height: 24px;
+    min-width: 25px;
+    max-height: 24px;
+    max-width: 25px;
+  }
+
+  &__text {
+    display: none;
+
+    @include breakpoint($bp-small) {
+      @include gutter($margin-left-half...);
+      display: flex;
+      flex-grow: 1;
+    }
+  }
+
+  &__caret {
+    display: none;
+
+    @include breakpoint($bp-small) {
+      @include gutter($margin-left-half...);
+      display: block;
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 10px solid $white;
+    }
+  }
+
+  &__menu {
+    @include gutter($padding-left-half...);
+    @include gutter($padding-right-half...);
+    position: absolute;
+    top: 70px;
+    right: 0;
+    box-shadow: 0 2px 3px 2px rgba(0, 0, 0, 0.4);
+    background-color: $white;
+    color: $black;
+    text-align: right;
+    display: none;
+    min-width: 200px;
+
+    li {
+      list-style: none;
+
+      a {
+        display: block;
+      }
+    }
+
+    &__group {
+      @include gutter($padding-top-half...);
+      @include gutter($padding-bottom-half...);
+      border-bottom: 1px solid $gray-50;
+
+      &:last-child {
+        border-bottom: 0;
+      }
+    }
+  }
+}

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -5,13 +5,13 @@
   justify-content: flex-end;
   color: $white;
   height: 70px;
-  min-width: 40px;
+  width: 40px;
   align-items: center;
   border-left: 1px solid $gray-50;
 
   @include breakpoint($bp-small) {
     border-left: 0;
-    min-width: 200px;
+    width: auto;
   }
 
   &__user-icon {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card-row.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card-row.scss
@@ -1,4 +1,5 @@
-.ama__hub-row {
+.ama__hub-row,
+.ama__hub-row > .layout__region--main {
   display: flex;
   flex-wrap: wrap;
 }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -16,9 +16,11 @@
 
   &__description {
     @include gutter-all($padding-all-full...);
+    max-width: none;
+    width: auto;
   }
 
-  > img {
+  .ama__image {
     width: 100%;
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -34,4 +34,9 @@
       text-align: left;
     }
   }
+
+  .ama__sign-in-dropdown {
+    background-color: transparent;
+    align-self: flex-end;
+  }
 }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -45,11 +45,15 @@
   }
 
   &__join--links {
-    @include gutter($margin-left-full...);
-    @include gutter($margin-right-full...);
-    display: flex;
-    line-height: 1em;
-    width: 65px;
+    display: none;
+
+    @include breakpoint($bp-small min-width) {
+      @include gutter($margin-left-full...);
+      @include gutter($margin-right-full...);
+      display: flex;
+      line-height: 1em;
+      width: 65px;
+    }
 
     @include breakpoint($bp-large min-width) {
       display: none;

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -2,13 +2,18 @@
   background-color: $purple;
   color: $white;
 
-  @include breakpoint($bp-small min-width) {
+  @include breakpoint($bp-med min-width) {
     padding: $gutter/4 0;
   }
 
   .container {
     display: flex;
     align-items: center;
+    padding-right: 0;
+
+    @include breakpoint($bp-small min-width) {
+      @include gutter($padding-right-half...);
+    }
   }
 
 
@@ -17,26 +22,37 @@
   }
 
   .ama__site-logo {
-    flex-grow: 1;
     align-items: flex-start;
     text-align: center;
+    min-width: 125px;
+    flex-grow: 1;
+
+    @include breakpoint($bp-med min-width) {
+      flex-grow: 0;
+      align-items: center;
+      text-align: left;
+    }
   }
 
-  &__button-container {
+  &__join--buttons {
     @include gutter($margin-left-full...);
     @include gutter($margin-right-full...);
     display: none;
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-large min-width) {
       display: block;
     }
   }
 
-  @include breakpoint($bp-med min-width) {
-    .ama__site-logo {
-      flex-grow: 0;
-      align-items: center;
-      text-align: left;
+  &__join--links {
+    @include gutter($margin-left-full...);
+    @include gutter($margin-right-full...);
+    display: flex;
+    line-height: 1em;
+    width: 65px;
+
+    @include breakpoint($bp-large min-width) {
+      display: none;
     }
   }
 


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5597: create user dropdown menu ](https://issues.ama-assn.org/browse/EWL-5597)

## Description
Create user dropdown menu for global nav

## To Test
- [x] `gulp  serve`
- [x] visit http://localhost:3000/?p=molecules-sign-in-dropdown
- [x] observe a purple banner with a user icon as outline, name and drop down caret all in white
- [x] click on the banner
- [x] observe a white menu slide out below the purple banner
- [x] observe the menu has links in groups separated by a gray line
- [x] resize your browser to mobile size
- [x] observe the name is hidden in the purple banner along with the caret
- [x] observe a grey line appear on the left of the user icon
- [x] visit http://localhost:3000/?p=organisms-main-navigation
- [x] observe the user dropdown in the global nav
- [x] do the same testing as above
- [ ] Did you test in IE 11?

## Visual Regressions
All testing is done by Travis
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5597-user-dropdown/html_report/index.html


## Relevant Screenshots/GIFs
<img width="511" alt="screen shot 2018-07-25 at 2 26 04 pm" src="https://user-images.githubusercontent.com/2271747/43222757-afa037b0-9016-11e8-947d-5ca6e3a4a51c.png">
<img width="688" alt="screen shot 2018-07-25 at 2 25 51 pm" src="https://user-images.githubusercontent.com/2271747/43222758-afb01c8e-9016-11e8-9a14-57913b90ec2d.png">


## Remaining Tasks
N/A


## Additional Notes
The user icon is the solid version. I'm still waiting for the outline variant of the user menu icon from UX. 
This should not affected testing in any way. I will switch the icon at a later date when I receive the icon from UX.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
