### PR TITLE
EWL-5773: Prevent view all / less from scrolling the page.

### DIFF
--- a/styleguide/source/assets/js/subcategory.js
+++ b/styleguide/source/assets/js/subcategory.js
@@ -36,13 +36,15 @@
         $('.ama__subcategory-exploration-with-images__view-less').hide();
         $('.ama__subcategory-exploration-with-images__view-all').show();
 
-        $('.viewAll').click(function() {
+        $('.viewAll').click(function(e) {
+          e.preventDefault();
           subcategory.fadeIn();
           $('.ama__subcategory-exploration-with-images__view-all').hide();
           $('.ama__subcategory-exploration-with-images__view-less').show();
         });
 
-        $('.viewLess').click(function() {
+        $('.viewLess').click(function(e) {
+          e.preventDefault();
           subcategory.hide();
           checkSize();
           $('.ama__subcategory-exploration-with-images__view-less').hide();


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5773: A1 | Subcategory Exploration View Theming](https://issues.ama-assn.org/browse/EWL-5773)

## Description
Patternlab blocks `#` links by default, but Drupal does not do this.


## To Test
This must really be tested in Drupal, but you can confirm it is still working in the style guide by viewing this pattern and using the `View all` and `View less` buttons.

https://americanmedicalassociation.github.io/ama-style-guide-2/?p=organisms-subcategory-exploration-as-with-images

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/subcategory-anchor-block/html_report/index.html).

## Relevant Screenshots/GIFs
![example](https://user-images.githubusercontent.com/397902/45105305-918bbe80-b0f9-11e8-938f-27f01a099b19.jpg)

## Remaining Tasks
N/A

## Additional Notes
This will be a blocker for testing the Drupal side of this work.

https://github.com/AmericanMedicalAssociation/ama-d8/pull/705

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
