### PR TITLE
[EWL-5850] QA/EWL- 4593 SG2 | Event Listing - Distorted in IE11

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -55,6 +55,7 @@
       @include gutter($padding-left-full...);
       grid-column: 1;
       grid-row: 2;
+      -ms-grid-column-span: 1;
     }
   } // end aside.secondary
 }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5850: QA/EWL- 4593 SG2 | Event Listing - Distorted in IE11](https://issues.ama-assn.org/browse/EWL-5850)

## To Test
- Pull `bugfix/EWL-5850-sidebar-left-ie11` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Check event listing and search result pages in IE11 and confirm sidebar is properly contained in left column.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5850-sidebar-left-ie11/html_report/index.html).


## Relevant Screenshots/GIFs
![image](https://user-images.githubusercontent.com/4438120/45038566-1528ab00-b027-11e8-969f-763e6bb9bc45.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
