### PR TITLE
EWL-5664 Fix Article four up teasers margins on various screen sizes

### DIFF
--- a/styleguide/source/_patterns/03-organisms/category-index.json
+++ b/styleguide/source/_patterns/03-organisms/category-index.json
@@ -80,7 +80,7 @@
           "info": "alt",
           "text": "Lorem ipsum",
           "type": "button",
-          "style": "primary",
+          "style": "promo",
           "size": ""
         }
       },

--- a/styleguide/source/_patterns/03-organisms/subcategory-index.json
+++ b/styleguide/source/_patterns/03-organisms/subcategory-index.json
@@ -190,7 +190,7 @@
           "info": "alt",
           "text": "Lorem ipsum",
           "type": "button",
-          "style": "primary",
+          "style": "promo",
           "size": ""
         }
       },

--- a/styleguide/source/_patterns/05-pages/subcategory.json
+++ b/styleguide/source/_patterns/05-pages/subcategory.json
@@ -378,7 +378,7 @@
             "info": "alt",
             "text": "Lorem ipsum",
             "type": "button",
-            "style": "primary",
+            "style": "promo",
             "size": ""
           }
         },

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -20,12 +20,11 @@
   &__copy {
     @include gutter($padding-left-full...);
     @include gutter($padding-right-full...);
+    flex-grow: 1;
 
     @include breakpoint($bp-med min-width) {
       padding: 0;
     }
-
-    flex-grow: 1;
   }
 
   .ama__image,
@@ -36,16 +35,15 @@
   &--related {
     @include ama-rules(1px, '', solid, $gray-50);
     @include gutter($padding-top-half...);
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    align-items: center;
 
     &:last-child {
       @include ama-rules(1px, 'bottom', solid, $gray-50);
       @include gutter($padding-bottom-half...);
     }
-
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
-    align-items: center;
 
     .ama__image,
     .ama__video {

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -9,13 +9,12 @@
 
   &__title {
     padding: 0;
+    width: 100%;
 
     @include breakpoint($bp-med min-width) {
       @include gutter($padding-left-full...);
       @include gutter($padding-right-full...);
     }
-
-    width: 100%;
   }
 
   &__copy {

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -8,11 +8,11 @@
   }
 
   &__title {
-    @include gutter($padding-left-full...);
-    @include gutter($padding-right-full...);
+    padding: 0;
 
     @include breakpoint($bp-med min-width) {
-      padding: 0;
+      @include gutter($padding-left-full...);
+      @include gutter($padding-right-full...);
     }
 
     width: 100%;

--- a/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
@@ -15,20 +15,19 @@
 
   .ama__article-stub {
     @include gutter($margin-bottom-full...);
-    @include gutter($padding-left-quarter...);
     flex-grow: 1;
     flex-basis: 0;
-
-    &:first-child {
-      padding: 0;
-    }
-
+    
     &__copy > h2 {
       @extend %ama__type--small;
     }
 
     @include breakpoint($bp-small) {
       @include gutter($padding-left-half...);
+
+      &:first-child {
+        padding: 0;
+      }
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
@@ -15,28 +15,20 @@
 
   .ama__article-stub {
     @include gutter($margin-bottom-full...);
+    @include gutter($padding-left-quarter...);
     flex-grow: 1;
     flex-basis: 0;
 
-    @include breakpoint($bp-small $bp-med) {
-      &:nth-of-type(even) {
-        @include gutter($padding-left-quarter...);
-      }
-
-      &:nth-of-type(odd) {
-        @include gutter($padding-right-quarter...);
-      }
+    &:first-child {
+      padding: 0;
     }
 
     &__copy > h2 {
       @extend %ama__type--small;
     }
 
-    @include breakpoint($bp-med) {
-      @include gutter($padding-right-half...);
-      &:last-child {
-        padding: 0;
-      }
+    @include breakpoint($bp-small) {
+      @include gutter($padding-left-half...);
     }
   }
 }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5664: A1 | Style Guide Article Stub four up margins](https://issues.ama-assn.org/browse/EWL-5664)

## Description
The article stub four up teasers margins zeroed out on mobile screen sizes causing them to run into each other.

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=organisms-four-up-teaser
- [x] resize your browser to mobile and tablet
- [x] observe the article teasers don't run into each other 
- [x] visit http://localhost:3000/?p=pages-people-bio
- [x] scroll to bottom of the page
- [x] resize your brower and observe the article four up teasers don't run into each at various screen sizes
- [x] Did you test in IE 11?

## Visual Regressions

Fixes a visual regression

## Relevant Screenshots/GIFs
<img width="1223" alt="screen shot 2018-07-27 at 11 19 48 am" src="https://user-images.githubusercontent.com/2271747/43332849-fd87cf3c-918e-11e8-966f-fa4918ddb247.png">


## Remaining Tasks
N/A


## Additional Notes
I also noticed that the promo buttons on the category and subcategory pages were the wrong color. I felt the change was too small to warrant a ticket specifically to change the button to orange. I decided to include the change in this PR. Please double check that the buttons are orange on these pages: http://localhost:3000/?p=pages-category
http://localhost:3000/?p=pages-subcategory

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
