### PR TITLE
EWL-6281 homepage email subscription

### DIFF
--- a/styleguide/source/_patterns/02-molecules/subscribe-promo.twig
+++ b/styleguide/source/_patterns/02-molecules/subscribe-promo.twig
@@ -1,10 +1,10 @@
 {% set classes = [
-    subscribePromo.wide ? "ama__subscribe-promo--wide" : "",
-    subscribePromo.homepage ? "ama__subscribe-promo--homepage" : ""
+    subscribePromo.wide ? "ama__subscribe-promo--wide",
+    subscribePromo.homepage ? "ama__subscribe-promo--homepage"
   ]
 %}
 
-<div class="ama__subscribe-promo {{ classes }}">
+<div class="ama__subscribe-promo {{ classes|join(' ') }}">
   {% include '@atoms/heading/heading.twig' with { heading : subscribePromo.subjectTitle } %}
   <div class="ama__subscribe-promo__container">
     <div class="ama__subscribe-promo__content">
@@ -13,9 +13,11 @@
       {% set email = subscribePromo.email %}
     </div>
     <div class="ama__subscribe-promo__form">
-      {% include '@atoms/forms/email-field.twig' %}
-      {% set button = subscribePromo.button %}
-      {% include '@atoms/button/button.twig' %}
+      <form>
+        {% include '@atoms/forms/email-field.twig' %}
+        {% set button = subscribePromo.button %}
+        {% include '@atoms/button/button.twig' %}
+      </form>
     </div>
   </div>
 </div>

--- a/styleguide/source/_patterns/02-molecules/subscribe-promo.twig
+++ b/styleguide/source/_patterns/02-molecules/subscribe-promo.twig
@@ -1,6 +1,10 @@
-{% set wide = subscribePromo.wide ? "ama__subscribe-promo--wide" : "" %}
+{% set classes = [
+    subscribePromo.wide ? "ama__subscribe-promo--wide" : "",
+    subscribePromo.homepage ? "ama__subscribe-promo--homepage" : ""
+  ]
+%}
 
-<div class="ama__subscribe-promo {{ wide }}">
+<div class="ama__subscribe-promo {{ classes }}">
   {% include '@atoms/heading/heading.twig' with { heading : subscribePromo.subjectTitle } %}
   <div class="ama__subscribe-promo__container">
     <div class="ama__subscribe-promo__content">

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -1497,6 +1497,7 @@
     },
     "subscribePromo": {
       "wide": true,
+      "homepage": true,
       "subjectTitle": {
         "level": "4",
         "text": "Lorem ipsum",

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -105,6 +105,14 @@
     .ama__subscribe-promo__form form {
       flex-direction: row;
       flex-wrap: nowrap;
+
+      .ama__form-group {
+        flex: 1;
+      }
+
+      .ama__button {
+        margin: 0;
+      }
     }
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -11,8 +11,13 @@
 
   &__form {
     .ama__button {
+      @extend .ama__button--homepage;
       display: block;
       margin: 0 auto;
+      padding:  $gutter / 2.2;
+      border: 0;
+      height: 49px;
+
       &:hover {
         background: $hoverPurple;
       }
@@ -43,6 +48,7 @@
     }
 
     .ama__subscribe-promo__content {
+      @include gutter($margin-right-full...);
       flex: 1;
     }
 
@@ -51,7 +57,8 @@
       display: flex;
       flex-direction: column;
 
-      .ama__form-group {
+      .ama__form-group,
+      .form-actions {
         margin: 0;
       }
 
@@ -78,6 +85,26 @@
           margin-bottom: 0;
         }
       }
+    }
+  }
+
+  &--homepage {
+    .ama__subscribe-promo__form {
+      flex-direction: row;
+      width: 100%;
+
+      @include breakpoint($bp-small min-width) {
+        width: 40%;
+      }
+
+      @include breakpoint($bp-large min-width) {
+        width: 35%;
+      }
+    }
+
+    .ama__subscribe-promo__form form {
+      flex-direction: row;
+      flex-wrap: nowrap;
     }
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6281: Homepage - email subscription does not match the style guide](https://issues.ama-assn.org/browse/EWL-6281)

## Description
Theme the homepage email subscription form

## To Test
- [ ] run `gulp serve`
- visit http://localhost:3000/?p=pages-homepage
- observe the email subscription match https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-homepage
- this PR has a dependency in D8. For further testing instructions visit: https://github.com/AmericanMedicalAssociation/ama-d8/pull/920
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6281-homepage-email-subscription/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1289" alt="screen shot 2018-10-18 at 12 36 44 pm" src="https://user-images.githubusercontent.com/2271747/47173004-7f916400-d2d2-11e8-986d-034d25dfd046.png">


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
