### PR TITLE
[EWL-5769] Resource inline promo linking

### DIFF
--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -6,7 +6,6 @@
     attach: function (context, settings) {
       var defaultActiveTab = 0;
       var viewportWidth = window.innerWidth;
-      var lastHash = null;
       if (viewportWidth >= 600 && $('.ama__resource-tabs').length > 0) {
         defaultActiveTab = 1;
       }
@@ -15,40 +14,11 @@
         active: defaultActiveTab
       });
 
-      //Resource page specific tags
-      $(".ama__resource-tabs").tabs({
-        active: defaultActiveTab,
-        create: function () {
-          var widget = $(this).data('ui-tabs');
-          $(window).on('hashchange', function () {
-            widget.option('active', widget._getIndex(location.hash));
-            lastHash = location.hash;
-
-            // Scroll to top of ui tabs navigation
-            smoothScroll($(widget.element), $(widget.active[0]));
-            return false;
-          });
-        }
-      });
-
       // Prevent jump onclick
       $('.ui-tabs-anchor').on('click', function (e) {
-        // Store window y location so we can restore after changing the hash
-        // which would otherwise cause the window to jump down.
-        var windowScrollY = window.scrollY;
-        // Update window hash location, and restore to previous y-position.
-        // Use currentTarget because target is sometimes the icon div.
-        window.location.hash = e.currentTarget.hash;
-        window.scroll({top: windowScrollY});
+        return false;
       });
 
-      // Scroll to when there is no has change on resource page tab links
-      $('.ama____page--resources__page-content a[href^="#"]').on('click', function (e) {
-        if (lastHash == window.location.hash) {
-          var hash = window.location.hash;
-          smoothScroll($('.ama__resource-tabs__nav'), $('.ama__resource-tabs__nav a[href="' + hash + '"]'));
-        }
-      });
 
       //Simulate click event on actual simpleTabs tab from mobile drop down.
       $('.ama__tabs-navigation--mobile select').on("selectmenuchange", function (event, ui) {
@@ -56,11 +26,20 @@
         $('a[href="#' + selectedValue + '"]').click();
       });
 
+      // When clicking an inline resource page link referencing a tab, open referenced tab.
+      $('.ama__resource-link--inline, .ama__page--resource__resource-link').on('click', function (e) {
+        var $tabs = $('.ama__resource-tabs');
+        var $clickedObj = $(this);
+        var linkHash = this.getAttribute("href");
+        switchTabs($tabs, linkHash);
+        return false;
+      });
+
       /*
        * This function animates the browser scroll action with attention to keyboard only accessibility concerns
        *
-       * @param {jQuery Object] $tabNav
-       * @param {jQuery Object] $target
+       * @param {jQuery Object} $tabNav
+       * @param {jQuery Object} $target
        */
       function smoothScroll($tabNav, $target) {
         var navCoords = $tabNav[0].getBoundingClientRect();
@@ -71,6 +50,23 @@
           $target.attr('tabindex', '-1');
           $target.focus();
         });
+      }
+
+      /*
+       * This function opens referenced tabs from inline links
+       *
+       * @param {jQuery Object} $tabObj The element which has the .tab() function attached.
+       * @param {string} linkHash
+       */
+      function switchTabs($tabObj, linkHash) {
+        var widget = $tabObj.data('ui-tabs');
+        var tabIndex = widget._getIndex(linkHash);
+
+        $tabObj.tabs({
+          active: tabIndex
+        });
+        // Scroll to top of ui tabs navigation
+        smoothScroll($tabObj, $(widget.active[0]));
       }
     }
   };

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -16,6 +16,13 @@
 
       // Prevent jump onclick
       $('.ui-tabs-anchor').on('click', function (e) {
+        // Store window y location so we can restore after changing the hash
+        // which would otherwise cause the window to jump down.
+        var windowScrollY = window.scrollY;
+        // Update window hash location, and restore to previous y-position.
+        // Use currentTarget because target is sometimes the icon div.
+        window.location.hash = e.currentTarget.hash;
+        window.scroll({top: windowScrollY});
         return false;
       });
 
@@ -28,6 +35,7 @@
 
       // When clicking an inline resource page link referencing a tab, open referenced tab.
       $('.ama__resource-link--inline, .ama__page--resource__resource-link').on('click', function (e) {
+        e.preventDefault();
         var $tabs = $('.ama__resource-tabs');
         var $clickedObj = $(this);
         var linkHash = this.getAttribute("href");
@@ -50,6 +58,7 @@
           $target.attr('tabindex', '-1');
           $target.focus();
         });
+        return false;
       }
 
       /*
@@ -67,6 +76,7 @@
         });
         // Scroll to top of ui tabs navigation
         smoothScroll($tabObj, $(widget.active[0]));
+        return false;
       }
     }
   };

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -23,6 +23,7 @@
         // Use currentTarget because target is sometimes the icon div.
         window.location.hash = e.currentTarget.hash;
         window.scroll({top: windowScrollY});
+        // Stop bubbling and default actions
         return false;
       });
 
@@ -37,9 +38,9 @@
       $('.ama__resource-link--inline, .ama__page--resource__resource-link').on('click', function (e) {
         e.preventDefault();
         var $tabs = $('.ama__resource-tabs');
-        var $clickedObj = $(this);
         var linkHash = this.getAttribute("href");
         switchTabs($tabs, linkHash);
+        // Stop bubbling and default actions
         return false;
       });
 
@@ -58,6 +59,7 @@
           $target.attr('tabindex', '-1');
           $target.focus();
         });
+        // Stop bubbling and default actions
         return false;
       }
 
@@ -76,6 +78,7 @@
         });
         // Scroll to top of ui tabs navigation
         smoothScroll($tabObj, $(widget.active[0]));
+        // Stop bubbling and default actions
         return false;
       }
     }

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -10,7 +10,7 @@
         defaultActiveTab = 1;
       }
 
-      $(".ama__tabs").tabs({
+      $(".ama__tabs, .ama__resource-tabs").tabs({
         active: defaultActiveTab
       });
 


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5769: A1 | Resource inline promo linking](https://issues.ama-assn.org/browse/EWL-5769)

## Description
This work updates tab.js to properly function in D8 while also removing complexity.

### Dependencies
[EWL-5769: A1 | Resource inline promo linking #769](https://github.com/AmericanMedicalAssociation/ama-d8/pull/769)

## To Test
- Pull `bugfix/EWL-5769-resource-page-inline-linking` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Check resource page and confirm inline links open tabs as before.
- Follow instructions in dependent PR: [EWL-5769: A1 | Resource inline promo linking #769](https://github.com/AmericanMedicalAssociation/ama-d8/pull/769).

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5769-resource-page-inline-linking/html_report/index.html).


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
Is part of work on ama-d8 pull request: [EWL-5769: A1 | Resource inline promo linking #769](https://github.com/AmericanMedicalAssociation/ama-d8/pull/814).
