### PR TITLE
HOTFIX: removes internal padding for description block

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -72,8 +72,7 @@
     }
   }
 
-  &__description,
-  &__description > div {
+  &__description {
     @include gutter-all($padding-all-full...);
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Description
 removes internal padding for description block. This PR is priority because it blocks another PR in D8 https://github.com/AmericanMedicalAssociation/ama-d8/pull/629

## To Test
- [ ] `gulp serve`
- [ ] observe nothing changed here http://localhost:3000/?p=organisms-hub-heroes
- [ ] Did you test in IE 11?

## Visual Regressions
here's the link to the [Travis Backstop](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/hotfix/EWL-5600-hub-card/html_report/index.html
)
## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
