### PR TITLE
Fix expand list hiding layout builder blocks

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_expand-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_expand-list.scss
@@ -72,10 +72,6 @@
     width: 100%;
   }
 
-  &__panel {
-    display: none;
-  }
-
   .ui-accordion-content {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Ticket(s)
n/a

**Jira Ticket**
n/a

## Description
Layout builder blocks are currently hidden due a style hiding all the blocks

## To Test

- run `gulp serve`
- enable local SG2 development in D8
- go to any layout builder edit page
- try to add a block to layout builder
- observe you see all the block links and your able to add a block to layout builder

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
n/a

## Remaining Tasks
n/a

## Additional Notes
n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
