### PR TITLE
EWL-6339 Fix news article gated overlay

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_gate.scss
+++ b/styleguide/source/assets/scss/01-atoms/_gate.scss
@@ -1,8 +1,10 @@
 .ama__gate {
   background:rgba(0,0,0,0.6);
   min-height: 235px;
+  height: 100%;
   padding-top: 30px;
   position: absolute;
+  top: 0;
   width: 100%;
   z-index:1;
 

--- a/styleguide/source/assets/scss/01-atoms/_gate.scss
+++ b/styleguide/source/assets/scss/01-atoms/_gate.scss
@@ -1,10 +1,8 @@
 .ama__gate {
   background:rgba(0,0,0,0.6);
   min-height: 235px;
-  height: 100%;
   padding-top: 30px;
   position: absolute;
-  top: 0;
   width: 100%;
   z-index:1;
 

--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -4,6 +4,7 @@
   grid-template-rows: auto auto auto;
   min-height: 30em;
   padding: 0;
+  overflow: hidden;
 
   &__content-top {
     grid-column: 1 / 5;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6339: Bug: News article as gated styling](https://issues.ama-assn.org/browse/EWL-6339)

## Description
Fix news as gated overlay going over into the footer and not overlaying the proper area in D8.

## To Test
- [ ] run `gulp serve`
- visit http://localhost:3000/?p=pages-news-as-gated compare it to https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-news-as-gated
- observe nothing has changed
- the rest of the testing procedure is in PR https://github.com/AmericanMedicalAssociation/ama-d8/pull/931
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6339-news-article-as-gated/html_report/index.html).

## Relevant Screenshots/GIFs
<img width="1470" alt="screen shot 2018-10-19 at 2 22 42 pm" src="https://user-images.githubusercontent.com/2271747/47239278-77a4f300-d3aa-11e8-86f5-852f1c0a7c02.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
