### PR TITLE
[Homepage] Promos and Hero

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -45,7 +45,7 @@
       margin-bottom: 0;
     }
 
-    &__promo-heading{
+    &__promo-heading {
       color: $homepagePurple;
     }
     @include breakpoint($bp-med) {

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -23,7 +23,9 @@
     color: $gray-64;
 
     // Right now the style guide uses `buttons`, but eventually we want to switch these to `a` elements.
-    button, a, .ama__button {
+    a, 
+    button, 
+    .ama__button {
       @include gutter($margin-top-full...);
       @include gutter($margin-right-half...);
       width: auto;

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -23,10 +23,12 @@
     color: $gray-64;
 
     // Right now the style guide uses `buttons`, but eventually we want to switch these to `a` elements.
-    button, a {
+    button, a, .ama__button {
       @include gutter($margin-top-full...);
       @include gutter($margin-right-half...);
       width: auto;
+      // Button should have a min width so that buttons with small words do not feel cramped
+      min-width: 150px;
     }
 
     &__feature-heading {
@@ -43,6 +45,11 @@
 
     &__promo-heading{
       color: $homepagePurple;
+    }
+    @include breakpoint($bp-med) {
+      flex: 0 0 70%;
+      max-width: 70%;
+      padding: 10px 5.5% 10px 10px;
     }
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -3,6 +3,9 @@
   .ama__layout--one-column__content-top {
     display: none;
   }
+  .ama__layout--split__right{
+    border-left: none;
+  }
 
   @include breakpoint($bp-small) {
     .ama__layout--one-column__content-top {
@@ -41,6 +44,13 @@
 
         &:last-child {
           margin-left: -5%;
+          flex: 0 0 35%;
+          max-width: 35%;
+
+          button{
+            // Button should have a min width so that buttons with small words do not feel cramped
+            min-width: 150px;
+          }
         }
       }
     }

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -3,7 +3,7 @@
   .ama__layout--one-column__content-top {
     display: none;
   }
-  .ama__layout--split__right{
+  .ama__layout--split__right {
     border-left: none;
   }
 


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6309: Homepage - promo incorrectly styled](https://issues.ama-assn.org/browse/EWL-6309)
- [EWL-6307: Homepage - hero has an unwanted line](https://issues.ama-assn.org/browse/EWL-6307)

## Description
Adds missing flex properties to flexbox children and adjusts widths and margins so that promo box ratios match Zeplin and do not overlap text. Removes left border in homepage hero on D8. 

### Dependencies
[Homepage: Hero and Articles #911](https://github.com/AmericanMedicalAssociation/ama-d8/pull/911)

## To Test
- Pull `bugfix/homepage-hero-promo` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work relies on template updates in [Homepage: Hero and Articles #911](https://github.com/AmericanMedicalAssociation/ama-d8/pull/911). Update ama-d8 branch and local provision vars accordingly. 
- Ensure you have prod content before testing further.
- Go to the default homepage and confirm hero no longer has vertical line separating left and right sections.
- Confirm promos have proper ratios and do not have overlapping text.
- Test this in IE 11, Safari, and Firefox to ensure flexbox widths work correctly.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/homepage-hero-promo/html_report/index.html).


## Relevant Screenshots/GIFs
Home page promos in D8
![image](https://user-images.githubusercontent.com/4438120/47110323-19dfa200-d216-11e8-8e96-508d7d30e7fc.png)

Original Incorrect Section
![image](https://user-images.githubusercontent.com/4438120/47117079-0558d500-d229-11e8-8b12-479203164e15.png)





## Remaining Tasks
N/A


## Additional Notes
N/A
