### PR TITLE
EWL-5769: A1 | Resource inline promo linking

### DIFF
--- a/styleguide/source/_patterns/03-organisms/resource-tabs.json
+++ b/styleguide/source/_patterns/03-organisms/resource-tabs.json
@@ -65,7 +65,7 @@
           "paragraph": {
             "text": "Example text for the article link, lorem ipsum dolor sit amet"
           },
-          "resourceLink": "media-3"
+          "resourceLink": "media"
         },
         "tags": [
           {
@@ -253,7 +253,7 @@
     },
     {
       "tabTitle": "Related Links",
-      "tabId": "related-links",
+      "tabId": "related_links",
       "tabContent": {
         "relatedLinkGroups": [
           {

--- a/styleguide/source/_patterns/03-organisms/resource-tabs.twig
+++ b/styleguide/source/_patterns/03-organisms/resource-tabs.twig
@@ -81,9 +81,9 @@
       {% set membership = tabs[2].tabContent.membership %}
       {% include '@molecules/membership/membership.twig' %}
     </section>
-    <section id="related-links">
+    <section id="related_links">
       {% for group in tabs[3].tabContent.relatedLinkGroups %}
-        <div id="ama__resource--related-links-{{ loop.index }}">
+        <div id="ama__resource--related_links-{{ loop.index }}">
           {% set heading = group.heading %}
           {% include '@atoms/heading/heading.twig' %}
 

--- a/styleguide/source/_patterns/05-pages/resource.json
+++ b/styleguide/source/_patterns/05-pages/resource.json
@@ -1017,7 +1017,7 @@
           "paragraph": {
             "text": "Example text for the article link, lorem ipsum dolor sit amet"
           },
-          "resourceLink": "media-3"
+          "resourceLink": "media"
         },
         "tags": [
           {
@@ -1205,7 +1205,7 @@
     },
     {
       "tabTitle": "Related Links",
-      "tabId": "related-links",
+      "tabId": "related_links",
       "tabContent": {
         "relatedLinkGroups": [
           {

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -27,8 +27,14 @@
 
       // Prevent jump onclick
       $('.ui-tabs-anchor').on('click', function (e) {
-        e.preventDefault();
-        return false;
+        // Use e.currentTarget because e.target is sometimes the icon div
+        var url = new URL(e.currentTarget.href);
+        // Store window y location so we can restore after changing the hash
+        // which would otherwise cause the window to jump down
+        var windowScrollY = window.scrollY;
+        // Update window hash location, and restore to previous y-position
+        window.location.hash = url.hash;
+        window.scroll({top: windowScrollY});
       });
 
       //Simulate click event on actual simpleTabs tab from mobile drop down.

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -27,13 +27,12 @@
 
       // Prevent jump onclick
       $('.ui-tabs-anchor').on('click', function (e) {
-        // Use e.currentTarget because e.target is sometimes the icon div
-        var url = new URL(e.currentTarget.href);
         // Store window y location so we can restore after changing the hash
-        // which would otherwise cause the window to jump down
+        // which would otherwise cause the window to jump down.
         var windowScrollY = window.scrollY;
-        // Update window hash location, and restore to previous y-position
-        window.location.hash = url.hash;
+        // Update window hash location, and restore to previous y-position.
+        // Use currentTarget because target is sometimes the icon div.
+        window.location.hash = e.currentTarget.hash;
         window.scroll({top: windowScrollY});
       });
 

--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -92,7 +92,7 @@ li {
     background-image: url('../icons/svg/icon-resources-nav-downloads.svg');
   }
 
-  & > [href='#related-links'] .ama__resource-tabs__nav__icon {
+  & > [href='#related_links'] .ama__resource-tabs__nav__icon {
     background-image: url('../icons/svg/icon-resources-nav-relatedlinks.svg');
   }
 
@@ -127,7 +127,7 @@ li {
       background-image: url('../icons/svg/icon-resources-nav-downloads-active.svg');
     }
 
-    & > [href='#related-links'] .ama__resource-tabs__nav__icon {
+    & > [href='#related_links'] .ama__resource-tabs__nav__icon {
       background-image: url('../icons/svg/icon-resources-nav-relatedlinks-active.svg');
     }
 
@@ -195,7 +195,7 @@ li {
   border-bottom: solid 1px $gray-50;
 }
 
-section#related-links ul {
+section#related_links ul {
   list-style-type: none;
   li {
     margin: 0;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
N/A

**Jira Ticket**
- [EWL-5769: A1 | Resource inline promo linking](https://issues.ama-assn.org/browse/EWL-5769)

## Description
1. Changed `#related-links` to `#related_links` everywhere that it was referenced.
2. Modified `.ui-tabs-anchor` click handler to modify `window.location.hash` but preserve the window scroll position. This was done to correct an issue with link + tab collision which would cause the inline promo links to "fail" after being clicked once. See more explanation in notes.


## To Test
- [ ] Go to the (Resource Page)[http://localhost:3000/patterns/05-pages-resource/05-pages-resource.html]
- [ ] Click on any of the tabs and see that the location hash updates, but the window scroll position is unaffected.
- [ ] Click on one of the resource promo links, see that the appropriate tab is opened and the hash is updated.
- [ ] Click on a different tab.
- [ ] Click on the same resource promo link as before, see that the link works as it did the first time.
- [ ] Did you test in IE 11?

Note: It seems like all the tab stuff functions a little weirdly on the framed version of the page. Visiting http://localhost:3000/patterns/05-pages-resource/05-pages-resource.html directly seems to be smoother.

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5769-resource-inline-promo-linking/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Previously, if you followed these steps:
- Visit Resource Page with inline promo link
- Click inline promo link to open associated tab (hash changes)
- Click a different tab (hash stays the same, but tab changes)
- Click inline promo link *again*, this time it doesn't do anything, because the window is still at the same hash as the first time you clicked this link.

Hopefully that makes sense.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
