### PR TITLE
EWL-5645: Stretch hero images to fill space.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subcategory-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subcategory-hero.scss
@@ -18,6 +18,10 @@
       width: 100%;
     }
     width: 75%;
+
+    img {
+      width: 100%;
+    }
   }
 
   &__copy {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5645: A1 | Hero Custom Block Theming](https://issues.ama-assn.org/browse/EWL-5645)

## Description
Force the hero image to take up 100% of the allotted space.


## To Test
See https://issues.ama-assn.org/browse/EWL-5642

- Go to /block/add/hero, add an image that is smallish (so it will be stretched)
- You can preview this by editing a subcategory such as /about-ama/foundation at /taxonomy/term/385/layout
- Create a new row with One column with class and add your block

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5645-hero-custom-block-image-size/html_report/index.html).

## Relevant Screenshots/GIFs
https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-subcategory

![example](https://user-images.githubusercontent.com/397902/45320129-6513e000-b507-11e8-8773-01fcebdd73a3.jpg)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
