### PR TITLE
Rewrite annotations focused on Home page

### DIFF
--- a/styleguide/source/_annotations/01_alert-wrap.md
+++ b/styleguide/source/_annotations/01_alert-wrap.md
@@ -1,0 +1,13 @@
+---
+el: .ama__alert
+title: Alert
+---
+A short message to appear at the top of a page.
+
+Fields:
+
+1. Alert message
+
+2. Button text (optional)
+
+3. Button URL (optional)

--- a/styleguide/source/_annotations/01_product-nav.md
+++ b/styleguide/source/_annotations/01_product-nav.md
@@ -1,0 +1,5 @@
+---
+el: .ama__product-nav
+title: Product Nav
+---
+A menu to products AMA offers.

--- a/styleguide/source/_annotations/02_homepage-navs.md
+++ b/styleguide/source/_annotations/02_homepage-navs.md
@@ -1,0 +1,11 @@
+---
+el: .ama__homepage__navs
+title: Homepage Navigation
+---
+The navigation menu present on the home page.
+
+Contains two menus:
+
+1. The AMA One categories
+
+2. Quick links for specific types of people (board members, delegates, etc.)

--- a/styleguide/source/_annotations/14_home-member-feature.md
+++ b/styleguide/source/_annotations/14_home-member-feature.md
@@ -1,0 +1,21 @@
+---
+el: .ama__member-feature
+title: Member Feature
+---
+A Homepage-specific block promoting membership to AMA.
+
+Fields:
+
+1. Block title (ex. "Membership Moves Medicine")
+
+2. Featured story:
+
+    * Pull quote (plain text)
+
+    * Quote attribution; person's name and title
+
+    * Button text and URL (Read More)
+
+    * Image: 876 x 574 pixels
+
+    * Right rail article stubs

--- a/styleguide/source/_annotations/15_home-four-up-links.md
+++ b/styleguide/source/_annotations/15_home-four-up-links.md
@@ -1,0 +1,13 @@
+---
+el: .ama__homepage__four-up-links
+title: Homepage Four-up Links
+---
+A Homepage-specific block showing topics and other key pages throughout the AMA One.
+
+Fields:
+
+1. List heading (ex. "For Physicians")
+
+2. List item name
+
+3. List item URL

--- a/styleguide/source/_annotations/16_upcoming-events.md
+++ b/styleguide/source/_annotations/16_upcoming-events.md
@@ -1,0 +1,15 @@
+---
+el: .ama__upcoming-events
+title: Upcoming Events
+---
+A listing of upcoming events.
+
+Fields:
+
+1. Event name
+
+2. Event URL
+
+3. Start date
+
+4. Location

--- a/styleguide/source/_annotations/17_products.md
+++ b/styleguide/source/_annotations/17_products.md
@@ -1,0 +1,17 @@
+---
+el: .ama__products
+title: AMA Products
+---
+A manually curated list of quick links to products that a member may have.
+
+Fields:
+
+1. Image (optional): 876 x 574 pixels
+
+    * Note: only the first product in each row of product stubs will have its image appear
+
+2. Product name
+
+3. Product description
+
+4. Link to full product page 

--- a/styleguide/source/_annotations/18_homepage-mission-header.md
+++ b/styleguide/source/_annotations/18_homepage-mission-header.md
@@ -1,0 +1,9 @@
+---
+el: .ama__homepage__mission-header
+title: Mission
+---
+The mission statement for the AMA.
+
+Fields:
+
+* plain text


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-6322: Annotation updates: Home page](https://issues.ama-assn.org/browse/EWL-6322)

## Description
Added annotations to components specific to the Home page of AMA One. 


## To Test
- [ ] Open style guide
- [ ] Navigate to Pages > Homepage
- [ ] Click the gear icon then "Show Pattern Info"
- [ ] Confirm presence of new annotations on:
-- Alert
-- Product nav
-- Homepage navigation
-- Member feature
-- Homepage four-up links
-- Upcoming events
-- AMA products
-- Mission


## Relevant Screenshots/GIFs
<img width="592" alt="screen shot 2018-10-18 at 3 48 06 pm" src="https://user-images.githubusercontent.com/31719159/47183290-46b2b880-d2ed-11e8-95a7-8316a88cb356.png">



## Remaining Tasks
Unsure which page templates to work on next. 


## Additional Notes
Weird visual error on my end where the annotation icons are being cut off on Upcoming events and AMA Products (see screenshot below). Functionality still works however (clicking within the area jumps the pattern info box to the appropriate annotation description).

<img width="470" alt="screen shot 2018-10-18 at 3 50 19 pm" src="https://user-images.githubusercontent.com/31719159/47183400-8da0ae00-d2ed-11e8-9410-25ec442a72c7.png">


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
