### PR TITLE
[EWL-6171] People Bio Affiliation Padding

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_content-with-label.scss
+++ b/styleguide/source/assets/scss/02-molecules/_content-with-label.scss
@@ -1,59 +1,61 @@
-dl {
-  overflow: hidden;
-  margin: 0;
-}
-
-dt {
-  font-weight: 600;
-  text-transform: capitalize;
-  margin-right: $gutter/4;
-
-  .as-gated {
-    &:before {
-      @extend .icon--lock;
-      content: "";
-      height: 20px;
-      width: 14px;
-      margin-left: $gutter/4;
-    }
-
-    @include breakpoint($bp-small min-width) {
-      display: none;
-    }
-  }
-}
-
-dd {
-  margin: 0;
-
-  span {
-    display: block;
+.ama__bio-section {
+  dl {
+    overflow: hidden;
+    margin: 0 0 $gutter/2 0;
   }
 
-  .as-gated {
-    @extend .ama__type--small;
-    display: none;
-
-    &:before {
-      @extend .icon--lock;
-      content: "";
-      height: 20px;
-      width: 14px;
-    }
-
-    @include breakpoint($bp-small min-width) {
-      display: inline;
-    }
-  }
-}
-
-@include breakpoint($bp-small min-width) {
   dt {
-    float: left;
-    clear: left;
+    font-weight: 600;
+    text-transform: capitalize;
+    margin-right: $gutter/4;
+
+    .as-gated {
+      &:before {
+        @extend .icon--lock;
+        content: "";
+        height: 20px;
+        width: 14px;
+        margin-left: $gutter/4;
+      }
+
+      @include breakpoint($bp-small min-width) {
+        display: none;
+      }
+    }
   }
 
   dd {
-    float: left;
+    margin: 0;
+
+    span {
+      display: block;
+    }
+
+    .as-gated {
+      @extend .ama__type--small;
+      display: none;
+
+      &:before {
+        @extend .icon--lock;
+        content: "";
+        height: 20px;
+        width: 14px;
+      }
+
+      @include breakpoint($bp-small min-width) {
+        display: inline;
+      }
+    }
+  }
+
+  @include breakpoint($bp-small min-width) {
+    dt {
+      float: left;
+      clear: left;
+    }
+
+    dd {
+      float: left;
+    }
   }
 }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6171: People Bio - padding between first term and second position](https://issues.ama-assn.org/browse/EWL-6171)

## Description
This work scopes the dl, dt, and dd styles to the `people_bio_section` class. This corrects the issues with capitalization of debug classes and variables in D8.  Margin has been added to the dl elements to ensure consecutive people listing information on people bios have proper space between them.

## To Test
- Pull `bugfix/EWL-6171-people-bio-affiliation-padding` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Update your local AMAOne provision vars to use your local SG2 files.
- Go to a peple_bio such as [Susan R. Bailey](http://ama-one.local/node/21576) and confirm affiliation groups have visual separation.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6171-people-bio-affiliation-padding/html_report/index.html).


## Relevant Screenshots/GIFs
People bio example page section in D8
![image](https://user-images.githubusercontent.com/4438120/46974142-cc81fa00-d088-11e8-94d8-8a9dd1910d3b.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
