### PR TITLE
[EWL-5928] Correct Resource Tab Scroll To Interaction

### DIFF
--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -43,10 +43,10 @@
       });
 
       // Scroll to when there is no has change on resource page tab links
-      $('.ama____page--resources__page-content a[href^="#"]').on('click',function (e) {
-        if(lastHash == window.location.hash){
+      $('.ama____page--resources__page-content a[href^="#"]').on('click', function (e) {
+        if (lastHash == window.location.hash) {
           var hash = window.location.hash;
-          smoothScroll($('.ama__resource-tabs__nav'),$('.ama__resource-tabs__nav a[href="'+hash+'"]'));
+          smoothScroll($('.ama__resource-tabs__nav'), $('.ama__resource-tabs__nav a[href="' + hash + '"]'));
         }
       });
 

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -6,6 +6,7 @@
     attach: function (context, settings) {
       var defaultActiveTab = 0;
       var viewportWidth = window.innerWidth;
+      var lastHash = null;
       if (viewportWidth >= 600 && $('.ama__resource-tabs').length > 0) {
         defaultActiveTab = 1;
       }
@@ -21,6 +22,11 @@
           var widget = $(this).data('ui-tabs');
           $(window).on('hashchange', function () {
             widget.option('active', widget._getIndex(location.hash));
+            lastHash = location.hash;
+
+            // Scroll to top of ui tabs navigation
+            smoothScroll($(widget.element), $(widget.active[0]));
+            return false;
           });
         }
       });
@@ -36,11 +42,36 @@
         window.scroll({top: windowScrollY});
       });
 
+      // Scroll to when there is no has change on resource page tab links
+      $('.ama____page--resources__page-content a[href^="#"]').on('click',function (e) {
+        if(lastHash == window.location.hash){
+          var hash = window.location.hash;
+          smoothScroll($('.ama__resource-tabs__nav'),$('.ama__resource-tabs__nav a[href="'+hash+'"]'));
+        }
+      });
+
       //Simulate click event on actual simpleTabs tab from mobile drop down.
       $('.ama__tabs-navigation--mobile select').on("selectmenuchange", function (event, ui) {
         var selectedValue = ui.item.value;
         $('a[href="#' + selectedValue + '"]').click();
       });
+
+      /*
+       * This function animates the browser scroll action with attention to keyboard only accessibility concerns
+       *
+       * @param {jQuery Object] $tabNav
+       * @param {jQuery Object] $target
+       */
+      function smoothScroll($tabNav, $target) {
+        var navCoords = $tabNav[0].getBoundingClientRect();
+        $('html,body').animate({
+          scrollTop: window.scrollY + navCoords.top
+        }, 850, function () {
+          // update focus for keyboard only navigation
+          $target.attr('tabindex', '-1');
+          $target.focus();
+        });
+      }
     }
   };
 })(jQuery, Drupal);


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5928: SG2 | Correct Resource Tab Scroll To Interaction](https://issues.ama-assn.org/browse/EWL-5928)

## Description
This work implements smooth scrolling for resource page anchor links.

## To Test
- Pull `bugfix/EWL-5928-resource-tab-scroll-to` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Navigate to the [resource page](http://localhost:3000/?p=pages-resource), scroll down a little and click on either inline resource promo link or purple in body text link and confirm viewport scrolls to top of tab navigation.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5928-resource-tab-scroll-to/html_report/index.html).


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A
