### PR TITLE
EWL-5659 - Removes checklist library from library which caused js errors on event listing page

### DIFF
--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -174,7 +174,7 @@
             $('#selectedItems').text(JSON.stringify(selection));
           }
 
-          if (typeof(jQuery.ui.checkList)){
+          if (typeof(jQuery.ui.checkList) != 'undefined'){
             $('#filterList').checkList({
               listItems: dataModel,
               onChange: selChange

--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -174,10 +174,12 @@
             $('#selectedItems').text(JSON.stringify(selection));
           }
 
-          $('#filterList').checkList({
-            listItems: dataModel,
-            onChange: selChange
-          });
+          if (typeof(jQuery.ui.checkList)){
+            $('#filterList').checkList({
+              listItems: dataModel,
+              onChange: selChange
+            });
+          }
 
           $('[type=checkbox]').checkboxradio();
           $('[type=radio]').checkboxradio().buttonset().find('label').css('width', '19.4%');


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-5659: A1 | Event Listing - Theme keyword filter box](https://issues.ama-assn.org/browse/EWL-5659)


## Description:
Fixes javascript errors stemming from the checklist plugin. The plugin has been removed because we only use it on SG2

## Description
Adds conditional around checklist function to ensure it only runs when the checklist plugin is loaded

## To Test
- [ ] switch your branch to `feature/EWL-5659-event-listing-keyword`
- [ ] visit http://localhost:3000/?p=molecules-filter-list-as-search-filter
- [ ] enter `hi`
- [ ] observe results are returned
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5659-event-listing-keyword/html_report/index.html).


## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
