### PR TITLE
EWL-5821: Homepage promo link styling.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -25,6 +25,12 @@
       @include gutter($margin-top-full...);
       @include gutter($margin-right-half...);
       width: auto;
+
+      a {
+        font-weight: inherit;
+        text-decoration: inherit;
+        color: inherit;
+      }
     }
 
     &__feature-heading {

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -21,16 +21,11 @@
     background: $gray-7;
     color: $gray-64;
 
-    button {
+    // Right now the style guide uses `buttons`, but eventually we want to switch these to `a` elements.
+    button, a {
       @include gutter($margin-top-full...);
       @include gutter($margin-right-half...);
       width: auto;
-
-      a {
-        font-weight: inherit;
-        text-decoration: inherit;
-        color: inherit;
-      }
     }
 
     &__feature-heading {

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -63,6 +63,12 @@
     button {
       display: block;
       margin: $gutter auto;
+
+      a {
+        font-weight: inherit;
+        text-decoration: inherit;
+        color: inherit;
+      }
     }
 
     @include breakpoint($bp-small){

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -60,20 +60,15 @@
       font-weight: normal;
     }
 
-    button {
+    // Right now the style guide uses `buttons`, but eventually we want to switch these to `a` elements.
+    button, a {
       display: block;
       margin: $gutter auto;
-
-      a {
-        font-weight: inherit;
-        text-decoration: inherit;
-        color: inherit;
-      }
     }
 
     @include breakpoint($bp-small){
-      button {
-        display: inline;
+      button, a {
+        display: inline-block;
         margin: 0;
       }
     }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5821: A1 | Homepage Promos block theming](https://issues.ama-assn.org/browse/EWL-5821)

## Description
The anchor tags are needed to provide a link, but they did not inherit the button styling. The style guide only shows a button and not a contained anchor.

## To Test
- This should not impact any existing styling.
- Go to /ama-style-guide-2/?p=pages-homepage

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5821-homepage-promo-links/html_report/index.html).

## Relevant Screenshots/GIFs

Example from styleguide which will not change appearance.

![example](https://user-images.githubusercontent.com/397902/45769694-fbca5600-bc05-11e8-95b9-b0c93bc3abe6.jpg)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
