### PR TITLE
Adjust hub cards and hub heroes to work in D8

### DIFF
--- a/styleguide/source/_patterns/02-molecules/hub/hub-card.twig
+++ b/styleguide/source/_patterns/02-molecules/hub/hub-card.twig
@@ -6,7 +6,7 @@
 
 <a class="ama__hub-card {{ hubCard.layout }}" href="#" style="{{ background }}">
   {% if hubCard.image.src is not empty %}
-    {% include "@atoms/image/image.twig" %}
+    {% include "@atoms/image/image.twig" with { 'class': 'ama__hub-card__image' } %}
   {% endif %}
   <div class="ama__hub-card__description">
     {% include "@atoms/heading/heading.twig" %}

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card-row.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card-row.scss
@@ -2,4 +2,5 @@
 .ama__hub-row > .layout__region--main {
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
 }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -37,10 +37,7 @@
     flex-basis: 100%;
     align-items: center;
     margin: 0;
-
-    @include breakpoint($bp-small) {
-      flex-basis: 50%;
-    }
+    width: 100%;
 
     .ama__image {
       width: 100%;

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -8,12 +8,11 @@
   text-decoration: none;
   min-height: 400px;
   width: 100%;
-
+  
   &__heading,
   & .ama__h2 {
     @include gutter($margin-top-full...);
-    @include gutter($margin-bottom-half...);
-    margin: 0;
+    margin-bottom: 0;
   }
 
   &__description {
@@ -37,7 +36,7 @@
     flex-basis: 100%;
     align-items: center;
     margin: 0;
-    width: 100%;
+
 
     .ama__image {
       width: 100%;

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -9,23 +9,54 @@
   min-height: 400px;
   width: 100%;
 
-  &__heading {
-    @include gutter-all($padding-all-full...);
+  &__heading,
+  & .ama__h2 {
+    @include gutter($margin-top-full...);
+    @include gutter($margin-bottom-half...);
     margin: 0;
   }
 
   &__description {
     @include gutter-all($padding-all-full...);
+    margin: 0;
     max-width: none;
     width: auto;
   }
 
-  .ama__image {
-    width: 100%;
+  &__button-container {
+    @include gutter-all($padding-all-full...);
+    text-align: center;
+
+    a {
+      @extend %ama__button;
+    }
   }
 
-  &:hover {
-    background-color: darken($gray-7, 10%);
+  &__image {
+    display: flex;
+    flex-basis: 100%;
+    align-items: center;
+    margin: 0;
+
+    @include breakpoint($bp-small) {
+      flex-basis: 50%;
+    }
+
+    .ama__image {
+      width: 100%;
+    }
+
+    & > * {
+      display: flex;
+      width: 100%;
+      padding: 0;
+    }
+  }
+
+  @at-root {
+    a:hover#{&} {
+      background-color: darken($gray-7, 10%);
+    }
   }
 
   &--no-image {
@@ -44,9 +75,54 @@
   &--portrait {
     background-size: cover;
     background-position: center top;
+    background-repeat: no-repeat;
+
+    .ama__image {
+      display: none;
+    }
 
     .ama__hub-card__description {
       margin-top: auto;
+    }
+  }
+
+  &--fifty-fifty {
+    flex-direction: column;
+    justify-content: flex-end;
+
+    @include breakpoint($bp-small) {
+      flex-direction: row;
+    }
+
+    .ama__hub-hero__button-container {
+      text-align: left;
+    }
+
+    .ama__hub-card__image,
+    .ama__image {
+      flex-basis: 100%;
+    }
+
+    .ama__hub-card__description {
+      background-color: rgba($white, 0.45);
+      width: 100%;
+      justify-content: center;
+      display: flex;
+      flex-direction: column;
+      text-align: left;
+
+      @include breakpoint($bp-small) {
+        width: 50%;
+      }
+    }
+  }
+
+  &--fifty-fifty-left {
+    @extend .ama__hub-card--fifty-fifty;
+    flex-direction: column;
+
+    @include breakpoint($bp-small) {
+      flex-direction: row-reverse;
     }
   }
 
@@ -106,6 +182,8 @@
   }
 
   @include breakpoint($bp-med) {
+    width: 100%;
+
     // 2-up layout
     // when there are three items it's 50:50
     &:nth-child(1):nth-last-child(2) {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -13,8 +13,8 @@
     background-size: cover;
   }
 
-  &__heading {
-    @include gutter($padding-left-full...);
+  &__heading,
+  & .ama__h2 {
     @include gutter($padding-top-full...);
 
     &h1,
@@ -23,7 +23,8 @@
     }
   }
 
-  &__copy {
+  &__copy,
+  &__text {
     @include gutter-all($padding-all-full...);
   }
 
@@ -42,12 +43,18 @@
     display: flex;
     flex-basis: 100%;
     align-items: center;
+    padding: 0;
 
     @include breakpoint($bp-small) {
       flex-basis: 50%;
     }
 
     .ama__image {
+      display: flex;
+      width: 100%;
+    }
+
+    & > * {
       width: 100%;
     }
   }
@@ -67,14 +74,20 @@
   }
 
   &__description {
+    @include gutter-all($padding-all-full...);
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    margin: 0;
   }
 
   &__button-container {
     @include gutter-all($padding-all-full...);
     text-align: center;
+
+    a {
+      @extend %ama__button;
+    }
   }
 
   &--cta-only {
@@ -129,13 +142,21 @@
         width: 50%;
       }
     }
+
+    .ama__hub-hero__button-container {
+      text-align: left;
+      padding-left: 0;
+    }
   }
 
+  &--split-no-overlay,
   &--split-no-overlay {
     align-items: stretch;
 
-    .ama__hub-hero__description {
+    .ama__hub-hero__description,
+    .ama__hub-hero__description > div {
       flex: 1;
+      width: 100%;
     }
 
     .ama__hub-hero__copy {
@@ -157,7 +178,9 @@
     @extend .ama__hub-hero--split-no-overlay;
 
     .ama__hub-hero__heading,
-    .ama__hub-hero__copy {
+    .ama__h2,
+    .ama__hub-hero__copy,
+    p {
       @include gutter-all($padding-all-full...);
       background-color: rgba(255, 255, 255, 0.45);
     }
@@ -171,7 +194,8 @@
       flex-direction: row;
     }
 
-    .ama__hub-hero__description {
+    .ama__hub-hero__description,
+    article {
       background-color: rgba($white, 0.45);
       width: 100%;
       justify-content: center;

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -15,8 +15,6 @@
 
   &__heading,
   & .ama__h2 {
-    @include gutter($padding-top-full...);
-
     &h1,
     &h2 {
       margin-bottom: 0;
@@ -144,7 +142,6 @@
     }
 
     .ama__hub-hero__button-container {
-      text-align: left;
       padding-left: 0;
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -15,8 +15,9 @@
 
   &__heading,
   & .ama__h2 {
-    &h1,
-    &h2 {
+    h1,
+    h2 {
+      @include gutter($padding-top-half...);
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5604: Create hub hero](https://issues.ama-assn.org/browse/EWL-5604)

## Description
Adjust hub card and hub hero css to work with D8 

## To Test
- [x] `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-hub
- [ ] the hub cards pretty much look the same as the ones in https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-hub
- [ ] the exception is that the padding around the headers and line height might have changed slightly
- [ ] Did you test in IE 11?

## Visual Regressions
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5604-hub-hero/html_report/index.html


## Relevant Screenshots/GIFs
<img width="1141" alt="screen shot 2018-08-07 at 4 45 00 pm" src="https://user-images.githubusercontent.com/2271747/43804330-3f9c08fe-9a61-11e8-805c-9d58bca7a22e.png">


## Remaining Tasks
N/A


## Additional Notes
The D8 side of this story is in PR [#629](https://github.com/AmericanMedicalAssociation/ama-d8/pull/629)


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
