### PR TITLE
EWL-6227 Fix Board of trustees image size being too big

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
@@ -4,6 +4,7 @@
 
   &__image {
     min-width: 280px;
+    max-width: 280px;
   }
 
   &__copy {

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -32,6 +32,8 @@
       height: 50px;
       width: 50px;
       background-size: 50px;
+      text-indent: -999px;
+      overflow: hidden;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -32,8 +32,6 @@
       height: 50px;
       width: 50px;
       background-size: 50px;
-      text-indent: -999px;
-      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6227: A1 Bugs - BoT pages are coming in with huge images](https://issues.ama-assn.org/browse/EWL-6227)


## Description:
Fix Board of Trustee images being too big

## To Test:
- visit http://localhost:3000/?p=pages-people-listing make sure it matches https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-people-listing
- we also need to test this in D8 please refer tohttps://github.com/AmericanMedicalAssociation/ama-d8/pull/890 for furth instructions

## Automated Test:
n/a


## Relevant Screenshots/GIFs:
<img width="1242" alt="screen shot 2018-10-15 at 12 24 11 pm" src="https://user-images.githubusercontent.com/2271747/46967124-3ee8df00-d075-11e8-8375-0cf2cbf30838.png">


## Additional Notes:
n/a


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
