### PR TITLE
EWL-6292 - Fix category page hero padding

### DIFF
--- a/styleguide/source/_patterns/05-pages/category.twig
+++ b/styleguide/source/_patterns/05-pages/category.twig
@@ -17,7 +17,7 @@
       {% include '@organisms/subcategory-exploration.twig' %}
     </div>
 
-    <div class="container ama__category__row ama__category__row--no-mobile-padding ama__category__row--no-border">
+    <div class="container ama__category__row ama__category__row--no-mobile-padding">
       {#And I should see the "Category Page Hero"#}
       {#And I should see the "Tools List"#}
       {#And I should optionally see a promo in the "Promotional Real Estate" under the "Tools list"#}

--- a/styleguide/source/_patterns/05-pages/category.twig
+++ b/styleguide/source/_patterns/05-pages/category.twig
@@ -17,7 +17,7 @@
       {% include '@organisms/subcategory-exploration.twig' %}
     </div>
 
-    <div class="container ama__category__row ama__category__row--no-mobile-padding">
+    <div class="container ama__category__row ama__category__row--no-mobile-padding ama__category__row--hero">
       {#And I should see the "Category Page Hero"#}
       {#And I should see the "Tools List"#}
       {#And I should optionally see a promo in the "Promotional Real Estate" under the "Tools list"#}

--- a/styleguide/source/assets/scss/02-molecules/_category-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/_category-hero.scss
@@ -12,6 +12,7 @@
     @extend .ama__h3;
     @include gutter($padding-left-half...);
     @include gutter($padding-right-half...);
+    margin-bottom: 0;
 
     @include breakpoint($bp-small) {
       background: $purple;

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -26,6 +26,10 @@
     }
   }
 
+  &__row--hero {
+    border-top: 0;
+  }
+
   .ama__masthead {
     margin-bottom: $gutter / 4;
     padding: 0;

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -44,7 +44,7 @@
   }
 
   .ama__membership {
-    margin: $gutter 0;
+    margin: $gutter 0 0;
   }
 
   .ama__layout--split__right .ama__article-stub--category {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6292: Bug: Category Page Padding Issue](https://issues.ama-assn.org/browse/EWL-6292)

## Description
Category page hero image is creating too much padding below it. UX has asked that the padding below match the topic in focus label padding.

## To Test
- [ ] run `gulp serve`
- [ ] in D8 enable local SG2
- [ ] run `scripts/build`
- [ ] visit http://ama-one.local/education
- [ ] observe the padding below the has been reduced
- [ ] edit the `why join the ama block`
- [ ] reduce the amount of text it
- [ ] return to http://ama-one.local/education
- [ ] observe the padding below the hero is the same as the topic in focus section
- [ ] Did you test in IE 11?

- [ ] This PR has a dependency in D8
https://github.com/AmericanMedicalAssociation/ama-d8/pull/950

## Visual Regressions

n/a


## Relevant Screenshots/GIFs
<img width="1259" alt="screen shot 2018-10-19 at 4 27 45 pm" src="https://user-images.githubusercontent.com/2271747/47244666-f0607b00-d3bb-11e8-899b-74555b827cdc.png">


## Remaining Tasks
n/a


## Additional Notes
There is a D8 dependency
https://github.com/AmericanMedicalAssociation/ama-d8/pull/950
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
