### PR TITLE
hotfix: product nav should be 20/20

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -88,11 +88,10 @@
   }
 
   &__menu-products {
+    @include font-size($footer-font-sizes--menu);
     @include gutter($padding-bottom-half...);
     text-transform: uppercase;
     text-align: center;
-    font-size: 1.111em;
-    line-height: 1em;
 
     li {
       display: inline-block;
@@ -100,6 +99,11 @@
       &:not(:last-child):after {
         content: " | ";
       }
+    }
+
+    @include breakpoint($bp-large) {
+      font-size: 1.111em;
+      line-height: 1em;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -88,10 +88,11 @@
   }
 
   &__menu-products {
-    @include font-size($footer-font-sizes--menu);
     @include gutter($padding-bottom-half...);
     text-transform: uppercase;
     text-align: center;
+    font-size: 1.111em;
+    line-height: 1em;
 
     li {
       display: inline-block;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
None, live life on the edge.

## Description
Update the product nav to be 20/20. 


## To Test
- [ ] `gulp serve`
- [ ] Navigate to a footer
- [ ] Inspect the product nav (JAMA, etc)
- [ ] Observe they are 20px at desktop
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/hotfix/footer-product-nav-size/html_report/index.html).


## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
