### PR TITLE
EWL-5649 Fixes article stub list margin issue making the first image larger

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -12,12 +12,12 @@
   }
 
   .ama__article-stub {
-    @include gutter($padding-left-full...);
+    @include gutter($margin-left-full...);
     @include gutter($margin-bottom-full...);
     width: 100%;
 
     &:first-child {
-      padding-left: 0;
+      margin-left: 0;
     }
 
     @include breakpoint($bp-small min-width) {

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-featured-content-as-carousel.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-featured-content-as-carousel.scss
@@ -2,7 +2,7 @@
   background-color: $gray-7;
 
   .ama__article-stub {
-    padding: 0 2%;
+    margin: 0 28px;
   }
 
   .slick-dots {

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-featured-content-as-carousel.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-featured-content-as-carousel.scss
@@ -2,7 +2,7 @@
   background-color: $gray-7;
 
   .ama__article-stub {
-    margin: 0 28px;
+    padding: 0 2%;
   }
 
   .slick-dots {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5649: Article Stub List theming](https://issues.ama-assn.org/browse/EWL-5649)

## Description
Fix the image sizes in the article stub list so that they all are the same size

## To Test
- [ ] 'gulp serve'
- [ ] visit http://localhost:3000/?p=pages-category
- [ ] observe the article stub list now all have the same images size
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5649-article-stub-list-margin/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1297" alt="screen shot 2018-09-14 at 11 10 52 am" src="https://user-images.githubusercontent.com/2271747/45562061-dd7fe700-b80e-11e8-9a40-aa6742587da7.png">


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
