### PR TITLE
EWL-6231 Fix subcategories links not showing beyond two rows

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -39,6 +39,7 @@
       "source/assets/js/form-items.js",
       "source/assets/js/nav.js",
       "source/assets/js/subcategory.js",
+      "source/assets/js/subcategory-exploration.js",
       "source/assets/js/wayfinder.js",
       "source/assets/js/tabs.js",
       "source/assets/js/accordion.js",

--- a/styleguide/source/_patterns/03-organisms/subcategory-exploration.twig
+++ b/styleguide/source/_patterns/03-organisms/subcategory-exploration.twig
@@ -1,15 +1,22 @@
 <div class="ama__subcategory-exploration">
-  <ul class="ama__subcategory-exploration__list">
-    {% for link in subcategoryExploration.links %}
-      <li>
-        <a href="{{ link.url }}">
-          <h2>{{ link.text }}</h2>
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
+  <div class="ama__subcategory-exploration__list">
+    <ul>
+      {% for link in subcategoryExploration.links %}
+        <li>
+          <a href="{{ link.url }}">
+            <h2>{{ link.text }}</h2>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+
   <a href="#" class="ama__subcategory-exploration__show-more">View all subcategories
-    <span class="ama__subcategory-exploration__show-more--open">{% include "@atoms/media/icons/svg/icon-opendropdown.twig" %}</span>
-    <span class="ama__subcategory-exploration__show-more--close">{% include "@atoms/media/icons/svg/icon-closedropdown.twig" %}</span>
+    <span class="ama__subcategory-exploration__show-more--open">
+      <i class="icon--opendropdown"></i>
+    </span>
+    <span class="ama__subcategory-exploration__show-more--close">
+      <i class="icon--closedropdown"></i>
+    </span>
   </a>
 </div>

--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -11,32 +11,32 @@
   Drupal.behaviors.subcategoriesExploration = {
     attach: function(context, settings) {
 
-      var subcategoryListContainer = $('.ama__subcategory-exploration__list');
-      var subcategoryList  = $('.ama__subcategory-exploration__list ul');
-      var subcategoryListExpander = $('.ama__subcategory-exploration__show-more');
-      var subcategoryListContainerHeight = subcategoryListContainer.outerHeight();
-      var subcategoryListLinkText = $('.ama__subcategory-exploration__text');
+      var $subcategoryListContainer = $('.ama__subcategory-exploration__list');
+      var $subcategoryList  = $('.ama__subcategory-exploration__list ul');
+      var $subcategoryListExpander = $('.ama__subcategory-exploration__show-more');
+      var $subcategoryListContainerHeight = $subcategoryListContainer.outerHeight();
+      var $subcategoryListLinkText = $('.ama__subcategory-exploration__text');
 
       // If the unordered list height is greater than the parent container then show the show more link
-      if (subcategoryList.height() > subcategoryListContainerHeight) {
-        subcategoryListExpander.show();
+      if ($subcategoryList.height() > $subcategoryListContainerHeight) {
+        $subcategoryListExpander.show();
       }
 
       // Drupal compels me to unbind clicks otherwise double clicks occur
-      subcategoryListExpander.unbind('click').click(function(e){
+      $subcategoryListExpander.unbind('click').click(function(e){
         e.stopPropagation();
         e.preventDefault();
 
         // Checks to see if the container has been expand or not by comparing initial height to current height
-        if(subcategoryListContainer.height() > subcategoryListContainerHeight) {
-          subcategoryListContainer.removeClass('ama__subcategory-exploration__list--expanded');
+        if($subcategoryListContainer.height() > $subcategoryListContainerHeight) {
+          $subcategoryListContainer.removeClass('ama__subcategory-exploration__list--expanded');
           $(this).removeClass('ama__subcategory-exploration__show-more--expanded');
-          subcategoryListLinkText.text('View all subcategories');
+          $subcategoryListLinkText.text('View all subcategories');
         }
         else {
-          subcategoryListContainer.addClass('ama__subcategory-exploration__list--expanded');
+          $subcategoryListContainer.addClass('ama__subcategory-exploration__list--expanded');
           $(this).addClass('ama__subcategory-exploration__show-more--expanded');
-          subcategoryListLinkText.text('View fewer subcategories');
+          $subcategoryListLinkText.text('View fewer subcategories');
         }
       });
     }

--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -1,4 +1,45 @@
-$('.ama__subcategory-exploration__show-more').click(function() {
-  $('.ama__subcategory-exploration__list').toggleClass('ama__subcategory-exploration__list--expanded');
-  $(this).toggleClass('ama__subcategory-exploration__show-more--expanded');
-});
+/**
+ * @file
+ * Subcategory
+ *
+ * JavaScript should be made compatible with libraries other than jQuery by
+ * wrapping it with an "anonymous closure". See:
+ * - https://drupal.org/node/1446420
+ * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
+ */
+(function ($, Drupal) {
+  Drupal.behaviors.subcategoriesExploration = {
+    attach: function(context, settings) {
+
+      var subcategoryListContainer = $('.ama__subcategory-exploration__list');
+      var subcategoryList  = $('.ama__subcategory-exploration__list ul');
+      var subcategoryListExpander = $('.ama__subcategory-exploration__show-more');
+      var subcategoryListContainerHeight = subcategoryListContainer.outerHeight();
+      var subcategoryListLinkText = $('.ama__subcategory-exploration__text');
+
+      // If the unordered list height is greater than the parent container then show the show more link
+      if (subcategoryList.height() > subcategoryListContainerHeight) {
+        subcategoryListExpander.show();
+      }
+
+      // Drupal compels me to unbind clicks otherwise double clicks occur
+      subcategoryListExpander.unbind('click').click(function(e){
+        e.stopPropagation();
+        e.preventDefault();
+
+        // Checks to see if the container has been expand or not by comparing initial height to current height
+        if(subcategoryListContainer.height() > subcategoryListContainerHeight) {
+          subcategoryListContainer.removeClass('ama__subcategory-exploration__list--expanded');
+          $(this).removeClass('ama__subcategory-exploration__show-more--expanded');
+          subcategoryListLinkText.text('View all subcategories');
+        }
+        else {
+          subcategoryListContainer.addClass('ama__subcategory-exploration__list--expanded');
+          $(this).addClass('ama__subcategory-exploration__show-more--expanded');
+          subcategoryListLinkText.text('View fewer subcategories');
+        }
+      });
+    }
+  };
+})(jQuery, Drupal);
+

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -6,83 +6,109 @@
     padding-bottom: $gutter;
   }
 
-  .ama__subcategory-exploration__list { // <ul>
+  .ama__subcategory-exploration__list {
+    overflow: hidden;
+    height: 108px;
+
     @include breakpoint($bp-small max-width) {
       margin-left: -2px - $gutter / 4;
       height: 1.1em;
     }
 
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    margin-left: -2px - $gutter / 2;
-    overflow: hidden;
-    height: 5.4em;
-
-      &--expanded {
-        height: auto;
-      }
-  }
-
-  li {
-    @include breakpoint($bp-small max-width) {
-      margin: 0 ($gutter / 4) ($gutter / 4) 0;
-      padding: 0 0 0 ($gutter / 4);
-    }
-
-    list-style-type: none;
-    border-left: solid 2px;
-    margin: 0 ($gutter / 2) ($gutter / 2) 0;
-    padding: 0 0 0 ($gutter / 2);
-  }
-
-  a {
-    text-decoration: none;
-
-    &:hover h2,
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  h2 {
-    font-weight: 600;
-
-    @include breakpoint($bp-small max-width) {
-      font-size: 16px;
-    }
-  }
-
-  .ama__subcategory-exploration__show-more {
-     @include font-size($h2-font-sizes);
-
-     @include breakpoint($bp-small max-width) {
-       font-size: 16px;
-     }
-
-     @include breakpoint($bp-small) {
-       display: inline-block;
-       margin-top: $gutter / 2;
-     }
-
-    @include breakpoint($bp-large) {
-      display: none;
-    }
-
-     width: 100%;
-
-    .ama__subcategory-exploration__show-more--close {
-      display: none;
-    }
-
     &--expanded {
-      .ama__subcategory-exploration__show-more--open {
-        display: none;
+      height: auto;
+    }
+
+    ul {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      margin-left: -2px - $gutter / 2;
+    }
+
+    li {
+      @include breakpoint($bp-small max-width) {
+        margin: 0 ($gutter / 4) ($gutter / 4) 0;
+        padding: 0 0 0 ($gutter / 4);
       }
 
-      .ama__subcategory-exploration__show-more--close {
-        display: inline;
+      list-style-type: none;
+      border-left: solid 2px;
+      margin: 0 ($gutter / 2) ($gutter / 2) 0;
+      padding: 0 0 0 ($gutter / 2);
+    }
+
+    a {
+      text-decoration: none;
+
+      &:hover h2,
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    h2 {
+      font-weight: 600;
+
+      @include breakpoint($bp-small max-width) {
+        font-size: 16px;
       }
     }
   }
 }
+
+.ama__subcategory-exploration__show-more {
+  @include font-size($h2-font-sizes);
+  width: 100%;
+
+   @include breakpoint($bp-small max-width) {
+     font-size: 16px;
+   }
+
+   @include breakpoint($bp-small) {
+     display: inline-block;
+     margin-top: $gutter / 2;
+   }
+
+  @include breakpoint($bp-large) {
+    display: none;
+  }
+
+  .ama__subcategory-exploration__show-more--close {
+    display: none;
+
+    i {
+      background-size: 14px 8px;
+      background-position: 0 0;
+      min-height: 14px;
+      min-width: 14px;
+      max-height: 14px;
+      max-width: 14px;
+    }
+  }
+
+  .ama__subcategory-exploration__show-more--open {
+    display: inline-block;
+
+    i {
+      background-size: 14px 8px;
+      background-position: 0 0;
+      min-height: 14px;
+      min-width: 14px;
+      max-height: 14px;
+      max-width: 14px;
+    }
+  }
+
+
+  &--expanded {
+    .ama__subcategory-exploration__show-more--open {
+      display: none;
+    }
+
+    .ama__subcategory-exploration__show-more--close {
+      display: inline-block;
+    }
+  }
+}
+


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6231: Missing subcategories in subcategory menu on category page](https://issues.ama-assn.org/browse/EWL-6231)


## Description:
This PR supports another PR in D8
https://github.com/AmericanMedicalAssociation/ama-d8/pull/897

The subcategories don't show beyond two rows. When there are more than two rows of subcategories a view more link should appear and when clicked the rest of the subcategories should show.

## To Test:
- `gulp serve`
- visit http://localhost:3000/?p=pages-category
- compare to https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-category
- observe nothing has changed

## Automated Test:
n/a

## Visual Regression:
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6231-missing-subcategory-menu/html_report/index.html).



## Relevant Screenshots/GIFs:
<img width="1262" alt="screen shot 2018-10-16 at 9 27 29 am" src="https://user-images.githubusercontent.com/2271747/47023655-b6764700-d125-11e8-9e8f-42382dc8e062.png">


## Additional Notes:
n/a

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
