### PR TITLE
Fix IE Category page layout issue

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
+++ b/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
@@ -5,9 +5,7 @@
 
   display: grid;
   grid-template-columns: 3fr 1fr;
-  grid-column-gap: $gutter;
   grid-template-rows: auto auto auto;
-  grid-row-gap: $gutter;
 
   &__top {
     @include breakpoint($bp-small max-width) {
@@ -20,11 +18,14 @@
   }
 
   &__left {
+    @include gutter($margin-right-half...);
     grid-column: 1 / 1;
     grid-row: 2 / 2;
   }
 
   &__right {
+    @include gutter($margin-left-half...);
+
     @include breakpoint($bp-small max-width) {
       grid-column: 1 / 1;
       grid-row: 3 / 3;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5378: SG2 | Broken category page layout in IE11](https://issues.ama-assn.org/browse/EWL-5378)

## Description
Fix category page not displaying correctly in IE11

## To Test
- [ ] `gulp serve`
- visit https://live.browserstack.com/dashboard#os=Windows&os_version=10&browser=IE&browser_version=11.0&zoom_to_fit=true&full_screen=true&resolution=responsive-mode&url=http%3A%2F%2Flocalhost%3A3000%2F%3Fp%3Dpages-category&speed=1&host_ports=google.com%2C80%2C0
- sign in to Browserstack - if you don't have an account ask @ccuiriz 
- observe the page matches https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-category
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-5602-hub-text-only/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1244" alt="screen shot 2018-10-12 at 3 45 35 pm" src="https://user-images.githubusercontent.com/2271747/46893225-e1b31a80-ce35-11e8-9f2c-c45aa320d019.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
