### PR TITLE
HOTFIX: Fixes global usermenu links being unclickable

### DIFF
--- a/styleguide/source/assets/js/sign-in-dropdown.js
+++ b/styleguide/source/assets/js/sign-in-dropdown.js
@@ -11,7 +11,6 @@
         parentElement.unbind('click').click(function(e){
           e.stopPropagation();
           $(menuElement).slideToggle();
-          return false;
         });
 
         $(document).click(function(e) {


### PR DESCRIPTION
## Description
Fixes usermenu links being unclickable

## To Test
- [ ] `drush @one.local cim -y && drush @one.local cr`
- [ ] open any page click on the usermenu logout link
- [ ] observe you are logged out


## Visual Regressions

n/a

## Relevant Screenshots/GIFs
n/a

## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
