### PR TITLE
EWL-6340 Fix CTA button to always be at the bottom of cards

### DIFF
--- a/styleguide/source/_patterns/02-molecules/people-listing/people-listing.twig
+++ b/styleguide/source/_patterns/02-molecules/people-listing/people-listing.twig
@@ -40,11 +40,13 @@
           {% include "@molecules/content-with-label.twig" %}
         {% endif %}
       {% endfor %}
-      
-      {% if peopleListingCard.button %}
-        {% set button = peopleListingCard.button %}
-        {% include "@atoms/button/button.twig" %}
-      {% endif %}
     </div>
   </div>
+
+  {% if peopleListingCard.button %}
+    {% set button = peopleListingCard.button %}
+    <div class="ama__people-listing-card__button-container">
+      {% include "@atoms/button/button.twig" %}
+    </div>
+  {% endif %}
 </div>

--- a/styleguide/source/_patterns/05-pages/people-listing.json
+++ b/styleguide/source/_patterns/05-pages/people-listing.json
@@ -1851,57 +1851,6 @@
                 }
               }
             ]
-          },
-          {
-            "heading": {
-              "level": "5",
-              "text": "Phone:",
-              "class": "ama__h5 title"
-            },
-            "paragraph" : {
-              "text": "(312) 646-4461",
-              "class": ""
-            }
-          },
-          {
-            "heading": {
-              "level": "5",
-              "text": "Fax:",
-              "class": "ama__h5 title"
-            },
-            "paragraph" : {
-              "text": "(312) 646-4461",
-              "class": ""
-            }
-          },
-          {
-            "heading": {
-              "level": "5",
-              "text": "Email:",
-              "class": "ama__h5 title"
-            },
-            "link": {
-              "title": "E-mail",
-              "href": "#",
-              "text": "jon.doe@ama-assn.org",
-              "target": "_self",
-              "class": "ama__link ama__link--purple"
-            }
-          },
-          {
-            "heading": {
-              "level": "5",
-              "text": "Conflict of Interest:",
-              "class": "ama__h5 title"
-            },
-            "link": {
-              "title": "PDF, 66.65 KB",
-              "href": "#",
-              "text": "PDF, 66.65 KB",
-              "target": "_self",
-              "class": "ama__link--icon",
-              "iconRight": "@atoms/media/icons/svg/icon-download.twig"
-            }
           }
         ],
         "button": {
@@ -2030,21 +1979,6 @@
               "text": "jon.doe@ama-assn.org",
               "target": "_self",
               "class": "ama__link ama__link--purple"
-            }
-          },
-          {
-            "heading": {
-              "level": "5",
-              "text": "Conflict of Interest:",
-              "class": "ama__h5 title"
-            },
-            "link": {
-              "title": "PDF, 66.65 KB",
-              "href": "#",
-              "text": "PDF, 66.65 KB",
-              "target": "_self",
-              "class": "ama__link--icon",
-              "iconRight": "@atoms/media/icons/svg/icon-download.twig"
             }
           }
         ],

--- a/styleguide/source/assets/scss/02-molecules/_people-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_people-listing.scss
@@ -1,40 +1,43 @@
 .ama__people-listing-card {
   background-color: $gray-7;
   width: 100%;
+  position: relative;
 
   .ama__image {
     width: 100%;
   }
 
-  &__bio a {
-    @include gutter($padding-bottom-half...);
-    display: block;
-  }
+  &__bio {
+    height: calc(100%  - 360px);
 
-  &__bio__heading {
-    @include gutter-all($padding-all-half...);
-  }
+    a {
+      @include gutter($padding-bottom-half...);
+      display: block;
+    }
 
-  &__bio .address-one {
-    margin-bottom: 0;
+    &__heading {
+      @include gutter-all($padding-all-half...);
+    }
+
+    .address-one {
+      margin-bottom: 0;
+    }
   }
 
   &__details {
     @include gutter-all($padding-all-half...);
     border-top: 1px solid $gray-50;
-  }
 
-  &__details {
-    .ama__link--icon{
+    .ama__link--icon {
       @extend .ama__type--small;
     }
   }
 
-  .ama__button--secondary {
-    width: 100%;
-  }
+  &__button-container {
+    @include gutter-all($padding-all-half...);
 
-  @include breakpoint($bp-small){
-    width: 281px;
+    .ama__button--secondary {
+      width: 100%;
+    }
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_people-listing.scss
+++ b/styleguide/source/assets/scss/05-pages/_people-listing.scss
@@ -9,6 +9,9 @@
     @include gutter($padding-bottom-full...);
     display: flex;
     flex-wrap: wrap;
+    height: 100%;
+    min-height: 100%;
+
 
     @include breakpoint($bp-small){
       @include grid_column_layout(4, 2, $gutter/2, $gutter/2);


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6340: Bug: People Bio - CTA Display Issue](https://issues.ama-assn.org/browse/EWL-6340)

## Description
The CTA button should always be at the bottom of the people listing card no matter how much info is in the card.

Note: this PR is a dependency of a D8 PR
https://github.com/AmericanMedicalAssociation/ama-d8/pull/934


## To Test
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-people-listing
- [ ] observe the CTA buttons for the people listing cards are on the bottom no matter how content is in the card
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6340-people-bio-cta/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1314" alt="screen shot 2018-10-22 at 2 04 13 pm" src="https://user-images.githubusercontent.com/2271747/47312983-6145a400-d603-11e8-8a3c-37d42464a588.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
