### PR TITLE
EWL-6249 Fix hub hero height

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -1,8 +1,9 @@
 .ama__hub-hero {
   width: 100%;
-  min-height: 200px;
+  min-height: 400px;
   display: flex;
   align-items: stretch;
+  justify-content: center;
   flex-direction: column;
   text-align: center;
   background-color: $gray-7;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-6249: Ticket Title](https://issues.ama-assn.org/browse/EWL-6249)

## Description
Fix hub hero height. Currently it's not tall enough

## To Test
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=molecules-hub-hero
- [ ] observe the hub hero min-height is 400px
- [ ] This also needs to be tested in D8
- [ ] enable local SG2. Make sure your still on this branch
- [ ] run `scripts/build`
- [ ] visit http://ama-one.local/node/23866. If this returns a 404 run `scripts/refresh-local -a one`
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6249-hub-hero-size/html_report/index.html).

## Relevant Screenshots/GIFs
<img width="1306" alt="screen shot 2018-10-16 at 12 33 29 pm" src="https://user-images.githubusercontent.com/2271747/47035456-b420e680-d13f-11e8-8875-016fec885816.png">

## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
