### PR TITLE
[Hotfix] Add jQueryUI Accordion Library to D8

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -40,7 +40,8 @@
       "source/assets/js/nav.js",
       "source/assets/js/subcategory.js",
       "source/assets/js/wayfinder.js",
-      "source/assets/js/tabs.js"
+      "source/assets/js/tabs.js",
+      "source/assets/js/vendor/jquery-ui.accordion.multiple.js"
     ],
     "dest"  : "public/assets/js/"
   },

--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -41,7 +41,8 @@
       "source/assets/js/subcategory.js",
       "source/assets/js/wayfinder.js",
       "source/assets/js/tabs.js",
-      "source/assets/js/vendor/jquery-ui.accordion.multiple.js"
+      "source/assets/js/accordion.js"
+
     ],
     "dest"  : "public/assets/js/"
   },


### PR DESCRIPTION
## Description
The accordion library was not added to the list of js files for Drupal to import. This work adds that file to the list in our build config.


## To Test
- Pull `hotfix/add-jqueryui-accordion-library-d8` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Open a local version of AMA One with assets pointed to local versions
-- Edit your local `provisioning/vars/local.yml` to use your local SG2 files
-- Run `vagrant up` and then `scripts/build` to update symlinks to css and js files.
- Go to any interior front facing page and confirm that `accordion.js` is loading via chrome inspector dev tools.

### Is needed for [PR #623 EWL-5250 Event Detail - Event Tab Theming](https://github.com/AmericanMedicalAssociation/ama-d8/pull/623)

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/hotfix/add-jqueryui-accordion-library-d8/html_report/index.html).


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
