### PR TITLE
EWL-5796: Create search results stub

### DIFF
--- a/styleguide/source/_patterns/03-organisms/filter.json
+++ b/styleguide/source/_patterns/03-organisms/filter.json
@@ -15,7 +15,7 @@
     "expandList": [
       {
         "header": "Location",
-        "content": "@molecules/checkbox-group.twig",
+        "content": "@molecules/checkbox-group/checkbox-group.twig",
         "searchField": {
           "label": "Search",
           "id": "ama__search__location",
@@ -320,7 +320,7 @@
       },
       {
         "header": "Audience",
-        "content": "@molecules/checkbox-group.twig",
+        "content": "@molecules/checkbox-group/checkbox-group.twig",
         "checkboxes": {
           "checks": [
             {

--- a/styleguide/source/_patterns/05-pages/event-listing.json
+++ b/styleguide/source/_patterns/05-pages/event-listing.json
@@ -16,7 +16,7 @@
       "expandList": [
         {
           "header": "Location",
-          "content": "@molecules/checkbox-group.twig",
+          "content": "@molecules/checkbox-group/checkbox-group.twig",
           "searchField": {
             "label": "Search",
             "name": "text field",
@@ -321,7 +321,7 @@
         },
         {
           "header": "Audience",
-          "content": "@molecules/checkbox-group.twig",
+          "content": "@molecules/checkbox-group/checkbox-group.twig",
           "checkboxes": {
             "checks": [
               {

--- a/styleguide/source/_patterns/05-pages/search-results.json
+++ b/styleguide/source/_patterns/05-pages/search-results.json
@@ -1,0 +1,90 @@
+{
+  "searchResults": {
+    "filter": {
+      "appliedFilters": {
+        "label": "Filters",
+        "clearAll": "Clear Filters",
+        "button": {
+          "href": "",
+          "info": "alt",
+          "text": "Filter",
+          "type": "button",
+          "style": "secondary",
+          "size": ""
+        }
+      },
+      "expandList": [
+        {
+          "header": "Category",
+          "content": "@molecules/checkbox-group.twig",
+          "searchField": {
+            "label": "Search",
+            "name": "text field",
+            "id": "ama__search__category",
+            "placeholder": "Search results Lorem Ipsum",
+            "helpText": "Help Text"
+          },
+          "checkboxes": {
+            "checks": [
+              {
+                "label": "Lorem Ipsum",
+                "value": "checkbox",
+                "index": 1
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "searchHeader":{
+    "searchResultsNum" : "Items 39",
+    "selectMenu":{
+      "label":"Search",
+      "required": false,
+      "id":"text-select",
+      "options":[{
+        "value":"http://www.google.com",
+        "text":"Chronological"
+      },{
+        "value":"http://www.google.com",
+        "text":"Sort A-Z"
+      },{
+        "value":"http://www.google.com",
+        "text":"Sort Z-A"
+      },{
+        "value":"http://www.google.com",
+        "text":"Most Recent"
+      }]
+    }
+  },
+  "articleStubAsInline": {
+    "heading": {
+      "text": "Related Coverage"
+    },
+    "link": {
+      "href": "http://www.google.com",
+      "text": "The new, general medical journal will feature health content",
+      "target": "_self",
+      "class": "ama__article-stub--inline__link ama__link--blue"
+    }
+  },
+  "pagination": {
+    "pages": [{
+      "active": false,
+      "text": "1"
+    },{
+      "active": true,
+      "text": "2"
+    },{
+      "active": false,
+      "text": "3"
+    },{
+      "active": false,
+      "text": "4"
+    },{
+      "active": false,
+      "text": "5"
+    }]
+  }
+}

--- a/styleguide/source/_patterns/05-pages/search-results.json
+++ b/styleguide/source/_patterns/05-pages/search-results.json
@@ -35,6 +35,62 @@
           }
         }
       ]
+    },
+    "promotionalRealEstate": {
+      "partnerPromo": {
+        "image": {
+          "alt": "alt text",
+          "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+          "height": "100%",
+          "width": "100%"
+        },
+        "heading": {
+          "level": "2",
+          "text": "Lorem ipsum dolor sit amet",
+          "class": "ama__h2 ama__partner-promo__heading"
+        },
+        "paragraph" : {
+          "text": "Non aliquam.",
+          "class": "ama__partner-promo__paragraph"
+        },
+        "button": {
+          "href": "",
+          "info": "alt",
+          "text": "Lorem ipsum",
+          "type": "button",
+          "style": "promo",
+          "size": ""
+        }
+      },
+      "subscribePromo": {
+        "subjectTitle": {
+          "level": "4",
+          "text": "Lorem ipsum",
+          "class": "ama__h4 ama__subscribe-promo__subject-title"
+        },
+        "heading": {
+          "level": "2",
+          "text": "Lorem ipsum dolor sit amet",
+          "class": "ama__h2 ama__subscribe-promo__heading"
+        },
+        "paragraph": {
+          "text": "Non aliquam.",
+          "class": "ama__subscribe-promo__paragraph"
+        },
+        "email": {
+          "label": "email",
+          "name": "email",
+          "placeholder": "Email Address"
+        },
+        "button": {
+          "href": "",
+          "info": "alt",
+          "text": "Subscribe",
+          "type": "button",
+          "style": "secondary",
+          "size": ""
+        }
+      }
     }
   },
   "searchHeader":{

--- a/styleguide/source/_patterns/05-pages/search-results.json
+++ b/styleguide/source/_patterns/05-pages/search-results.json
@@ -16,7 +16,7 @@
       "expandList": [
         {
           "header": "Category",
-          "content": "@molecules/checkbox-group.twig",
+          "content": "@molecules/checkbox-group/checkbox-group.twig",
           "searchField": {
             "label": "Search",
             "name": "text field",

--- a/styleguide/source/_patterns/05-pages/search-results.md
+++ b/styleguide/source/_patterns/05-pages/search-results.md
@@ -4,4 +4,4 @@ A default search results page that shows what search results should look like wh
 #### User Story
 As a user, I want to see a search result page when I input terms into the search in the Main Navigation, so that I can review the content that matches my search terms.
 
-[EWL-5790 SG2 | Create "Search Results" page](https://issues.ama-assn.org/browse/EWL-5790)
+[EWL-5796 SG2 | Create "Search Results" page](https://issues.ama-assn.org/browse/EWL-5796)

--- a/styleguide/source/_patterns/05-pages/search-results.md
+++ b/styleguide/source/_patterns/05-pages/search-results.md
@@ -1,0 +1,7 @@
+### Description
+A default search results page that shows what search results should look like when a user searches globally through the search bar in the Main Navigation.
+
+#### User Story
+As a user, I want to see a search result page when I input terms into the search in the Main Navigation, so that I can review the content that matches my search terms.
+
+[EWL-5790 SG2 | Create "Search Results" page](https://issues.ama-assn.org/browse/EWL-5790)

--- a/styleguide/source/_patterns/05-pages/search-results.twig
+++ b/styleguide/source/_patterns/05-pages/search-results.twig
@@ -11,7 +11,6 @@
 {% endblock %}
 
 {% block pageContent %}
-  <!-- {% include '@organisms/event-list.twig' %} -->
   {% include "@molecules/article-stub/article-stub-as-inline-alt.twig" %}
   {% include "@molecules/pagination.twig" %}
 {% endblock %}

--- a/styleguide/source/_patterns/05-pages/search-results.twig
+++ b/styleguide/source/_patterns/05-pages/search-results.twig
@@ -1,0 +1,12 @@
+{% extends '@templates/two-column-left.twig' %}
+{% set filter = searchResults.filter %}
+
+{% block sidebarPrimary %}
+  {% include "@organisms/filter.twig" %}
+{% endblock %}
+
+{% block pageContent %}
+  <!-- {% include '@organisms/event-list.twig' %} -->
+  {% include "@molecules/article-stub/article-stub-as-inline-alt.twig" %}
+  {% include "@molecules/pagination.twig" %}
+{% endblock %}

--- a/styleguide/source/_patterns/05-pages/search-results.twig
+++ b/styleguide/source/_patterns/05-pages/search-results.twig
@@ -1,8 +1,13 @@
 {% extends '@templates/two-column-left.twig' %}
 {% set filter = searchResults.filter %}
+{% set partnerPromo, subscribePromo =
+  searchResults.promotionalRealEstate.partnerPromo,
+  searchResults.promotionalRealEstate.subscribePromo %}
 
 {% block sidebarPrimary %}
   {% include "@organisms/filter.twig" %}
+  {% include '@molecules/partner-promo.twig' %}
+  {% include '@molecules/subscribe-promo.twig' %}
 {% endblock %}
 
 {% block pageContent %}


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-5796: Create Search Results Stub](https://issues.ama-assn.org/browse/EWL-5796)

## Description
Create a stub of the Search Results page that includes the existing patterns for that page.


## To Test
- [ ] `gulp serve`
- [ ] Click "Pages" in the SG2 menu
- [ ] Observe you see "Search Results"
- [ ] Click "Search Results"
- [ ] Observe you see the "Category" filter group in the left sidebar
- [ ] Observe you see the "Partner Promo" in the left sidebar
- [ ] Observe you see the "Subscribe Promo" in the left sidebar
- [ ] Observe you see the "Article Stub as Inline" in the body
- [ ] Observe you see the "Pagination" in the body
- [ ] Observe you see the "Footer"
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5796-search-results-stub/html_report/index.html).


## Relevant Screenshots/GIFs
![localhost_3000__p pages-search-results](https://user-images.githubusercontent.com/1653723/44370096-5903a800-a49e-11e8-9e6c-8bc820b3d218.png)


## Remaining Tasks
N/A


## Additional Notes
**I noticed a bug in the filter list** 
<img width="328" alt="screen shot 2018-08-16 at 10 35 55 am" src="https://user-images.githubusercontent.com/1653723/44370236-f1019180-a49e-11e8-9233-5ab367a1dbae.png">
If you know where this pattern lives please LMK so I can update the path/fix the bug throughout.

@designerneil I'm curious about the additional padding around the filters, why do are they not set to the full-width of the sidebar?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
