### PR TITLE
[EWL-5811] Member Feature Tweaks

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -33,10 +33,10 @@
       .ama__hero-story {
         grid-column-start: 1;
         grid-column-end: 4;
-        justify-content: flex-end;
+        justify-content: flex-start;
       }
       .ama__hero-story__media {
-        margin-right: $gutter*-2;
+        margin-right: $gutter*-1;
 
         img {
           height: 100%;


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5811: A1 |Member Feature Custom Block Theming](https://issues.ama-assn.org/browse/EWL-5811)

## Description
This work updates styles for vertical spacing of member hero and prevents overlap of main media image with side rail images.

### Dependencies
[EWL-5811: Member Feature Block Theming #814](https://github.com/AmericanMedicalAssociation/ama-d8/pull/814)

## To Test
- Pull `bugfix/EWL-5811-member-feature-theming` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Check homepage and confirm member feature block is top aligned and has proper overlap.
- Follow instructions in dependent PR: [EWL-5811: Member Feature Block Theming #814](https://github.com/AmericanMedicalAssociation/ama-d8/pull/814). Confirm updated styling does not affect other homepage components negatively.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5811-member-feature-theming/html_report/index.html).


## Relevant Screenshots/GIFs
![image](https://user-images.githubusercontent.com/4438120/46302707-6ae16c00-c56f-11e8-8377-924208292298.png)


## Remaining Tasks
N/A


## Additional Notes
Is part of work on ama-d8 pull request: [EWL-5811: Member Feature Block Theming #814](https://github.com/AmericanMedicalAssociation/ama-d8/pull/814).
