### PR TITLE
Update Clear Filter Styles for D8

### DIFF
--- a/styleguide/source/assets/scss/00-base/_forms.scss
+++ b/styleguide/source/assets/scss/00-base/_forms.scss
@@ -56,4 +56,7 @@ label {
     text-transform: capitalize;
   }
 }
-
+input.ama__link--blue{
+  font-size: 1em;
+  border: none;
+}


### PR DESCRIPTION
## Description
Filters in D8 are inputs of type submit, not anchor tags. This update applies a couple of styles to the input so that it can mimic the established reset link styling on the event listing page. Functionality will be tested when reviewing the dependent PR, however I have added the steps below.


## To Test
- Pull `feature/update-clear-filter-styles-input` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Pull `feature/EWL-5658-event-listing-filters-theming` of ama-d8.
- Open a local version of AMA One with assets pointed to local versions
-- Edit your local `provisioning/vars/local.yml` to use your local SG2 files
-- Run `vagrant up` and then `scripts/build` to update symlinks to css and js files.
- Follow instructions from [PR #641 Event Listing - Theme Filters and Keyword Box](https://github.com/AmericanMedicalAssociation/ama-d8/pull/641) to set up environment for testing.
- Add a filter from side bar and confirm "clear filter" text shows as in SG2

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/update-clear-filter-styles-input/html_report/index.html).


## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
