### PR TITLE
EWL-6207 Fix bullet position and style (original PR #448)

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_social-icons.scss
+++ b/styleguide/source/assets/scss/01-atoms/_social-icons.scss
@@ -1,3 +1,7 @@
 .ama__social-icons {
   list-style: none;
+
+  li {
+    list-style: none;
+  }
 }

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -1,8 +1,12 @@
+section ul,
+article ul,
 .ama__list {
+  @include gutter($margin-bottom-half...);
+
   li {
     @include gutter($margin-left-full...);
     padding: 0;
-    list-style-position: outside;
+    list-style: disc;
 
     ul {
       @include gutter($margin-left-full...);
@@ -12,7 +16,7 @@
 
   ul {
     @include gutter($margin-left-full...);
-    list-style-position: outside;
+    list-style: none;
   }
 }
 

--- a/styleguide/source/assets/scss/02-molecules/_jama.scss
+++ b/styleguide/source/assets/scss/02-molecules/_jama.scss
@@ -31,17 +31,12 @@
 
     a {
       display: flex;
-
-      // For this component, the image is on the right.
-      .ama__image__text {
-        padding-left: inherit;
-        padding-right: 14px;
-      }
     }
   }
 
   .ama__rule {
     @include gutter($margin-top-full...);
+    border-color: $gray-50;
   }
 
   // Styles the Image Href with Text variant.
@@ -57,16 +52,40 @@
       }
     }
   }
-}
 
-.ama__jama a.ama__jama__header {
-  color: $white;
-  background-color: $hoverRed;
-  padding: 0 7px;
-  font-size: 27px;
-  min-width: 265px;
-  max-width: 100%;
-  display: inline-block;
+  &--homepage {
+    .ama__jama__links {
+      display: flex;
+      flex-direction: column;
+      border-top: 0;
+      list-style: none;
+    }
+
+    .ama__jama__links li {
+      @include gutter($margin-right-full...);
+      border-top: 1px solid $gray-50;
+      list-style: none;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+
+    .ama__image-wrap {
+      display: none;
+      padding: 0;
+    }
+
+    .ama__link--with-image span {
+      padding-left: 0;
+    }
+
+    @include breakpoint($bp-small) {
+      .ama__jama__links {
+        flex-direction: row;
+      }
+    }
+  }
 }
 
 .ama__jama__title {
@@ -89,11 +108,14 @@
   }
 }
 
+article[class*='__page-content'] .ama__jama__links,
 .ama__jama__links {
   list-style-type: none;
+  border-top: 1px solid $gray-50;
 
   li {
-
+    list-style: none;
+    margin: 0;
 
     &:hover {
       border-color: $hoverRed;
@@ -105,7 +127,7 @@
 
     a {
       @extend .ama__link--hover-red;
-      display: block;
+      display: flex;
       padding: ($gutter / 4) 0;
       text-decoration: none;
 
@@ -119,6 +141,15 @@
           color: $black;
         }
       }
+    }
+
+    .ama__image__text {
+      padding: 0;
+      flex: 1;
+    }
+
+    .ama__image-wrap {
+
     }
   }
 }
@@ -138,41 +169,8 @@
   }
 }
 
-.ama__jama--homepage {
-  .ama__jama__links {
-    flex-direction: column;
-  
-    @include breakpoint($bp-small) {
-      display: flex;
-      justify-content: space-between;
-      flex-direction: row;
-  
-      li {
-        width: 25%;
-        @include gutter($margin-right-full...);
-        border-top: 1px solid $gray-50;
-  
-        &:last-child {
-          margin-right: 0;
-        }
-  
-        &:hover {
-          border-color: $hoverRed;
-        }
-      }
-  
-      a {
-        padding-bottom: 0;
-      }
-    }
-  }
-
-  .ama__rule {
-    border-color: $hoverRed;
-  }
-}
-
-.ama__jama--horizontal .ama__jama__links {
+.ama__page--news__teasers .ama__jama__links,
+.ama__page--press-release__teasers .ama__jama__links {
   @include breakpoint($bp-small) {
     display: flex;
     justify-content: space-between;

--- a/styleguide/source/assets/scss/02-molecules/_jama.scss
+++ b/styleguide/source/assets/scss/02-molecules/_jama.scss
@@ -31,12 +31,17 @@
 
     a {
       display: flex;
+
+      // For this component, the image is on the right.
+      .ama__image__text {
+        padding-left: inherit;
+        padding-right: 14px;
+      }
     }
   }
 
   .ama__rule {
     @include gutter($margin-top-full...);
-    border-color: $gray-50;
   }
 
   // Styles the Image Href with Text variant.
@@ -52,40 +57,16 @@
       }
     }
   }
+}
 
-  &--homepage {
-    .ama__jama__links {
-      display: flex;
-      flex-direction: column;
-      border-top: 0;
-      list-style: none;
-    }
-
-    .ama__jama__links li {
-      @include gutter($margin-right-full...);
-      border-top: 1px solid $gray-50;
-      list-style: none;
-
-      &:last-child {
-        margin-right: 0;
-      }
-    }
-
-    .ama__image-wrap {
-      display: none;
-      padding: 0;
-    }
-
-    .ama__link--with-image span {
-      padding-left: 0;
-    }
-
-    @include breakpoint($bp-small) {
-      .ama__jama__links {
-        flex-direction: row;
-      }
-    }
-  }
+.ama__jama a.ama__jama__header {
+  color: $white;
+  background-color: $hoverRed;
+  padding: 0 7px;
+  font-size: 27px;
+  min-width: 265px;
+  max-width: 100%;
+  display: inline-block;
 }
 
 .ama__jama__title {
@@ -108,14 +89,12 @@
   }
 }
 
-article[class*='__page-content'] .ama__jama__links,
 .ama__jama__links {
-  list-style-type: none;
-  border-top: 1px solid $gray-50;
+  list-style: none;
 
   li {
-    list-style: none;
     margin: 0;
+    list-style: none;
 
     &:hover {
       border-color: $hoverRed;
@@ -127,7 +106,7 @@ article[class*='__page-content'] .ama__jama__links,
 
     a {
       @extend .ama__link--hover-red;
-      display: flex;
+      display: block;
       padding: ($gutter / 4) 0;
       text-decoration: none;
 
@@ -141,15 +120,6 @@ article[class*='__page-content'] .ama__jama__links,
           color: $black;
         }
       }
-    }
-
-    .ama__image__text {
-      padding: 0;
-      flex: 1;
-    }
-
-    .ama__image-wrap {
-
     }
   }
 }
@@ -169,8 +139,42 @@ article[class*='__page-content'] .ama__jama__links,
   }
 }
 
-.ama__page--news__teasers .ama__jama__links,
-.ama__page--press-release__teasers .ama__jama__links {
+.ama__jama--homepage {
+  .ama__jama__links {
+    flex-direction: column;
+
+    @include breakpoint($bp-small) {
+      display: flex;
+      justify-content: space-between;
+      flex-direction: row;
+
+      li {
+        @include gutter($margin-right-full...);
+        width: 25%;
+        list-style: none;
+        border-top: 1px solid $gray-50;
+
+        &:last-child {
+          margin-right: 0;
+        }
+
+        &:hover {
+          border-color: $hoverRed;
+        }
+      }
+
+      a {
+        padding-bottom: 0;
+      }
+    }
+  }
+
+  .ama__rule {
+    border-color: $hoverRed;
+  }
+}
+
+.ama__jama--horizontal .ama__jama__links {
   @include breakpoint($bp-small) {
     display: flex;
     justify-content: space-between;

--- a/styleguide/source/assets/scss/02-molecules/_social-share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_social-share.scss
@@ -46,7 +46,16 @@ $social-icons: (
   margin: 0;
   padding: 0;
 
+  li {
+    list-style: none;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
   li ~ li {
     margin-left: $gutter/2;
+    list-style: none;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -1,15 +1,21 @@
-.ama__tags {
+.ama__tags,
+article[class*='__page-content'] .ama__tags {
   @include ama-rules(1px, "", $gray-7, solid);
   @include ama-rules(1px, "bottom", $gray-7, solid);
   @include gutter($margin-top-full...);
   @include gutter($margin-bottom-full...);
   @include gutter($padding-top-full...);
   @include gutter($padding-bottom-full...);
-  list-style-type: none;
+  list-style: none;
   display: flex;
   flex-wrap: wrap;
   flex: 1;
-  
+
+  li {
+    margin-left: 0;
+    list-style: none;
+  }
+
   &:last-child {
     margin-right: 0;
   }

--- a/styleguide/source/assets/scss/03-organisms/_category-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-nav.scss
@@ -9,6 +9,7 @@
   
   li {
     display: inline-block;
+    list-style: none;
 
     a {
       @extend %ama__h5--homepage;


### PR DESCRIPTION
## Ticket(s)
This PR was reopened because it was reverted due to last minute merge conflicts with the JAMA components.

**Jira Ticket**
- [EWL-6207: Addition of SG2 styling of bullets per new zeplins](https://issues.ama-assn.org/browse/EWL-6207)

## Description
Match the bullets in list to the Zeplin doc
https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5bb67aa50a86693f117fc827

## To Test
- visit http://localhost:3000/?p=pages-news-with-jama-examples
- **observe the JAMA network blocks are the same** as https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-news-with-jama-examples
- observe no other the social icon list looks the same
- We need to also test in D8
- to make sure you have the latest prod database run inside your vagrant `scripts/refresh-local -a one`
- set up your local.yml to use local SG2
- run `scripts/build`
- visit http://ama-one.local/delivering-care/diabetes/7-steps-get-prediabetic-patients-preventive-help-they-need
- observe the bullets are indented and match https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5bb67aa50a86693f117fc827
- Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6207-bullet-styling/html_report/index.html).



## Relevant Screenshots/GIFs
<img width="1032" alt="screen shot 2018-10-15 at 11 22 12 am" src="https://user-images.githubusercontent.com/2271747/46963950-90d93700-d06c-11e8-8cf3-673b088031f7.png">


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
