### PR TITLE
EWL-5367 SG2 | Correct News as Gated Styling

### DIFF
--- a/styleguide/source/_patterns/05-pages/news/news-as-gated.json
+++ b/styleguide/source/_patterns/05-pages/news/news-as-gated.json
@@ -338,6 +338,7 @@
         "text": "Lorem ipsum dolor sit amet.",
         "target": "_self"
       },
+      "headingLevel": "h3",
       "image": {
         "alt": "alt text",
         "src": "https://ipsumimage.appspot.com/450x321?l=7:5|450x321&s=36",
@@ -360,6 +361,7 @@
         "class": "ama__link-black",
         "target": "_self"
       },
+      "headingLevel": "h3",
       "image": {
         "alt": "alt text",
         "src": "https://ipsumimage.appspot.com/450x321?l=7:5|450x321&s=36",
@@ -375,6 +377,7 @@
         "class": "ama__link-black",
         "target": "_self"
       },
+      "headingLevel": "h3",
       "image": {
         "alt": "alt text",
         "src": "https://ipsumimage.appspot.com/450x321?l=7:5|450x321&s=36",
@@ -390,6 +393,7 @@
         "class": "ama__link-black",
         "target": "_self"
       },
+      "headingLevel": "h3",
       "image": {
         "alt": "alt text",
         "src": "https://ipsumimage.appspot.com/450x321?l=7:5|450x321&s=36",
@@ -411,7 +415,7 @@
         "headingLevel": "h3",
         "image": {
           "alt": "alt text",
-          "src": "https://ipsumimage.appspot.com/279x186?l=3:2|279x186&s=36",
+          "src": "https://via.placeholder.com/279x186?l=3:2|279x186&s=36",
           "height": "186",
           "width": "279"
         }
@@ -427,7 +431,7 @@
         "headingLevel": "h3",
         "image": {
           "alt": "alt text",
-          "src": "https://ipsumimage.appspot.com/279x186?l=3:2|279x186&s=36",
+          "src": "https://via.placeholder.com/279x186?l=3:2|279x186&s=36",
           "height": "186",
           "width": "279"
         }
@@ -443,7 +447,7 @@
         "headingLevel": "h3",
         "image": {
           "alt": "alt text",
-          "src": "https://ipsumimage.appspot.com/279x186?l=3:2|279x186&s=36",
+          "src": "https://via.placeholder.com/279x186?l=3:2|279x186&s=36",
           "height": "186",
           "width": "279"
         }

--- a/styleguide/source/assets/js/gate.js
+++ b/styleguide/source/assets/js/gate.js
@@ -12,8 +12,8 @@
     attach: function(context, settings) {
       if ($('.ama__gate', context).length) {
         var heightGate = $('.ama__tags').offset().top - $('.ama__gate').offset().top;
-        $('.ama__gate', context).height(heightGate);
-        $('.ama__gate').nextUntil('.ama__tags').wrapAll('<div class="ama__gate__blurry" />');
+        $('.ama__gate', context).outerHeight(heightGate);
+        $('.ama__gate').nextUntil('.ama__page--news__teasers').wrapAll('<div class="ama__gate__blurry" />');
       }
     }
   };


### PR DESCRIPTION
**Jira Ticket**
- [EWL-5367: SG2 | Correct News as Gated Styling](https://issues.ama-assn.org/browse/EWL-5367)

## Description
The blur and dark overly should only be over the body. Currently it goes all the way down to the four up teasers

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-news-as-gated
- [ ] observe the dark and blurry section only covers the body
- [ ] observe the four up links are now links and not html code
- [ ] Did you test in IE 11?

## Visual Regressions
here the link to the [Travis Backstop](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5367-news-as-gated/html_report/index.html
)

## Relevant Screenshots/GIFs
<img width="1103" alt="screen shot 2018-08-13 at 4 36 45 pm" src="https://user-images.githubusercontent.com/2271747/44059460-1725c1b6-9f17-11e8-9470-b1b5a4ff5905.png">

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
