### PR TITLE
EWL-6244 footer links

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
@@ -4,6 +4,7 @@
 
   &__image {
     min-width: 280px;
+    max-width: 280px;
   }
 
   &__copy {

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -32,6 +32,8 @@
       height: 50px;
       width: 50px;
       background-size: 50px;
+      text-indent: -999px;
+      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6244: Footer links going only to google.com(https://issues.ama-assn.org/browse/EWL-6244)


## Description:
Fix footer links to go the right URLs

## To Test:
- visit http://localhost:3000/?p=organisms-footer and compare it to https://americanmedicalassociation.github.io/ama-style-guide-2/?p=organisms-footer
- observe no differences

**This PR is to support a D8 bug fix PR
https://github.com/AmericanMedicalAssociation/ama-d8/pull/894**


## Automated Test:
n/a

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6244-footer-links/html_report/index.html).


## Relevant Screenshots/GIFs:
n/a

## Additional Notes:
n/a

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)