### PR TITLE
EWL-5723 | Show Authentication states in Main Navigation

### DIFF
--- a/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
+++ b/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
@@ -14,7 +14,6 @@
           {% if link.subMenu %}
             <ul class="ama_category_navigation_menu__flyout">
               <li class="ama_category_navigation_menu__flyout__container">
-                <i class="ama_category_navigation_menu__flyout__caret"></i>
                 <div class="ama_category_navigation_menu__submenu">
                   <ol>
                     {% for subMenuItem in link.subMenu %}

--- a/styleguide/source/_patterns/03-organisms/main-navigation.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.json
@@ -1,5 +1,6 @@
 {
   "mainNavigation": {
+    "loggedIn": true,
     "siteLogo": {
       "src": "../../assets/images/brand/logo.svg",
       "href": "#",
@@ -18,7 +19,7 @@
       "info": "alt",
       "text": "Join",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "renewButton": {
@@ -26,7 +27,7 @@
       "info": "alt",
       "text": "Renew",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "joinRenewLink":
@@ -36,6 +37,13 @@
       "text": "Join / Renew",
       "target": "_self",
       "class": "ama__link ama__link--white ama__link--no-underline"
+    },
+    "memberBenefitsLink": {
+      "title": "Member Benefits",
+      "href": "#",
+      "text": "Member Benefits",
+      "target": "_self",
+      "class": "ama__link ama__link--white"
     },
     "signInDropdown": {
       "text": "John Smithe",
@@ -889,6 +897,15 @@
                 "title": "FREIDA",
                 "href": "#",
                 "text": "FREIDA",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Education Center",
+                "href": "#",
+                "text": "Education Center",
                 "target": "_self",
                 "class": "ama__link ama__link--no-underline ama__link--white"
               }

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -11,9 +11,15 @@
     {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : mainNavigation.siteLogo } %}
 
     <div class="ama__main-navigation__join--buttons">
-      {% include '@atoms/button/button.twig' with { button : mainNavigation.joinButton } %}
-      {% include '@atoms/button/button.twig' with { button : mainNavigation.renewButton } %}
-      {% if mainNavigation.memberSince and mainNavigation.universal %}
+      {% if mainNavigation.joinButton.text %}
+        {% include '@atoms/button/button.twig' with { button : mainNavigation.joinButton } %}
+      {% endif %}
+
+      {% if mainNavigation.renewButton.text %}
+        {% include '@atoms/button/button.twig' with { button : mainNavigation.renewButton } %}
+      {% endif %}
+
+      {% if mainNavigation.memberSince %}
         {% include '@atoms/paragraph.twig' with { paragraph : mainNavigation.memberSince } %}
       {% endif %}
     </div>

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -1,7 +1,7 @@
-{% set loggedIn = mainNavigation.loggedIn ? "ama__main-navigation--loggedIn" %}
-<div class="ama__main-navigation {{ loggedIn }}">
+{% set universal = mainNavigation.universal ? "ama__main-navigation--universal" %}
+<div class="ama__main-navigation {{ universal }}">
   <div class="container">
-    {% if mainNavigation.loggedIn %}
+    {% if mainNavigation.universal %}
       {% include '@molecules/explore-menu.twig' with { exploreMenu : mainNavigation.exploreMenu } %}
     {% else %}
       {% include '@atoms/menu-icon.twig' with { menuIcon : mainNavigation.menuIcon } %}
@@ -13,7 +13,7 @@
     <div class="ama__main-navigation__join--buttons">
       {% include '@atoms/button/button.twig' with { button : mainNavigation.joinButton } %}
       {% include '@atoms/button/button.twig' with { button : mainNavigation.renewButton } %}
-      {% if mainNavigation.memberSince and mainNavigation.loggedIn %}
+      {% if mainNavigation.memberSince and mainNavigation.universal %}
         {% include '@atoms/paragraph.twig' with { paragraph : mainNavigation.memberSince } %}
       {% endif %}
     </div>
@@ -22,14 +22,14 @@
       {% include '@atoms/link/link.twig' with { link : mainNavigation.joinRenewLink } %}
     </div>
 
-    {% if mainNavigation.loggedIn %}
-      <div class="ama__main-navigation__member-benefits-link">
-      {% include '@atoms/link/link.twig' with { link : mainNavigation.memberBenefitsLink } %}
-      </div>
-    {% else %}
-      {% include '@molecules/global-search.twig' with { globalSearch : mainNavigation.globalSearch } %}
-    {% endif %}
+    {% include '@molecules/global-search.twig' with { globalSearch : mainNavigation.globalSearch } %}
 
-    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
+    <div class="ama__main-navigation__member-benefits-link">
+      {% include '@atoms/link/link.twig' with { link : mainNavigation.memberBenefitsLink } %}
+    </div>
+
+    {% if mainNavigation.loggedIn %}
+      {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
+    {% endif %}
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/main-navigation.twig
@@ -28,8 +28,6 @@
       {% include '@atoms/link/link.twig' with { link : mainNavigation.memberBenefitsLink } %}
     </div>
 
-    {% if mainNavigation.loggedIn %}
-      {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
-    {% endif %}
+    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : mainNavigation.signInDropdown } %}
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/main-navigation~as-member.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation~as-member.json
@@ -1,0 +1,958 @@
+{
+  "mainNavigation": {
+    "loggedIn": true,
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo.svg",
+      "href": "#",
+      "class": "ama__site-logo",
+      "imageClass": "logo",
+      "alt": "American Medical Association",
+      "reversed": {
+        "src": "../../assets/images/brand/logo-reversed.svg"
+      }
+    },
+    "menuIcon": {
+      "text": "Menu"
+    },
+    "joinButton": {
+      "href": "",
+      "info": "alt",
+      "text": "",
+      "type": "button",
+      "style": "tertiary",
+      "size": "small"
+    },
+    "renewButton": {
+      "href": "",
+      "info": "alt",
+      "text": "Renew",
+      "type": "button",
+      "style": "tertiary",
+      "size": "small"
+    },
+    "joinRenewLink":
+    {
+      "title": "Join / Renew",
+      "href": "#",
+      "text": "Join / Renew",
+      "target": "_self",
+      "class": "ama__link ama__link--white ama__link--no-underline"
+    },
+    "memberSince" : {
+      "text": "Member <br/> Since 1996",
+      "class": "ama__main-navigation__member-since"
+    },
+    "memberBenefitsLink": {
+      "title": "Member Benefits",
+      "href": "#",
+      "text": "Member Benefits",
+      "target": "_self",
+      "class": "ama__link ama__link--white"
+    },
+    "signInDropdown": {
+      "text": "John Smithe",
+      "menuGroups": [
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "John Smitherson  MD",
+                "href": "#",
+                "text": "John Smitherson  MD",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "Join/Renew",
+                "href": "#",
+                "text": "Join/Renew",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Member Benefits",
+                "href": "#",
+                "text": "Member Benefits",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link": {
+                "title": "AMA Account",
+                "href": "#",
+                "text": "AMA Account",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Email Preferences",
+                "href": "#",
+                "text": "Email Preferences",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Billing Information",
+                "href": "#",
+                "text": "Billing Information",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "Sign Out",
+                "href": "#",
+                "text": "Sign Out",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "globalSearch": {
+      "searchField": {
+        "label": "Search",
+        "id": "ama__search__input",
+        "name": "global search",
+        "placeholder": "Enter Search Term"
+      },
+      "searchFieldMobile": {
+        "label": "Search",
+        "id": "ama__search__input",
+        "name": "global search",
+        "placeholder": "Enter Search Term",
+        "buttonText": {
+          "text": "Search"
+        }
+      }
+    },
+    "exploreMenu": {
+      "heading": {
+        "level": "3",
+        "text": "Explore",
+        "class": "ama__h3 ama__explore-menu__text"
+      },
+      "links": [
+        {
+          "title": "AMA Home",
+          "href": "#",
+          "text": "AMA Home",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "JAMA Network",
+          "href": "#",
+          "text": "JAMA Network",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "FREIDA",
+          "href": "#",
+          "text": "FREIDA",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "Education Center",
+          "href": "#",
+          "text": "Education Center",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "AMA Insurance",
+          "href": "#",
+          "text": "AMA Insurance",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "AMA Journal of Ethics",
+          "href": "#",
+          "text": "AMA Journal of Ethics",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "CPT",
+          "href": "#",
+          "text": "CPT",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "Store",
+          "href": "#",
+          "text": "Store",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        }
+      ]
+    },
+    "categoryNavigationMenu": {
+      "menuGroups": [
+        {
+          "group": [
+            {
+              "link": {
+                "title": "Homepage",
+                "href": "#",
+                "text": "Homepage",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+
+              "link": {
+                "title": "Delivering Care",
+                "href": "#",
+                "text": "Delivering Care",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white",
+                "articleStubs": [
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  },
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  }
+                ],
+                "subMenu": [
+                  {
+                    "link": {
+                      "title": "Delivering Care",
+                      "href": "#",
+                      "text": "Delivering Care",
+                      "target": "_self",
+                      "class": "ama__h5 ama_category_navigation_menu__submenu__header"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Career Development",
+                      "href": "#",
+                      "text": "Career Development",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Digital",
+                      "href": "#",
+                      "text": "Digital",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Diversity",
+                      "href": "#",
+                      "text": "Diversity",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Claims Processing",
+                      "href": "#",
+                      "text": "Claims Processing",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "CPT",
+                      "href": "#",
+                      "text": "CPT",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Economics",
+                      "href": "#",
+                      "text": "Economics",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "HIPPA",
+                      "href": "#",
+                      "text": "HIPPA",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicaid",
+                      "href": "#",
+                      "text": "Medicaid",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicare",
+                      "href": "#",
+                      "text": "Medicare",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Payment Models",
+                      "href": "#",
+                      "text": "Payment Models",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Private Tier",
+                      "href": "#",
+                      "text": "Private Tiers",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Sustainability",
+                      "href": "#",
+                      "text": "Sustainability",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Well-being",
+                      "href": "#",
+                      "text": "Well-being",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "link": {
+                "title": "Practice Management",
+                "href": "#",
+                "text": "Practice Management",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white",
+                "articleStubs": [
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  },
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  }
+                ],
+                "subMenu": [
+                  {
+                    "link": {
+                      "title": "Practice Management",
+                      "href": "#",
+                      "text": "Practice Management",
+                      "target": "_self",
+                      "class": "ama__h5 ama_category_navigation_menu__submenu__header"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Career Development",
+                      "href": "#",
+                      "text": "Career Development",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Digital",
+                      "href": "#",
+                      "text": "Digital",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Diversity",
+                      "href": "#",
+                      "text": "Diversity",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Claims Processing",
+                      "href": "#",
+                      "text": "Claims Processing",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "CPT",
+                      "href": "#",
+                      "text": "CPT",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Economics",
+                      "href": "#",
+                      "text": "Economics",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "HIPPA",
+                      "href": "#",
+                      "text": "HIPPA",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicaid",
+                      "href": "#",
+                      "text": "Medicaid",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicare",
+                      "href": "#",
+                      "text": "Medicare",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Payment Models",
+                      "href": "#",
+                      "text": "Payment Models",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Private Tier",
+                      "href": "#",
+                      "text": "Private Tiers",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Sustainability",
+                      "href": "#",
+                      "text": "Sustainability",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Well-being",
+                      "href": "#",
+                      "text": "Well-being",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "link": {
+                "title": "Education",
+                "href": "#",
+                "text": "Education",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Adovcacy",
+                "href": "#",
+                "text": "Adovcacy",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Member Benefits",
+                "href": "#",
+                "text": "Member Benefits",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "heading": {
+                "level": "6",
+                "text": "Organization",
+                "class": "ama__h6 ama_category_navigation_menu__section__heading"
+              }
+            },
+            {
+              "link": {
+                "title": "Board of Trustees",
+                "href": "#",
+                "text": "Board of Trustees",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Councils & Committees",
+                "href": "#",
+                "text": "Councils & Committees",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Member Sections",
+                "href": "#",
+                "text": "Member Sections",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white",
+                "articleStubs": [
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  },
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  }
+                ],
+                "subMenu": [
+                  {
+                    "link": {
+                      "title": "Practice Management",
+                      "href": "#",
+                      "text": "Practice Management",
+                      "target": "_self",
+                      "class": "ama__h5 ama_category_navigation_menu__submenu__header"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Career Development",
+                      "href": "#",
+                      "text": "Career Development",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Digital",
+                      "href": "#",
+                      "text": "Digital",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Diversity",
+                      "href": "#",
+                      "text": "Diversity",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Claims Processing",
+                      "href": "#",
+                      "text": "Claims Processing",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "CPT",
+                      "href": "#",
+                      "text": "CPT",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Economics",
+                      "href": "#",
+                      "text": "Economics",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "HIPPA",
+                      "href": "#",
+                      "text": "HIPPA",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicaid",
+                      "href": "#",
+                      "text": "Medicaid",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicare",
+                      "href": "#",
+                      "text": "Medicare",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Payment Models",
+                      "href": "#",
+                      "text": "Payment Models",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Private Tier",
+                      "href": "#",
+                      "text": "Private Tiers",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Sustainability",
+                      "href": "#",
+                      "text": "Sustainability",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Well-being",
+                      "href": "#",
+                      "text": "Well-being",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "link": {
+                "title": "House of Delegates",
+                "href": "#",
+                "text": "House of Delegates",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "About AMA",
+                "href": "#",
+                "text": "About AMA",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "heading": {
+                "level": "6",
+                "text": "Explore Products",
+                "class": "ama__h6 ama_category_navigation_menu__section__heading"
+              }
+            },
+            {
+              "link": {
+                "title": "JAMA Network",
+                "href": "#",
+                "text": "JAMA Network",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "FREIDA",
+                "href": "#",
+                "text": "FREIDA",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Education Center",
+                "href": "#",
+                "text": "Education Center",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "AMA Insurance",
+                "href": "#",
+                "text": "AMA Insurance",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "AMA Journal of Ethics",
+                "href": "#",
+                "text": "AMA Journal of Ethics",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "CPT",
+                "href": "#",
+                "text": "CPT",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Store",
+                "href": "#",
+                "text": "Store",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/main-navigation~as-non-member.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation~as-non-member.json
@@ -1,0 +1,954 @@
+{
+  "mainNavigation": {
+    "loggedIn": true,
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo.svg",
+      "href": "#",
+      "class": "ama__site-logo",
+      "imageClass": "logo",
+      "alt": "American Medical Association",
+      "reversed": {
+        "src": "../../assets/images/brand/logo-reversed.svg"
+      }
+    },
+    "menuIcon": {
+      "text": "Menu"
+    },
+    "joinButton": {
+      "href": "",
+      "info": "alt",
+      "text": "Join",
+      "type": "button",
+      "style": "tertiary",
+      "size": "small"
+    },
+    "renewButton": {
+      "href": "",
+      "info": "",
+      "text": "",
+      "type": "",
+      "style": "",
+      "size": ""
+    },
+    "joinRenewLink":
+    {
+      "title": "Join",
+      "href": "#",
+      "text": "Join",
+      "target": "_self",
+      "class": "ama__link ama__link--white ama__link--no-underline"
+    },
+    "memberBenefitsLink": {
+      "title": "Member Benefits",
+      "href": "#",
+      "text": "Member Benefits",
+      "target": "_self",
+      "class": "ama__link ama__link--white"
+    },
+    "signInDropdown": {
+      "text": "John Smithe",
+      "menuGroups": [
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "John Smitherson  MD",
+                "href": "#",
+                "text": "John Smitherson  MD",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "Join/Renew",
+                "href": "#",
+                "text": "Join/Renew",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Member Benefits",
+                "href": "#",
+                "text": "Member Benefits",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link": {
+                "title": "AMA Account",
+                "href": "#",
+                "text": "AMA Account",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Email Preferences",
+                "href": "#",
+                "text": "Email Preferences",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            },
+            {
+              "link":
+              {
+                "title": "Billing Information",
+                "href": "#",
+                "text": "Billing Information",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "link":
+              {
+                "title": "Sign Out",
+                "href": "#",
+                "text": "Sign Out",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "globalSearch": {
+      "searchField": {
+        "label": "Search",
+        "id": "ama__search__input",
+        "name": "global search",
+        "placeholder": "Enter Search Term"
+      },
+      "searchFieldMobile": {
+        "label": "Search",
+        "id": "ama__search__input",
+        "name": "global search",
+        "placeholder": "Enter Search Term",
+        "buttonText": {
+          "text": "Search"
+        }
+      }
+    },
+    "exploreMenu": {
+      "heading": {
+        "level": "3",
+        "text": "Explore",
+        "class": "ama__h3 ama__explore-menu__text"
+      },
+      "links": [
+        {
+          "title": "AMA Home",
+          "href": "#",
+          "text": "AMA Home",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "JAMA Network",
+          "href": "#",
+          "text": "JAMA Network",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "FREIDA",
+          "href": "#",
+          "text": "FREIDA",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "Education Center",
+          "href": "#",
+          "text": "Education Center",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "AMA Insurance",
+          "href": "#",
+          "text": "AMA Insurance",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "AMA Journal of Ethics",
+          "href": "#",
+          "text": "AMA Journal of Ethics",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "CPT",
+          "href": "#",
+          "text": "CPT",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        },
+        {
+          "title": "Store",
+          "href": "#",
+          "text": "Store",
+          "target": "_self",
+          "class": "ama__link ama__link--white"
+        }
+      ]
+    },
+    "categoryNavigationMenu": {
+      "menuGroups": [
+        {
+          "group": [
+            {
+              "link": {
+                "title": "Homepage",
+                "href": "#",
+                "text": "Homepage",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+
+              "link": {
+                "title": "Delivering Care",
+                "href": "#",
+                "text": "Delivering Care",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white",
+                "articleStubs": [
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  },
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  }
+                ],
+                "subMenu": [
+                  {
+                    "link": {
+                      "title": "Delivering Care",
+                      "href": "#",
+                      "text": "Delivering Care",
+                      "target": "_self",
+                      "class": "ama__h5 ama_category_navigation_menu__submenu__header"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Career Development",
+                      "href": "#",
+                      "text": "Career Development",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Digital",
+                      "href": "#",
+                      "text": "Digital",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Diversity",
+                      "href": "#",
+                      "text": "Diversity",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Claims Processing",
+                      "href": "#",
+                      "text": "Claims Processing",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "CPT",
+                      "href": "#",
+                      "text": "CPT",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Economics",
+                      "href": "#",
+                      "text": "Economics",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "HIPPA",
+                      "href": "#",
+                      "text": "HIPPA",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicaid",
+                      "href": "#",
+                      "text": "Medicaid",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicare",
+                      "href": "#",
+                      "text": "Medicare",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Payment Models",
+                      "href": "#",
+                      "text": "Payment Models",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Private Tier",
+                      "href": "#",
+                      "text": "Private Tiers",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Sustainability",
+                      "href": "#",
+                      "text": "Sustainability",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Well-being",
+                      "href": "#",
+                      "text": "Well-being",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "link": {
+                "title": "Practice Management",
+                "href": "#",
+                "text": "Practice Management",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white",
+                "articleStubs": [
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  },
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  }
+                ],
+                "subMenu": [
+                  {
+                    "link": {
+                      "title": "Practice Management",
+                      "href": "#",
+                      "text": "Practice Management",
+                      "target": "_self",
+                      "class": "ama__h5 ama_category_navigation_menu__submenu__header"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Career Development",
+                      "href": "#",
+                      "text": "Career Development",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Digital",
+                      "href": "#",
+                      "text": "Digital",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Diversity",
+                      "href": "#",
+                      "text": "Diversity",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Claims Processing",
+                      "href": "#",
+                      "text": "Claims Processing",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "CPT",
+                      "href": "#",
+                      "text": "CPT",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Economics",
+                      "href": "#",
+                      "text": "Economics",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "HIPPA",
+                      "href": "#",
+                      "text": "HIPPA",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicaid",
+                      "href": "#",
+                      "text": "Medicaid",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicare",
+                      "href": "#",
+                      "text": "Medicare",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Payment Models",
+                      "href": "#",
+                      "text": "Payment Models",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Private Tier",
+                      "href": "#",
+                      "text": "Private Tiers",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Sustainability",
+                      "href": "#",
+                      "text": "Sustainability",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Well-being",
+                      "href": "#",
+                      "text": "Well-being",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "link": {
+                "title": "Education",
+                "href": "#",
+                "text": "Education",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Adovcacy",
+                "href": "#",
+                "text": "Adovcacy",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Member Benefits",
+                "href": "#",
+                "text": "Member Benefits",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "heading": {
+                "level": "6",
+                "text": "Organization",
+                "class": "ama__h6 ama_category_navigation_menu__section__heading"
+              }
+            },
+            {
+              "link": {
+                "title": "Board of Trustees",
+                "href": "#",
+                "text": "Board of Trustees",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Councils & Committees",
+                "href": "#",
+                "text": "Councils & Committees",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Member Sections",
+                "href": "#",
+                "text": "Member Sections",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white",
+                "articleStubs": [
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  },
+                  {
+                    "link": {
+                      "title": "A link to Google, for example.",
+                      "href": "http://www.google.com",
+                      "text": "Lorem ipsum dolor sit amet."
+                    },
+                    "image": {
+                      "alt": "alt text",
+                      "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+                      "height": "600",
+                      "width": "800"
+                    },
+                    "headingLevel": "h2",
+                    "video": "",
+                    "related": "",
+                    "small": "",
+                    "paragraph": {
+                      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose."
+                    },
+                    "metadata": {
+                      "date": "",
+                      "readtime": ""
+                    },
+                    "navigation": true
+                  }
+                ],
+                "subMenu": [
+                  {
+                    "link": {
+                      "title": "Practice Management",
+                      "href": "#",
+                      "text": "Practice Management",
+                      "target": "_self",
+                      "class": "ama__h5 ama_category_navigation_menu__submenu__header"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Career Development",
+                      "href": "#",
+                      "text": "Career Development",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Digital",
+                      "href": "#",
+                      "text": "Digital",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Diversity",
+                      "href": "#",
+                      "text": "Diversity",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Claims Processing",
+                      "href": "#",
+                      "text": "Claims Processing",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "CPT",
+                      "href": "#",
+                      "text": "CPT",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Economics",
+                      "href": "#",
+                      "text": "Economics",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "HIPPA",
+                      "href": "#",
+                      "text": "HIPPA",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicaid",
+                      "href": "#",
+                      "text": "Medicaid",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Medicare",
+                      "href": "#",
+                      "text": "Medicare",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Payment Models",
+                      "href": "#",
+                      "text": "Payment Models",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Private Tier",
+                      "href": "#",
+                      "text": "Private Tiers",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Sustainability",
+                      "href": "#",
+                      "text": "Sustainability",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  },
+                  {
+                    "link": {
+                      "title": "Well-being",
+                      "href": "#",
+                      "text": "Well-being",
+                      "target": "_self",
+                      "class": "ama__link ama__link--no-underline ama__link--purple"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "link": {
+                "title": "House of Delegates",
+                "href": "#",
+                "text": "House of Delegates",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "About AMA",
+                "href": "#",
+                "text": "About AMA",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            }
+          ]
+        },
+        {
+          "group": [
+            {
+              "heading": {
+                "level": "6",
+                "text": "Explore Products",
+                "class": "ama__h6 ama_category_navigation_menu__section__heading"
+              }
+            },
+            {
+              "link": {
+                "title": "JAMA Network",
+                "href": "#",
+                "text": "JAMA Network",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "FREIDA",
+                "href": "#",
+                "text": "FREIDA",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Education Center",
+                "href": "#",
+                "text": "Education Center",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "AMA Insurance",
+                "href": "#",
+                "text": "AMA Insurance",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "AMA Journal of Ethics",
+                "href": "#",
+                "text": "AMA Journal of Ethics",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "CPT",
+                "href": "#",
+                "text": "CPT",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            },
+            {
+              "link": {
+                "title": "Store",
+                "href": "#",
+                "text": "Store",
+                "target": "_self",
+                "class": "ama__link ama__link--no-underline ama__link--white"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
@@ -1,6 +1,7 @@
 {
   "mainNavigation": {
-    "loggedIn": true,
+    "loggedIn": false,
+    "universal": true,
     "siteLogo": {
       "src": "../../assets/images/brand/logo.svg",
       "href": "#",
@@ -19,7 +20,7 @@
       "info": "alt",
       "text": "Join",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "renewButton": {
@@ -27,7 +28,7 @@
       "info": "alt",
       "text": "Renew",
       "type": "button",
-      "style": "secondary",
+      "style": "tertiary",
       "size": "small"
     },
     "joinRenewLink":

--- a/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
+++ b/styleguide/source/_patterns/03-organisms/main-navigation~as-off-AMAOne.json
@@ -51,30 +51,16 @@
       "class": "ama__link ama__link--white"
     },
     "signInDropdown": {
-      "text": "John Smithe",
+      "text": "Sign In",
       "menuGroups": [
         {
           "group": [
             {
               "link":
               {
-                "title": "John Smitherson  MD",
+                "title": "Sign In",
                 "href": "#",
-                "text": "John Smitherson  MD",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            }
-          ]
-        },
-        {
-          "group": [
-            {
-              "link":
-              {
-                "title": "Join/Renew",
-                "href": "#",
-                "text": "Join/Renew",
+                "text": "Sign In",
                 "target": "_self",
                 "class": "ama__link ama__link--no-underline"
               }
@@ -82,56 +68,9 @@
             {
               "link":
               {
-                "title": "Member Benefits",
+                "title": "Create free account",
                 "href": "#",
-                "text": "Member Benefits",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            }
-          ]
-        },
-        {
-          "group": [
-            {
-              "link": {
-                "title": "AMA Account",
-                "href": "#",
-                "text": "AMA Account",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            },
-            {
-              "link":
-              {
-                "title": "Email Preferences",
-                "href": "#",
-                "text": "Email Preferences",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            },
-            {
-              "link":
-              {
-                "title": "Billing Information",
-                "href": "#",
-                "text": "Billing Information",
-                "target": "_self",
-                "class": "ama__link ama__link--no-underline"
-              }
-            }
-          ]
-        },
-        {
-          "group": [
-            {
-              "link":
-              {
-                "title": "Sign Out",
-                "href": "#",
-                "text": "Sign Out",
+                "text": "Create free account",
                 "target": "_self",
                 "class": "ama__link ama__link--no-underline"
               }

--- a/styleguide/source/assets/js/category-menu.js
+++ b/styleguide/source/assets/js/category-menu.js
@@ -12,7 +12,7 @@
     attach: function(context, settings) {
       $('.ama_category_navigation_menu__group').smartmenus({
         mainMenuSubOffsetX: 250,
-        mainMenuSubOffsetY: -80,
+        mainMenuSubOffsetY: 20,
         keepInViewport: true
       });
     }

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -15,6 +15,17 @@
       color: $white;
     }
   }
+
+  @else if($style == "tertiary") {
+    background-color: $white;
+    border-color: $purple;
+    color: $purple;
+
+    &:hover {
+      background-color: $hoverPurple;
+      color: $white;
+    }
+  }
   //outline
   @else if($style == "reset") {
     background-color: transparent;

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -7,6 +7,10 @@ button {
     @include ama-button("", "secondary");
   }
 
+  &--tertiary {
+    @include ama-button("", "tertiary");
+  }
+
   &--block {
     @include ama-button("block", "");
   }
@@ -36,6 +40,6 @@ button {
   }
 }
 
-.ama__button--small.ama__button--secondary  {
-  @include ama-button("small", "secondary");
+.ama__button--small.ama__button--tertiary  {
+  @include ama-button("small", "tertiary");
 }

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -34,10 +34,6 @@
   }
 
   &--in-body {
-    @include breakpoint($bp-large) {
-      width: 75%;
-    }
-
     align-items: unset;
 
     .ama__search__field__input[type="text"],

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -10,15 +10,19 @@
   }
 
   // This has to be specific b/c it's so different.
-  &__input[type="text"],
-  &__input[type="text"]:focus,
-  &__input[type="text"]:active {
+  &__input[type="text"] {
+    font-style: italic;
     border: 0;
     border-bottom: 1px solid $light-blue;
-    font-style: italic;
     color: $gray-50;
     line-height: initial;
     padding: 1em 28px 3px 0;
+
+    &:focus,
+    &:active {
+      color: $black;
+      font-style: normal;
+    }
   }
 
   // This has to be specific b/c it's so different.
@@ -40,7 +44,6 @@
     .ama__search__field__input[type="text"]:focus,
     .ama__search__field__input[type="text"]:active {
       padding: 5px 10px;
-      border: solid 1px $purple;
     }
 
     .ama__search__field__button {

--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -51,7 +51,7 @@
     display: none;
     position: absolute;
     border: 2px solid $purple;
-    top: 45px;
+    top: 60px;
     left: 0;
     width: 100%;
     background-color: $purple;

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -9,6 +9,10 @@
   align-items: center;
   border-left: 1px solid $gray-50;
 
+  &:hover {
+    cursor: pointer;
+  }
+
   @include breakpoint($bp-small) {
     justify-content: flex-end;
     border-left: 0;

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -16,11 +16,12 @@
   }
 
   @include breakpoint($bp-med) {
+    min-width: 100px;
     width: auto;
   }
 
   @include breakpoint($bp-med) {
-    min-width: 200px;
+    min-width: 135px;
     border-left: 0;
   }
 

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: center;
   color: $white;
-  height: 70px;
+  height: 60px;
   width: 70px;
   align-items: center;
   border-left: 1px solid $gray-50;
@@ -12,10 +12,15 @@
   @include breakpoint($bp-small) {
     justify-content: flex-end;
     border-left: 0;
+    width: 100px;
   }
 
   @include breakpoint($bp-med) {
-    width: 200px;
+    width: auto;
+  }
+
+  @include breakpoint($bp-med) {
+    min-width: 200px;
     border-left: 0;
   }
 
@@ -36,8 +41,12 @@
 
     @include breakpoint($bp-large) {
       @include gutter($margin-left-half...);
-      display: flex;
       flex-grow: 1;
+      max-width: 140px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: block;
     }
   }
 
@@ -59,7 +68,7 @@
     @include gutter($padding-left-half...);
     @include gutter($padding-right-half...);
     position: absolute;
-    top: 70px;
+    top: 60px;
     right: 0;
     box-shadow: 0 2px 3px 2px rgba(0, 0, 0, 0.4);
     background-color: $white;

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -27,13 +27,14 @@
   }
 
   &__section {
-    position: relative;
     list-style: none;
 
     a {
+      position: relative;
       display: block;
-      padding: $gutter/4 $gutter;
+      padding: $gutter/6 $gutter;
       text-decoration: none;
+      font-weight: 600;
 
       &:hover,
       &:active {
@@ -54,7 +55,26 @@
       }
 
       &.highlighted .sub-arrow {
-        transform:rotate(90deg);
+        transform: rotate(90deg);
+
+        @include breakpoint($bp-small) {
+          transform: none;
+        }
+      }
+
+      &.has-submenu.highlighted {
+        &:after {
+          content: "";
+          position: absolute;
+          right: -2px;
+          top: 11px;
+          width: 0;
+          height: 0;
+          border-top: 10px solid transparent;
+          border-bottom: 10px solid transparent;
+          border-right:10px solid $white;
+          z-index: 99;
+        }
       }
     }
 
@@ -77,6 +97,7 @@
 
     @include breakpoint($bp-small) {
       position: absolute;
+      top: 0 !important;
       z-index: 1;
       width: 550px !important;
       max-width: none !important;
@@ -85,18 +106,6 @@
     @include breakpoint($bp-med) {
       width: 900px !important;
       max-width: none !important;
-    }
-
-    &__caret {
-      position: absolute;
-      left: -9px;
-      top: 50px;
-      width: 0;
-      height: 0;
-      border-top: 10px solid transparent;
-      border-bottom: 10px solid transparent;
-      border-right:10px solid $white;
-      z-index: 2;
     }
   }
 
@@ -136,7 +145,7 @@
       @include gutter($margin-bottom-half...);
       @include gutter($padding-left-half...);
       @include gutter($padding-right-half...);
-      color: $hoverPurple;
+      color: $homepagePurple;
       text-transform: uppercase;
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -20,7 +20,7 @@
   .ama_category_navigation_menu {
     display: none;
     position: absolute;
-    top: 70px;
+    top: 60px;
     left: 0;
   }
 
@@ -45,6 +45,10 @@
     @include breakpoint($bp-large min-width) {
       display: flex;
       align-items: center;
+
+      .ama__button {
+        padding: 2px $gutter;
+      }
     }
   }
 
@@ -64,13 +68,36 @@
     }
   }
 
+  .ama__global-search {
+    .ama__search__field__input,
+    .ama__search__field__button {
+      height: 55px;
+
+      @include breakpoint($bp-small min-width) {
+        height: 30px;
+      }
+    }
+
+    .ama__search__field__button {
+      padding: 4px 5px 0;
+
+      svg {
+        background-size: 20px 20px;
+        min-height: 20px;
+        min-width: 20px;
+        max-height: 20px;
+        max-width: 20px;
+      }
+    }
+  }
+
   &__member-since {
     @include gutter($margin-left-full...);
     @extend %ama__type--14px;
     text-align: center;
     margin-top: 0;
     margin-bottom: 0;
-
+    min-width: 70px;
   }
 
   .ama__sign-in-dropdown {
@@ -81,10 +108,18 @@
   &__member-benefits-link {
     @include gutter($margin-left-full...);
     @include gutter($margin-right-full...);
+    display: none;
+
+    @include breakpoint($bp-med min-width) {
+      display: block;
+      min-width: 130px;
+      flex-grow: 1;
+      text-align: right;
+    }
   }
 
 
-  &--loggedIn {
+  &--universal {
     .ama__main-navigation__join--buttons {
       flex-grow: 1;
     }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -72,6 +72,7 @@
     .ama__search__field__input,
     .ama__search__field__button {
       height: 55px;
+      width: 70px;
 
       @include breakpoint($bp-small min-width) {
         height: 30px;

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -72,7 +72,7 @@
     .ama__search__field__input,
     .ama__search__field__button {
       height: 55px;
-      width: 70px;
+      width: 35px;
 
       @include breakpoint($bp-small min-width) {
         height: 30px;

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -47,7 +47,7 @@
       align-items: center;
 
       .ama__button {
-        padding: 2px $gutter;
+        padding: 2px $gutter/2;
       }
     }
   }
@@ -102,12 +102,11 @@
 
   .ama__sign-in-dropdown {
     background-color: transparent;
-    align-self: flex-end;
   }
 
   &__member-benefits-link {
-    @include gutter($margin-left-full...);
-    @include gutter($margin-right-full...);
+    @include gutter($margin-left-half...);
+    @include gutter($margin-right-half...);
     display: none;
 
     @include breakpoint($bp-med min-width) {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5723: Show Authentication states in Main Navigation](https://issues.ama-assn.org/browse/EWL-5723)

## Description
Add member and non member main navigation states

## To Test
- [ ] `gulp serve`

**Member state**
- [x] visit http://localhost:3000/?p=organisms-main-navigation-as-member
- [x] observe the only button showing is the renew button
- [x] observe the text "Member Since 1996" next to the renew button

**Non Member state**
- [x] visit http://localhost:3000/?p=organisms-main-navigation-as-non-member
- [x] observe the only button showing is join
- [x] observe that users name shows in the menu

- [x] Did you test in IE 11?

## Visual Regressions
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5723-show-auth-states/html_report/index.html


## Relevant Screenshots/GIFs
MEMBER
<img width="1217" alt="screen shot 2018-08-09 at 4 50 46 pm" src="https://user-images.githubusercontent.com/2271747/43927815-648ecec8-9bf4-11e8-9cad-b1cb8f570d65.png">

NON MEMBER
<img width="1250" alt="screen shot 2018-08-09 at 4 50 33 pm" src="https://user-images.githubusercontent.com/2271747/43927816-649c2528-9bf4-11e8-8845-7ee0b6c13013.png">


## Remaining Tasks
N/A


## Additional Notes
This is a branch of PR 
https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/379
PR #379 needs to be merged before this PR
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
