### PR TITLE
EWL-6122: Resource page promo button color.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -148,8 +148,13 @@ li {
 .ama__resource-tabs__content {
   position: relative;
 
-  a:not(.ama__tool) {
+  a:not(.ama__tool):not(.ama__button) {
     @extend %ama__link--no-underline;
+  }
+
+  // To override the `.ui-widget-content a` rule that is part of jquery UI.
+  .ui-widget-content a.ama__button {
+    color: $white;
   }
 }
 


### PR DESCRIPTION
**Jira Ticket**
- [EWL-6122: Text in promo should be white, not black](https://issues.ama-assn.org/browse/EWL-6122)

## Description
The link selector shouldn't include those that are treated as buttons. The jQuery UI used here for the tabs also has color styling that need to be overridden.


## To Test
- Create or edit a resource page and add a membership promo to one of the tab sections
- View the resource page
- Check the color of the membership promo button text

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6122-resource-page-promo-text-color/html_report/index.html).

## Relevant Screenshots/GIFs
Before:
![example](https://user-images.githubusercontent.com/397902/46875844-6ab05e80-ce02-11e8-9c35-dac1cd75f3fa.jpg)

After:
![after](https://user-images.githubusercontent.com/397902/46875871-7c920180-ce02-11e8-8905-74aff5616abd.jpg)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
