### PR TITLE
EWL-5589 Updates main navigation based on feedback from UX

### DIFF
--- a/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
+++ b/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
@@ -14,7 +14,6 @@
           {% if link.subMenu %}
             <ul class="ama_category_navigation_menu__flyout">
               <li class="ama_category_navigation_menu__flyout__container">
-                <i class="ama_category_navigation_menu__flyout__caret"></i>
                 <div class="ama_category_navigation_menu__submenu">
                   <ol>
                     {% for subMenuItem in link.subMenu %}

--- a/styleguide/source/_patterns/03-organisms/main-navigation.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.json
@@ -1,5 +1,6 @@
 {
   "mainNavigation": {
+    "loggedIn": true,
     "siteLogo": {
       "src": "../../assets/images/brand/logo.svg",
       "href": "#",
@@ -18,7 +19,7 @@
       "info": "alt",
       "text": "Join",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "renewButton": {
@@ -26,7 +27,7 @@
       "info": "alt",
       "text": "Renew",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "joinRenewLink":
@@ -36,6 +37,13 @@
       "text": "Join / Renew",
       "target": "_self",
       "class": "ama__link ama__link--white ama__link--no-underline"
+    },
+    "memberBenefitsLink": {
+      "title": "Member Benefits",
+      "href": "#",
+      "text": "Member Benefits",
+      "target": "_self",
+      "class": "ama__link ama__link--white"
     },
     "signInDropdown": {
       "text": "John Smithe",
@@ -889,6 +897,15 @@
                 "title": "FREIDA",
                 "href": "#",
                 "text": "FREIDA",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Education Center",
+                "href": "#",
+                "text": "Education Center",
                 "target": "_self",
                 "class": "ama__link ama__link--no-underline ama__link--white"
               }

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -1,7 +1,7 @@
-{% set loggedIn = mainNavigation.loggedIn ? "ama__main-navigation--loggedIn" %}
-<div class="ama__main-navigation {{ loggedIn }}">
+{% set universal = mainNavigation.universal ? "ama__main-navigation--universal" %}
+<div class="ama__main-navigation {{ universal }}">
   <div class="container">
-    {% if mainNavigation.loggedIn %}
+    {% if mainNavigation.universal %}
       {% include '@molecules/explore-menu.twig' with { exploreMenu : mainNavigation.exploreMenu } %}
     {% else %}
       {% include '@atoms/menu-icon.twig' with { menuIcon : mainNavigation.menuIcon } %}
@@ -13,7 +13,7 @@
     <div class="ama__main-navigation__join--buttons">
       {% include '@atoms/button/button.twig' with { button : mainNavigation.joinButton } %}
       {% include '@atoms/button/button.twig' with { button : mainNavigation.renewButton } %}
-      {% if mainNavigation.memberSince and mainNavigation.loggedIn %}
+      {% if mainNavigation.memberSince and mainNavigation.universal %}
         {% include '@atoms/paragraph.twig' with { paragraph : mainNavigation.memberSince } %}
       {% endif %}
     </div>
@@ -22,14 +22,14 @@
       {% include '@atoms/link/link.twig' with { link : mainNavigation.joinRenewLink } %}
     </div>
 
-    {% if mainNavigation.loggedIn %}
-      <div class="ama__main-navigation__member-benefits-link">
-      {% include '@atoms/link/link.twig' with { link : mainNavigation.memberBenefitsLink } %}
-      </div>
-    {% else %}
-      {% include '@molecules/global-search.twig' with { globalSearch : mainNavigation.globalSearch } %}
-    {% endif %}
+    {% include '@molecules/global-search.twig' with { globalSearch : mainNavigation.globalSearch } %}
 
-    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
+    <div class="ama__main-navigation__member-benefits-link">
+      {% include '@atoms/link/link.twig' with { link : mainNavigation.memberBenefitsLink } %}
+    </div>
+
+    {% if mainNavigation.loggedIn %}
+      {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
+    {% endif %}
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -28,8 +28,6 @@
       {% include '@atoms/link/link.twig' with { link : mainNavigation.memberBenefitsLink } %}
     </div>
 
-    {% if mainNavigation.loggedIn %}
-      {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
-    {% endif %}
+    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
@@ -1,6 +1,7 @@
 {
   "mainNavigation": {
-    "loggedIn": true,
+    "loggedIn": false,
+    "universal": true,
     "siteLogo": {
       "src": "../../assets/images/brand/logo.svg",
       "href": "#",
@@ -19,7 +20,7 @@
       "info": "alt",
       "text": "Join",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "renewButton": {
@@ -27,7 +28,7 @@
       "info": "alt",
       "text": "Renew",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "joinRenewLink":

--- a/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
@@ -51,30 +51,16 @@
       "class": "ama__link ama__link--white"
     },
     "signInDropdown": {
-      "text": "John Smithe",
+      "text": "Sign In",
       "menuGroups": [
         {
           "group": [
             {
               "link":
               {
-                "title": "John Smitherson  MD",
+                "title": "Sign In",
                 "href": "#",
-                "text": "John Smitherson  MD",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            }
-          ]
-        },
-        {
-          "group": [
-            {
-              "link":
-              {
-                "title": "Join/Renew",
-                "href": "#",
-                "text": "Join/Renew",
+                "text": "Sign In",
                 "target": "_self",
                 "class": "ama__link ama__link--no-underline"
               }
@@ -82,56 +68,9 @@
             {
               "link":
               {
-                "title": "Member Benefits",
+                "title": "Create free account",
                 "href": "#",
-                "text": "Member Benefits",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            }
-          ]
-        },
-        {
-          "group": [
-            {
-              "link": {
-                "title": "AMA Account",
-                "href": "#",
-                "text": "AMA Account",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            },
-            {
-              "link":
-              {
-                "title": "Email Preferences",
-                "href": "#",
-                "text": "Email Preferences",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            },
-            {
-              "link":
-              {
-                "title": "Billing Information",
-                "href": "#",
-                "text": "Billing Information",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            }
-          ]
-        },
-        {
-          "group": [
-            {
-              "link":
-              {
-                "title": "Sign Out",
-                "href": "#",
-                "text": "Sign Out",
+                "text": "Create free account",
                 "target": "_self",
                 "class": "ama__link ama__link--no-underline"
               }

--- a/styleguide/source/assets/js/category-menu.js
+++ b/styleguide/source/assets/js/category-menu.js
@@ -12,7 +12,7 @@
     attach: function(context, settings) {
       $('.ama_category_navigation_menu__group').smartmenus({
         mainMenuSubOffsetX: 250,
-        mainMenuSubOffsetY: -80,
+        mainMenuSubOffsetY: 20,
         keepInViewport: true
       });
     }

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -15,6 +15,17 @@
       color: $white;
     }
   }
+
+  @else if($style == "tertiary") {
+    background-color: $white;
+    border-color: $purple;
+    color: $purple;
+
+    &:hover {
+      background-color: $hoverPurple;
+      color: $white;
+    }
+  }
   //outline
   @else if($style == "reset") {
     background-color: transparent;

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -7,6 +7,10 @@ button {
     @include ama-button("", "secondary");
   }
 
+  &--tertiary {
+    @include ama-button("", "tertiary");
+  }
+
   &--block {
     @include ama-button("block", "");
   }
@@ -36,6 +40,6 @@ button {
   }
 }
 
-.ama__button--small.ama__button--secondary  {
-  @include ama-button("small", "secondary");
+.ama__button--small.ama__button--tertiary  {
+  @include ama-button("small", "tertiary");
 }

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -10,15 +10,19 @@
   }
 
   // This has to be specific b/c it's so different.
-  &__input[type="text"],
-  &__input[type="text"]:focus,
-  &__input[type="text"]:active {
+  &__input[type="text"] {
+    font-style: italic;
     border: 0;
     border-bottom: 1px solid $light-blue;
-    font-style: italic;
     color: $gray-50;
     line-height: initial;
     padding: 1em 28px 3px 0;
+
+    &:focus,
+    &:active {
+      color: $black;
+      font-style: normal;
+    }
   }
 
   // This has to be specific b/c it's so different.
@@ -40,7 +44,6 @@
     .ama__search__field__input[type="text"]:focus,
     .ama__search__field__input[type="text"]:active {
       padding: 5px 10px;
-      border: solid 1px $purple;
     }
 
     .ama__search__field__button {

--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -51,7 +51,7 @@
     display: none;
     position: absolute;
     border: 2px solid $purple;
-    top: 45px;
+    top: 60px;
     left: 0;
     width: 100%;
     background-color: $purple;

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -16,11 +16,12 @@
   }
 
   @include breakpoint($bp-med) {
+    min-width: 100px;
     width: auto;
   }
 
   @include breakpoint($bp-med) {
-    min-width: 200px;
+    min-width: 135px;
     border-left: 0;
   }
 

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: center;
   color: $white;
-  height: 70px;
+  height: 60px;
   width: 70px;
   align-items: center;
   border-left: 1px solid $gray-50;
@@ -12,10 +12,15 @@
   @include breakpoint($bp-small) {
     justify-content: flex-end;
     border-left: 0;
+    width: 100px;
   }
 
   @include breakpoint($bp-med) {
-    width: 200px;
+    width: auto;
+  }
+
+  @include breakpoint($bp-med) {
+    min-width: 200px;
     border-left: 0;
   }
 
@@ -36,8 +41,12 @@
 
     @include breakpoint($bp-large) {
       @include gutter($margin-left-half...);
-      display: flex;
       flex-grow: 1;
+      max-width: 140px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: block;
     }
   }
 
@@ -59,7 +68,7 @@
     @include gutter($padding-left-half...);
     @include gutter($padding-right-half...);
     position: absolute;
-    top: 70px;
+    top: 60px;
     right: 0;
     box-shadow: 0 2px 3px 2px rgba(0, 0, 0, 0.4);
     background-color: $white;

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -27,13 +27,14 @@
   }
 
   &__section {
-    position: relative;
     list-style: none;
 
     a {
+      position: relative;
       display: block;
-      padding: $gutter/4 $gutter;
+      padding: $gutter/6 $gutter;
       text-decoration: none;
+      font-weight: 600;
 
       &:hover,
       &:active {
@@ -54,7 +55,26 @@
       }
 
       &.highlighted .sub-arrow {
-        transform:rotate(90deg);
+        transform: rotate(90deg);
+
+        @include breakpoint($bp-small) {
+          transform: none;
+        }
+      }
+
+      &.has-submenu.highlighted {
+        &:after {
+          content: "";
+          position: absolute;
+          right: -2px;
+          top: 11px;
+          width: 0;
+          height: 0;
+          border-top: 10px solid transparent;
+          border-bottom: 10px solid transparent;
+          border-right:10px solid $white;
+          z-index: 99;
+        }
       }
     }
 
@@ -77,6 +97,7 @@
 
     @include breakpoint($bp-small) {
       position: absolute;
+      top: 0 !important;
       z-index: 1;
       width: 550px !important;
       max-width: none !important;
@@ -85,18 +106,6 @@
     @include breakpoint($bp-med) {
       width: 900px !important;
       max-width: none !important;
-    }
-
-    &__caret {
-      position: absolute;
-      left: -9px;
-      top: 50px;
-      width: 0;
-      height: 0;
-      border-top: 10px solid transparent;
-      border-bottom: 10px solid transparent;
-      border-right:10px solid $white;
-      z-index: 2;
     }
   }
 
@@ -136,7 +145,7 @@
       @include gutter($margin-bottom-half...);
       @include gutter($padding-left-half...);
       @include gutter($padding-right-half...);
-      color: $hoverPurple;
+      color: $homepagePurple;
       text-transform: uppercase;
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -20,7 +20,7 @@
   .ama_category_navigation_menu {
     display: none;
     position: absolute;
-    top: 70px;
+    top: 60px;
     left: 0;
   }
 
@@ -45,6 +45,10 @@
     @include breakpoint($bp-large min-width) {
       display: flex;
       align-items: center;
+
+      .ama__button {
+        padding: 2px $gutter;
+      }
     }
   }
 
@@ -64,13 +68,36 @@
     }
   }
 
+  .ama__global-search {
+    .ama__search__field__input,
+    .ama__search__field__button {
+      height: 55px;
+
+      @include breakpoint($bp-small min-width) {
+        height: 30px;
+      }
+    }
+
+    .ama__search__field__button {
+      padding: 4px 5px 0;
+
+      svg {
+        background-size: 20px 20px;
+        min-height: 20px;
+        min-width: 20px;
+        max-height: 20px;
+        max-width: 20px;
+      }
+    }
+  }
+
   &__member-since {
     @include gutter($margin-left-full...);
     @extend %ama__type--14px;
     text-align: center;
     margin-top: 0;
     margin-bottom: 0;
-
+    min-width: 70px;
   }
 
   .ama__sign-in-dropdown {
@@ -81,10 +108,18 @@
   &__member-benefits-link {
     @include gutter($margin-left-full...);
     @include gutter($margin-right-full...);
+    display: none;
+
+    @include breakpoint($bp-med min-width) {
+      display: block;
+      min-width: 130px;
+      flex-grow: 1;
+      text-align: right;
+    }
   }
 
 
-  &--loggedIn {
+  &--universal {
     .ama__main-navigation__join--buttons {
       flex-grow: 1;
     }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -72,6 +72,7 @@
     .ama__search__field__input,
     .ama__search__field__button {
       height: 55px;
+      width: 70px;
 
       @include breakpoint($bp-small min-width) {
         height: 30px;

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -47,7 +47,7 @@
       align-items: center;
 
       .ama__button {
-        padding: 2px $gutter;
+        padding: 2px $gutter/2;
       }
     }
   }
@@ -102,12 +102,11 @@
 
   .ama__sign-in-dropdown {
     background-color: transparent;
-    align-self: flex-end;
   }
 
   &__member-benefits-link {
-    @include gutter($margin-left-full...);
-    @include gutter($margin-right-full...);
+    @include gutter($margin-left-half...);
+    @include gutter($margin-right-half...);
     display: none;
 
     @include breakpoint($bp-med min-width) {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5589: Ticket Title](https://issues.ama-assn.org/browse/EWL-5589)

## Description
Update main nav based on UX feedback.

Universal Nav
- Join and renew buttons should have a 'hover purple' hover state instead of  'AMA purple'

Global Menu:
- All flyout menus should align to the top. 
- The arrow should stay the same direction the main menu when the flyout menu appears
- Reduce padding between links in the main category menu
- Join and renew buttons should have a 'hover purple' hover state instead of  'AMA purple'
- When you type into the search bar, the written type should be black and non-italicized
- On tablet and mobile, clicking on the search bar should bring up a search bar directly under, not over, the menu. 

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=organisms-main-navigation
- [x] does the menu have all the changes listed in the description above?
- [x] visit http://localhost:3000/?p=organisms-main-navigation-as-off-AMAOne
- [x] does the menu have all the changes listed in the description above in the global menu section?
- [x] Did you test in IE 11?

## Visual Regressions
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5589-main-nav-feedback/html_report/index.html


## Relevant Screenshots/GIFs

<img width="1212" alt="screen shot 2018-08-09 at 3 10 33 pm" src="https://user-images.githubusercontent.com/2271747/43923097-6497d9c2-9be6-11e8-8c2a-59fd69e5025c.png">
<img width="1305" alt="screen shot 2018-08-09 at 3 10 24 pm" src="https://user-images.githubusercontent.com/2271747/43923099-64a6fee8-9be6-11e8-82b5-ac60437c37c4.png">

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
