### PR TITLE
EWL-5816 - Updates footer subscription portion to accommodate extra D8 divs

### DIFF
--- a/styleguide/source/_patterns/03-organisms/footer/footer.twig
+++ b/styleguide/source/_patterns/03-organisms/footer/footer.twig
@@ -32,15 +32,17 @@
         </div>
       {% endif %}
     </div>
+  </div>
 
+  <div class="container">
     {% block products %}
       <div class="ama__footer__menu-products">
         <ul>
-        {% for link in menus.products %}
-          <li>
-            {% include "@atoms/link/link.twig" %}
-          </li>
-        {% endfor %}
+          {% for link in menus.products %}
+            <li>
+              {% include "@atoms/link/link.twig" %}
+            </li>
+          {% endfor %}
         </ul>
       </div>
     {% endblock %}

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -46,7 +46,8 @@
       flex: 1;
     }
 
-    .ama__subscribe-promo__form {
+    .ama__subscribe-promo__form,
+    .ama__subscribe-promo__form form {
       display: flex;
       flex-direction: column;
 

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -141,12 +141,6 @@
     }
   }
 
-  .container > div:not(:last-child) {
-    @include gutter($padding-bottom-half...);
-    @include gutter($margin-bottom-half...);
-    border-bottom: 1px solid $gray-50;
-  }
-
   @include breakpoint($bp-small) {
     > .container {
       display: flex;
@@ -172,8 +166,11 @@
     }
 
     &__menu-products {
+      @include gutter($padding-top-half...);
+      @include gutter($margin-top-half...);
       order: 4;
       flex: 1 100%;
+      border-top: 1px solid $gray-50;
     }
 
     &__mission {

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -27,13 +27,6 @@
     list-style-type: none;
   }
 
-  .ama__form-group {
-    flex-grow: 2;
-    input:not(:focus) {
-      font-style: italic;
-    }
-  }
-
   .ama__social-share {
     a {
       height: 50px;
@@ -69,12 +62,20 @@
     }
   }
 
-  .ama__subscribe-promo--wide .ama__subscribe-promo__form .form-actions {
-    margin: 0;
-  }
+  .ama__subscribe-promo--wide .ama__subscribe-promo__form {
+    .form-actions {
+      margin: 0;
+    }
 
-  .ama__subscribe-promo--wide .ama__subscribe-promo__form .ama__button {
-    @extend %ama__button;
+     .ama__button {
+      @extend %ama__button;
+      text-transform: uppercase;
+    }
+
+    .ama__form-group {
+      display: flex;
+      flex-grow: 2;
+    }
   }
 
   &__menu-utility {

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -69,6 +69,14 @@
     }
   }
 
+  .ama__subscribe-promo--wide .ama__subscribe-promo__form .form-actions {
+    margin: 0;
+  }
+
+  .ama__subscribe-promo--wide .ama__subscribe-promo__form .ama__button {
+    @extend %ama__button;
+  }
+
   &__menu-utility {
     margin-top: 0;
     padding: $gutter / 2 0;


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-5816: Ticket Title](https://issues.ama-assn.org/browse/EWL-5816)


## Description:
Theme global footer. 

This PR is dependent on https://github.com/AmericanMedicalAssociation/ama-d8/pull/841

## To Test:
- pull SG2 branch `feature\EWL-5816-global-footer-theme`
- enable local SG2 for D8 in local.yml
- `drush @one.local cim -y && drush @one.local cr`
- load any page in D8
- scroll to bottom of page
- observe the footer matches https://americanmedicalassociation.github.io/ama-style-guide-2/?p=organisms-footer


## Automated Test:
n/a

## Style Guide:
This PR is dependent on SG2 branch `feature\EWL-5816-global-footer-theme`
For reference to the footer:
https://americanmedicalassociation.github.io/ama-style-guide-2/?p=organisms-footer

## Relevant Screenshots/GIFs:
<img width="1355" alt="screen shot 2018-10-02 at 5 32 17 pm" src="https://user-images.githubusercontent.com/2271747/46380752-220dde00-c669-11e8-9b66-2c437e11ac5b.png">


## Additional Notes:
n/a


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
