### PR TITLE
EWL-5662 Fixes paths for jama logos

### DIFF
--- a/styleguide/source/_patterns/02-molecules/jama/jama.json
+++ b/styleguide/source/_patterns/02-molecules/jama/jama.json
@@ -1,5 +1,11 @@
 {
   "jama": {
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo-jama.svg",
+      "href": "#",
+      "imageClass": "logo",
+      "alt": "American Medical Association"
+    },
     "links": [
       {
         "subtitle": "JAMA Surgery",

--- a/styleguide/source/_patterns/02-molecules/jama/jama.twig
+++ b/styleguide/source/_patterns/02-molecules/jama/jama.twig
@@ -1,7 +1,8 @@
 {% set homepage = jama.homepage ? "ama__jama--homepage" %}
 
 <div class="ama__jama {{ homepage }}">
-  {% include "@atoms/site-logo/site-logo-as-jama.twig" %}
+  {% set siteLogo = jama.siteLogo %}
+  {% include "@atoms/site-logo/site-logo.twig" %}
   <span class="ama__jama__title">
     {% if jama.title.icon is not empty %}
       <icon class="ama__icon {{ jama.title.icon }}"></icon>

--- a/styleguide/source/_patterns/02-molecules/jama/jama~as-content-bottom.json
+++ b/styleguide/source/_patterns/02-molecules/jama/jama~as-content-bottom.json
@@ -1,5 +1,11 @@
 {
   "jama": {
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo-jama.svg",
+      "href": "#",
+      "imageClass": "logo",
+      "alt": "American Medical Association"
+    },
     "links": [
       {
         "subtitle": "JAMA Surgery",

--- a/styleguide/source/_patterns/02-molecules/jama/jama~as-homepage.json
+++ b/styleguide/source/_patterns/02-molecules/jama/jama~as-homepage.json
@@ -1,6 +1,12 @@
 {
   "jama": {
     "homepage": true,
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo-jama.svg",
+      "href": "#",
+      "imageClass": "logo",
+      "alt": "American Medical Association"
+    },
     "links": [
       {
         "href": "https://www.google.com",

--- a/styleguide/source/_patterns/02-molecules/jama/jama~as-three-up.json
+++ b/styleguide/source/_patterns/02-molecules/jama/jama~as-three-up.json
@@ -1,5 +1,11 @@
 {
   "jama": {
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo-jama.svg",
+      "href": "#",
+      "imageClass": "logo",
+      "alt": "American Medical Association"
+    },
     "links": [
       {
         "href": "https://www.google.com",

--- a/styleguide/source/_patterns/05-pages/category.json
+++ b/styleguide/source/_patterns/05-pages/category.json
@@ -162,6 +162,12 @@
       ]
     },
     "jamaAsContentBottom": {
+      "siteLogo": {
+        "src": "../../assets/images/brand/logo-jama.svg",
+        "href": "#",
+        "imageClass": "logo",
+        "alt": "American Medical Association"
+      },
       "links": [
         {
           "subtitle": "JAMA Surgery",
@@ -691,6 +697,12 @@
       "title": {
         "text": "Podcasts",
         "icon": "icon--podcast-black"
+      },
+      "siteLogo": {
+        "src": "../../assets/images/brand/logo-jama.svg",
+        "href": "#",
+        "imageClass": "logo",
+        "alt": "American Medical Association"
       },
       "links": [
         {

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -423,6 +423,12 @@
     },
     "jama": {
       "homepage": true,
+      "siteLogo": {
+        "src": "../../assets/images/brand/logo-jama.svg",
+        "href": "#",
+        "imageClass": "logo",
+        "alt": "American Medical Association"
+      },
       "links": [
         {
           "subtitle": "JAMA Surgery",

--- a/styleguide/source/_patterns/05-pages/news/news-with-jama-examples.json
+++ b/styleguide/source/_patterns/05-pages/news/news-with-jama-examples.json
@@ -220,6 +220,12 @@
       "text": "Podcasts",
       "icon": "icon--podcast-black"
     },
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo-jama.svg",
+      "href": "#",
+      "imageClass": "logo",
+      "alt": "American Medical Association"
+    },
     "links": [
       {
         "subtitle": "JAMA Surgery",
@@ -264,6 +270,12 @@
     ]
   },
   "jamaAsContentBottom": {
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo-jama.svg",
+      "href": "#",
+      "imageClass": "logo",
+      "alt": "American Medical Association"
+    },
     "links": [
       {
         "subtitle": "JAMA Surgery",
@@ -305,6 +317,12 @@
     ]
   },
   "jamaAsThreeUp": {
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo-jama.svg",
+      "href": "#",
+      "imageClass": "logo",
+      "alt": "American Medical Association"
+    },
     "links": [
       {
         "subtitle": "JAMA Surgery",


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5662: Fix JAMA logo paths](https://issues.ama-assn.org/browse/EWL-5662)

## Description
JAMA logos are broken in styleguide.


## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=pages-homepage
- [x] confirm the JAMA logo appears
- [x] visit http://localhost:3000/?p=viewall-molecules-jama
- [x] confirm the all JAMA logo appears
- [x] visit http://localhost:3000/?p=pages-category
- [x] confirm the all JAMA logo appears
- [x] visit http://localhost:3000/?p=pages-news-with-jama-examples
- [x] confirm the all JAMA logo appears
- [x] Did you test in IE 11?

## Visual Regressions

This fixes a visual regression

## Relevant Screenshots/GIFs
<img width="1546" alt="screen shot 2018-07-27 at 10 30 56 am" src="https://user-images.githubusercontent.com/2271747/43330213-2bc0976e-9188-11e8-877a-875f6d4f7142.png">


## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
