### PR TITLE
Fixes image sizes for hub cards

### DIFF
--- a/styleguide/source/_patterns/02-molecules/hub/hub-card.twig
+++ b/styleguide/source/_patterns/02-molecules/hub/hub-card.twig
@@ -6,7 +6,9 @@
 
 <a class="ama__hub-card {{ hubCard.layout }}" href="#" style="{{ background }}">
   {% if hubCard.image.src is not empty %}
-    {% include "@atoms/image/image.twig" with { 'class': 'ama__hub-card__image' } %}
+    <div class="ama__hub-card__image">
+      {% include "@atoms/image/image.twig" with { 'class': 'ama__hub-card__image' } %}
+    </div>
   {% endif %}
   <div class="ama__hub-card__description">
     {% include "@atoms/heading/heading.twig" %}

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -32,18 +32,15 @@
   }
 
   &__image {
-    display: flex;
-    flex-basis: 100%;
-    align-items: center;
     margin: 0;
-
-
+    
     .ama__image {
+      height: auto;
       width: 100%;
     }
 
     & > * {
-      display: flex;
+      height: auto;
       width: 100%;
       padding: 0;
     }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -72,12 +72,15 @@
     }
   }
 
-  &__description {
+  &__description,
+  &__description > div {
     @include gutter-all($padding-all-full...);
     display: flex;
     flex-direction: column;
     align-items: stretch;
     margin: 0;
+    max-width: none;
+    width: auto;
   }
 
   &__button-container {
@@ -86,6 +89,7 @@
 
     a {
       @extend %ama__button;
+      display: block;
     }
   }
 
@@ -181,6 +185,14 @@
     p {
       @include gutter-all($padding-all-full...);
       background-color: rgba(255, 255, 255, 0.45);
+    }
+
+    p {
+      order: 3;
+    }
+
+    .ama__hub-hero__button-container {
+      order: 2;
     }
   }
 


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5600: Create hub cards](https://issues.ama-assn.org/browse/EWL-5600)

## Description
Adjust hub card images work with D8 

## To Test
- [x] `gulp serve`
- [x] visit http://localhost:3000/?p=pages-hub
- [ ] the hub card images look the same as the ones in https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-hub
- [ ] Did you test in IE 11?

## Visual Regressions
http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5600-hub-card/html_report/index.html


## Relevant Screenshots/GIFs
<img width="1251" alt="screen shot 2018-08-13 at 11 41 14 am" src="https://user-images.githubusercontent.com/2271747/44045324-d07839b6-9eed-11e8-8647-0496d0e109b4.png">


## Remaining Tasks
N/A


## Additional Notes
The D8 side of this story is in PR [#629](https://github.com/AmericanMedicalAssociation/ama-d8/pull/629)


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
