### PR TITLE
EWL-5649 - A1 | Article Stub List custom block theming

### DIFF
--- a/styleguide/source/_patterns/03-organisms/_category-article-three-up-jama.twig
+++ b/styleguide/source/_patterns/03-organisms/_category-article-three-up-jama.twig
@@ -1,16 +1,23 @@
 {% extends '@templates/two-column-right-75-25.twig' %}
 
-{% block contentTop %}
-  {% set contentGroupingHeader = category.articleStubsThreeUp.contentGroupingHeader %}
-  {% include '@atoms/content-grouping-header.twig' %}
-{% endblock %}
-
 {% block contentLeft %}
   <div class="ama__category__article-stub-three-up">
-    {% for articleStub in category.articleStubsThreeUp.content %}
-      {% include "@molecules/article-stub/article-stub.twig" %}
-    {% endfor %}
+    {% set contentGroupingHeader = category.articleStubsThreeUp.contentGroupingHeader %}
+    {% include '@atoms/content-grouping-header.twig' %}
+    <div class="grid-container">
+      {% for articleStub in category.articleStubsThreeUp.content %}
+        {% include "@molecules/article-stub/article-stub.twig" %}
+      {% endfor %}
+    </div>
   </div>
+
+
+
+  {#<div class="ama__category__article-stub-three-up">#}
+    {#{% for articleStub in category.articleStubsThreeUp.content %}#}
+      {#{% include "@molecules/article-stub/article-stub.twig" %}#}
+    {#{% endfor %}#}
+  {#</div>#}
 {% endblock %}
 
 {% block contentRight %}

--- a/styleguide/source/_patterns/03-organisms/_category-article-three-up-jama.twig
+++ b/styleguide/source/_patterns/03-organisms/_category-article-three-up-jama.twig
@@ -10,14 +10,6 @@
       {% endfor %}
     </div>
   </div>
-
-
-
-  {#<div class="ama__category__article-stub-three-up">#}
-    {#{% for articleStub in category.articleStubsThreeUp.content %}#}
-      {#{% include "@molecules/article-stub/article-stub.twig" %}#}
-    {#{% endfor %}#}
-  {#</div>#}
 {% endblock %}
 
 {% block contentRight %}
@@ -25,50 +17,6 @@
   {# @todo - get this to work #}
   {% set jama = category.jamaAsSidebar %}
   {% include '@molecules/jama/jama.twig' %}
-  {#<div class="ama__jama">#}
-  {#<span class="logo logo-outer ">#}
-  {#<img src="../../assets/images/brand/logo-jama.svg" class="logo" alt="American Medical Association">#}
-{#</span>#}
-    {#<div class="ama__rule ama__rule--horizontal"></div>#}
-    {#<span class="ama__jama__title">#}
-
-  {#</span>#}
-    {#<ul class="ama__jama__links">#}
-      {#<li class="ama__link--with-image">#}
-        {#<a href="https://www.google.com" title="">#}
-          {#<span class="ama__image__text">#}
-                  {#<span class="ama__image__text__subtitle">#}
-            {#JAMA Surgery#}
-          {#</span>#}
-                {#<h3 class="ama__h3">Surgeon general nominee fought HIV outbreak in rural Indiana</h3>#}
-      {#</span>#}
-        {#</a>#}
-      {#</li>#}
-      {#<li class="">#}
-        {#<a href="https://www.aol.com" title="">#}
-          {#<span class="ama__image__text">#}
-                  {#<span class="ama__image__text__subtitle">#}
-            {#JAMA Psychiatry#}
-          {#</span>#}
-                {#<h3 class="ama__h3">Sugary-drinks tax passes legal muster in Pennsylvania</h3>#}
-      {#</span>#}
-        {#</a>#}
-      {#</li>#}
-      {#<li class="ama__link--with-image">#}
-        {#<a href="https://www.yahoo.com" title="">#}
-          {#<span class="ama__image__text">#}
-                  {#<span class="ama__image__text__subtitle">#}
-            {#JAMA Dermatology#}
-          {#</span>#}
-                {#<h3 class="ama__h3">Avoid MIPS penalties in 2019: What physicians need to know</h3>#}
-      {#</span>#}
-        {#</a>#}
-      {#</li>#}
-    {#</ul>#}
-    {#<div class="ama__rule ama__rule--horizontal"></div>#}
-    {#<a href="#" class="ama__jama__link--sign-up">Sign-up for a membership to the AMA and receive a subscription to <span class="ama__jama--reg">JAMA</span></a>#}
-  {#</div>#}
-{#</div>#}
 {% endblock %}
 
 {% block footer %}

--- a/styleguide/source/_patterns/03-organisms/_category-article-two-up.twig
+++ b/styleguide/source/_patterns/03-organisms/_category-article-two-up.twig
@@ -1,8 +1,9 @@
 <div class="ama__category__article-stub-two-up">
   {% set contentGroupingHeader = category.articleStubsThreeUp.contentGroupingHeader %}
   {% include '@atoms/content-grouping-header.twig' %}
-
-  {% for articleStub in category.articleStubsTwoUp.content %}
-    {% include "@molecules/article-stub/article-stub.twig" %}
-  {% endfor %}
+  <div class="grid-container">
+    {% for articleStub in category.articleStubsTwoUp.content %}
+      {% include "@molecules/article-stub/article-stub.twig" %}
+    {% endfor %}
+  </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/category-page-article-stub.twig
+++ b/styleguide/source/_patterns/03-organisms/category-page-article-stub.twig
@@ -3,7 +3,7 @@
     {% set contentGroupingHeader = categoryArticleStub.contentGroupingHeader %}
   {% endif %}
   {% include "@atoms/content-grouping-header.twig" %}
-  <div class="ama__category-page-article-stub__container">
+  <div class="grid-container">
     {% for articleStub in categoryArticleStub.articleStubs %}
       {% include "@molecules/article-stub/article-stub.twig" %}
     {% endfor %}

--- a/styleguide/source/assets/js/category-carousel.js
+++ b/styleguide/source/assets/js/category-carousel.js
@@ -1,5 +1,5 @@
 (function($) {
-  $('.ama__subcategory-featured-content-as-carousel .ama__category-page-article-stub__container').slick({
+  $('.ama__subcategory-featured-content-as-carousel .grid-container').slick({
     slidesToShow: 4,
     slidesToScroll: 2,
     infinite: false,

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -30,7 +30,7 @@
   .ama__image,
   .ama__video {
     @include gutter($margin-bottom-half...);
-    min-height: 210px;
+    width: 100%;
   }
 
   &--related {

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -30,6 +30,7 @@
   .ama__image,
   .ama__video {
     @include gutter($margin-bottom-half...);
+    min-height: 210px;
   }
 
   &--related {

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -1,15 +1,13 @@
 .ama__category-page-article-stub {
 
-  &__container {
+  .grid-container {
     @include gutter($margin-top-full...);
     display: flex;
     flex-direction: row;
-    margin-left: -20px;
     flex-wrap: wrap;
 
     @include breakpoint($bp-med min-width) {
       flex-wrap: nowrap;
-      margin-left: -28px;
     }
   }
 
@@ -17,6 +15,10 @@
     @include gutter($padding-left-full...);
     @include gutter($margin-bottom-full...);
     width: 100%;
+
+    &:first-child {
+      padding-left: 0;
+    }
 
     @include breakpoint($bp-small min-width) {
       width: 47%;

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -35,6 +35,10 @@
     text-transform: uppercase;
   }
 
+  .ama__article-stub__title {
+    padding: 0;
+  }
+
   .ama__tools {
     padding: 0;
   }
@@ -55,11 +59,14 @@
     }
 
     @include breakpoint($bp-small) {
-      display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
-      grid-template-rows: auto auto;
-      grid-column-gap: $gutter;
-      grid-row-gap: $gutter;
+      .grid-container {
+        @include gutter($margin-top-full...);
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-rows: auto auto;
+        grid-column-gap: $gutter;
+        grid-row-gap: $gutter;
+      }
     }
   }
 
@@ -77,18 +84,14 @@
 
   &__article-stub-two-up {
     @include breakpoint($bp-small) {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-template-rows: auto auto;
-      grid-column-gap: $gutter;
-      grid-row-gap: $gutter;
 
-      .ama__content-grouping-header {
-        grid-row: 1 / 1;
-      }
-
-      .ama__article-stub {
-        grid-row: 2 / 2;
+      .grid-container {
+        @include gutter($margin-top-full...);
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: auto auto;
+        grid-column-gap: $gutter;
+        grid-row-gap: $gutter;
       }
     }
   }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- EWL-5649: A1 | Article Stub List custom block theming](https://issues.ama-assn.org/browse/EWL-5649)

## Description
Update related article stubs to work in D8

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-category
- [ ] compare this page to https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-category
- [ ] observe it looks the same
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5649-article-stub-custom-block/html_report/index.html).

## Relevant Screenshots/GIFs
<img width="1269" alt="screen shot 2018-09-12 at 11 55 32 am" src="https://user-images.githubusercontent.com/2271747/45440760-ca401080-b682-11e8-999f-183317db864e.png">


## Remaining Tasks
N/A

## Additional Notes
This PR is being used in a D8 PR 
https://github.com/AmericanMedicalAssociation/ama-d8/pull/729

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
