### PR TITLE
EWL-5651  Fixes partner promo button

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -11,7 +11,8 @@
     line-height: 1em;
   }
 
-  button {
+  button,
+  .ama__button {
     @include gutter($margin-top-half...);
     width: 100%;
   }

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -66,6 +66,10 @@
         grid-template-rows: auto auto;
         grid-column-gap: $gutter;
         grid-row-gap: $gutter;
+
+        .ama__article-stub {
+          width: 100%;
+        }
       }
     }
   }
@@ -92,6 +96,10 @@
         grid-template-rows: auto auto;
         grid-column-gap: $gutter;
         grid-row-gap: $gutter;
+
+        .ama__article-stub {
+          width: 100%;
+        }
       }
     }
   }


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-5651: A1 | Partner Promo Theming](https://issues.ama-assn.org/browse/EWL-5651)


## Description:
Fix the partner promo submit buttons for category and subcategory pages

## To Test:
- switch you D8 branch to `feature/EWL-EWL-5651-partner-promo-theming`
 -  enable local SG2 in your local.yml
- `drush @one.local cim`
- add a custom promo partner block http://ama-one.local/block/add/partner_promo
- visit http://ama-one.local/about-ama/advocacy
- edit layout
-  Via layout builder add a new two column template 
- place new custom promo block
- observe how it looks like the partner promo block on https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-category


## Automated Test:
n/a

## Style Guide:
https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-category

## Relevant Screenshots/GIFs:
<img width="288" alt="screen shot 2018-10-01 at 10 11 47 am" src="https://user-images.githubusercontent.com/2271747/46297491-6f535800-c562-11e8-9972-c87f6222132c.png">


## Additional Notes:
This PR is a dependency of https://github.com/AmericanMedicalAssociation/ama-d8/pull/749

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
