### PR TITLE
[Homepage] Organization Nav 2x2

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_category-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-nav.scss
@@ -3,6 +3,8 @@
   
   @include breakpoint($bp-small) {
     display: block;
+    flex: 0 0 65%;
+    max-width: 65%;
   }
   
   li {

--- a/styleguide/source/assets/scss/03-organisms/_org-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_org-nav.scss
@@ -1,5 +1,6 @@
 .ama__org-nav {
-  max-width: 33.33%;
+  flex: 0 0 34%;
+  max-width: 34%;
   text-align: right;
 
   li {
@@ -9,7 +10,7 @@
       color: $purple;
       text-transform: uppercase;
       text-decoration: none;
-      margin: 0 ($gutter / 2);
+      margin: 0 ($gutter / 4);
       font-size: .778em;
       line-height: 2.214em;
       font-weight: 600;


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6284 | Homepage organizational nav is stacked instead of as it displays in wireframe](https://issues.ama-assn.org/browse/EWL-6284)

## Description
Adds missing flex properties to flexbox children and adjusts widths and margins for nav items to get organization nav on two lines more often. This will not prevent additional lines as content is variable and menu items that are two long in text will prevent two items from showing up per line.

## To Test
- Pull `bugfix/homepage-org-nav-spacing` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Update your local AMAOne provision vars to use your local SG2 files.
- Ensure you have prod content before testing further.
- Go to the default homepage and confirm organization nav shows two two rows of content as in SG2.
- Test this in IE 11, Safari, and Firefox to ensure flexbox widths work correctly.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/homepage-org-nav-spacing/html_report/index.html).


## Relevant Screenshots/GIFs
Home page  top nav section in D8
![image](https://user-images.githubusercontent.com/4438120/47106781-26abc800-d20d-11e8-9d97-14e221ca60df.png)



## Remaining Tasks
N/A


## Additional Notes
N/A
