### PR TITLE
Rewrite annotations focused on Category and Subcategory pages

### DIFF
--- a/styleguide/source/_annotations/02_subcategory-exploration.md
+++ b/styleguide/source/_annotations/02_subcategory-exploration.md
@@ -1,0 +1,11 @@
+---
+el: .ama__subcategory-exploration
+title: Subcategory Exploration
+---
+An inner menu used for quick links to subcategory pages within the parent category.
+
+Fields:
+
+* Subcategory name
+
+* URL to subcategory page

--- a/styleguide/source/_annotations/03_category-hero.md
+++ b/styleguide/source/_annotations/03_category-hero.md
@@ -1,0 +1,13 @@
+---
+el: .ama__category-hero
+title: Hero article on Category page
+---
+A featured position for a story on a Category page. Receives a larger image treatment and a headline styled in white on a purple background. There can only be 1 Hero article per Category page.
+
+Fields:
+
+* Image: 3:2 ratio; 1600 x 1200 pixels
+
+* Article title (H2)
+
+* URL to article

--- a/styleguide/source/_annotations/03_subcategory-hero.md
+++ b/styleguide/source/_annotations/03_subcategory-hero.md
@@ -1,0 +1,17 @@
+---
+el: .ama__subcategory-hero
+title: Hero article on Subcategory page
+---
+A featured position for a story on a Subcategory page. Receives a larger image treatment than an article stub and has the headline and other information floated to the right centered in the container. There can only be 1 Hero article per Subcategory page.
+
+Fields:
+
+* Image (optional): 3:2 ratio; 800 x 600 pixels
+
+* Subcategory name and link
+
+* Article name and link
+
+* Date published
+
+* Estimated read time: plain text

--- a/styleguide/source/_annotations/04_search__field--in-body.md
+++ b/styleguide/source/_annotations/04_search__field--in-body.md
@@ -1,0 +1,5 @@
+---
+el: .ama__search__field--in-body
+title: In-body search field
+---
+Search field for the subcategory page. Visitors can search for articles within the subcategory or for articles tagged with topics that appear below the search field.

--- a/styleguide/source/_annotations/05_display-switch-menu.md
+++ b/styleguide/source/_annotations/05_display-switch-menu.md
@@ -1,0 +1,9 @@
+---
+el: .ama__display-switch-menu
+title: Display Switch Menu
+---
+The display switch menu are taxonomy terms that an editor can add to a subcategory page. Adding terms to the page means that articles that are tagged with that term will appear in the subcategory index. 
+
+Fields:
+
+* Taxonomy terms

--- a/styleguide/source/_annotations/06_article-stub.md
+++ b/styleguide/source/_annotations/06_article-stub.md
@@ -1,0 +1,19 @@
+---
+el: .ama__article-stub
+title: Article stub
+---
+A teaser for an article. Includes an image, the subcategory under which the article lives, the article title, optional summary text (depends on the template where the stub appears), date published and estimated read time.
+
+Fields:
+
+* Image (optional): 3:2 ratio; 800 x 600 pixels
+
+* Subcategory name and link
+
+* Article name and link
+
+* Summary / teaser text (optional): only appears in certain places on some templates
+
+* Date published
+
+* Estimated read time: plain text

--- a/styleguide/source/_annotations/07_article-stub-list.md
+++ b/styleguide/source/_annotations/07_article-stub-list.md
@@ -1,0 +1,17 @@
+---
+el: .ama__category-page-article-stub
+title: Article Stub List
+---
+The Article Stub List is a list of related page teasers grouped under a descriptive heading.
+
+Fields:
+
+* Content grouping header (required)
+
+    * Label given to provide context for the article stubs.
+
+    * Plain text field
+
+* Article stubs (optional)
+
+    * see [Article Stub](/06_article-stub.md) for details

--- a/styleguide/source/_annotations/08_subcategory-featured-content-container.md
+++ b/styleguide/source/_annotations/08_subcategory-featured-content-container.md
@@ -1,0 +1,5 @@
+---
+el: .ama__subcategory-featured-content
+title: Subcategory Feature Content
+---
+Highlight content within a subcategory with this featured content area. Uses the article stub fields.

--- a/styleguide/source/_annotations/09_subcategory-featured-content-as-carousel.md
+++ b/styleguide/source/_annotations/09_subcategory-featured-content-as-carousel.md
@@ -1,0 +1,5 @@
+---
+el: .ama__subcategory-featured-content-as-carousel
+title: Subcategory Featured Content as Carousel
+---
+A carousel display of article stubs to feature. Highlight content with a subcategory on the category page.

--- a/styleguide/source/_annotations/10_category__article-stub-three-up.md
+++ b/styleguide/source/_annotations/10_category__article-stub-three-up.md
@@ -1,0 +1,5 @@
+---
+el: .ama__category__article-stub-three-up
+title: Page Section - Two Column - Right rail
+---
+A split layout where 75% is dedicated to article stubs and 25% is for the JAMA sidebar.

--- a/styleguide/source/_annotations/11_category__article-stub-two-up.md
+++ b/styleguide/source/_annotations/11_category__article-stub-two-up.md
@@ -1,0 +1,5 @@
+---
+el: .ama__category__article-stub-two-up
+title: Page Section - Two Column - Split layout
+---
+An even split layout where each space fills 50% of the container for two article stubs.

--- a/styleguide/source/_annotations/12_category-index.md
+++ b/styleguide/source/_annotations/12_category-index.md
@@ -1,0 +1,9 @@
+---
+el: .ama__category-index
+title: Category Index
+---
+A listing display of all the pages within the category. Pages are listed reverse chronologically where the articles published most recently appear first.
+
+There is space for two ad promos in the right rail. One for a partner promo, one for a subscribe promo.
+
+Promos are added as blocks to the page. 

--- a/styleguide/source/_annotations/12_subcategory-index__stubs.md
+++ b/styleguide/source/_annotations/12_subcategory-index__stubs.md
@@ -1,0 +1,19 @@
+---
+el: .ama__subcategory-index__stubs
+title: Subcategory Index
+---
+A listing display of all the pages within the subcategory. Pages are listed reverse chronologically where the articles published most recently appear first.
+
+Visitors who toggle the display switches will affect the articles that appear in the listing.
+
+Fields:
+
+* Image (optional): 566 x 370 pixels
+
+* Subcategory name
+
+* Article title
+
+* Summary / description
+
+* Article URL

--- a/styleguide/source/_annotations/13_partner-promo.md
+++ b/styleguide/source/_annotations/13_partner-promo.md
@@ -1,0 +1,19 @@
+---
+el: .ama__partner-promo
+title: Partner Promo
+---
+Promote an AMA partner.
+
+Fields:
+
+* Image: 3:2 ratio; 800 x 600 pixels
+
+* Heading: plain text
+
+* Description: plain text
+
+* Call to action button
+
+    * Button text
+
+    * URL

--- a/styleguide/source/_annotations/13_subscribe-promo.md
+++ b/styleguide/source/_annotations/13_subscribe-promo.md
@@ -1,0 +1,21 @@
+---
+el: .ama__subscribe-promo
+title: Subscribe Promo
+---
+A promo to entice people to subscribe to AMA.
+
+Fields:
+
+* Subject title: plain text
+
+* Heading: plain text
+
+* Description: plain text
+
+* Form field for visitor to enter email address
+
+* Submit button
+
+    * Button text
+
+    * URL

--- a/styleguide/source/_patterns/05-pages/category.md
+++ b/styleguide/source/_patterns/05-pages/category.md
@@ -1,1 +1,52 @@
 [EWL-5310](https://issues.ama-assn.org/browse/EWL-5310)
+
+The Category page aggregates content that lives within the subcategory pages under a category based on taxonomical hierarchy.
+
+The layout of the Category page has some level of customization as noted in the Editor's Choice section below.The following format is standard:
+
+1 Hero custom block
+
+1 Topics, Tools, and Resources list to the right (optional)
+
+1 Membership call to action under the Tools list (optional)
+
+---
+Editor's choice:
+
+* AMA Page Section Two Column Split layout:
+
+    * JAMA Component block
+
+    * Article Stub List custom block
+
+* AMA Page Section One Column layout:
+
+    * Article Stub List custom block
+
+        * use to show 4+ articles within a section
+
+    * Subcategory Featured Content block
+
+        * use to highlight a max. of three articles
+
+    * Subcategory Featured Content carousel
+
+        * use to feature 4+ articles within a carousel
+
+* AMA Page Section Two Column Right rail layout:
+
+    * Article Stub List custom block on left (3 articles per row, >3 extend to second line)
+
+    * JAMA Component block on right
+
+---
+
+Category Listing View - left
+
+Partner Promo - right rail
+
+Subscribe Promo - right rail
+
+Subcategory Exploration View with Images
+
+  * Images (required): 2:2 ratio; 180 x 180 pixels


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-6077: Annotation updates: Category/subcategory](https://issues.ama-assn.org/browse/EWL-6077)

## Description
Added new annotations specific to the components found on the Category and Subcategory page templates. 
Added a new description for the Category page.

## To Test
- [ ] Launch local styleguide
- [ ] Go to Pages > Category
- [ ] Click the gear icon in the top right corner then "Show pattern info"
- [ ] Confirm placement of annotations
- [ ] Go to Pages > Subcategory
- [ ] Click the gear icon in the top right corner then "Show pattern info"
- [ ] Confirm placement of annotations



## Remaining Tasks
Finishing up the rest of the page templates. 


## Additional Notes
- Ordering of the annotations will not appear sequentially. That's because the same classes are used in a different sequence on other page templates. That's just how it is. 
- I don't know how to do internal links in to another annotation in pattern lab. It comes up on the Category page where I say refer to the Article Sub annotation for details.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
