### PR TITLE
EWL-6251 Adds max-height to image container and hides overflow of large images

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -66,6 +66,13 @@
     }
   }
 
+  &--image-text {
+    .ama__hub-card__image {
+      max-height: 180px;
+      overflow: hidden;
+    }
+  }
+
   &--portrait {
     background-size: cover;
     background-position: center top;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-6251: Hub page: image size is different on 4th card of a card row](https://issues.ama-assn.org/browse/EWL-6251)

## Description
Fourth image for hub cards in a row was slightly higher than the others

## To Test
- [ ] `gulp serve`
- [ ] This needs to be test in D8
- [ ] enable local SG2 in your local.yml
- [ ] run `scripts/build`
- [ ] visit http://ama-one.local/node/23706 (make sure you have the latest Prod database)
- [ ] observe that the last hub card image is the same size as the others
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6251-hub-card-image-height/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1144" alt="screen shot 2018-10-16 at 12 49 03 pm" src="https://user-images.githubusercontent.com/2271747/47036328-e4698480-d141-11e8-8137-e090a335d1bb.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
