### PR TITLE
EWl-5835 Fix news article no author byline

### DIFF
--- a/styleguide/source/_patterns/05-pages/news/news.twig
+++ b/styleguide/source/_patterns/05-pages/news/news.twig
@@ -2,7 +2,9 @@
 
 {% block contentTop %}
   {% include '@organisms/masthead/masthead.twig' %}
-  {% include "@molecules/inline-bio.twig" %}
+  <div class="container">
+    {% include "@molecules/inline-bio.twig" %}
+  </div>
 {% endblock %}
 
 {% block pageContent %}

--- a/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
@@ -1,8 +1,11 @@
 .ama__inline-bio {
-  border-bottom: 1px solid $gray-50;
   @include gutter($padding-top-half...);
   @include gutter($padding-bottom-half...);
+  border-bottom: 1px solid $gray-50;
 
+  @include breakpoint($bp-small) {
+    margin: 0 -15px;
+  }
 
   &__image {
     display: none;

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -2,8 +2,7 @@
   display: grid;
   display: -ms-grid;
   grid-template-columns: 1fr ;
-  @include gutter($padding-left-full...);
-  @include gutter($padding-right-full...);
+  @include gutter-all($padding-all-full...);
 
   @include breakpoint($bp-med min-width) {
     padding: 0;
@@ -66,6 +65,7 @@
 
     &__container {
       overflow: hidden;
+      display: grid;
     }
 
     .ama__h1 {
@@ -93,6 +93,10 @@
         grid-column: 4 / 5;
         grid-row: 3;
         display: block;
+      }
+
+      .ama__social-share {
+        justify-content: flex-end;
       }
     }
   }

--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -35,7 +35,9 @@
     }
 
     @include breakpoint($bp-med min-width) {
-      padding: 0;
+      @include gutter($padding-top-full...);
+      padding-right: 0;
+      padding-left: 0;
       grid-column:  1 / 3;
       grid-row: 2 / 4;
     }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5835: A1 News Article - No Author Design](https://issues.ama-assn.org/browse/EWL-5835)

## Description
UX has asked to update the news articles for when no author is present.

Note: This is dependency of a PR in D8
https://github.com/AmericanMedicalAssociation/ama-d8/pull/935

## To Test
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-news
- [ ] does it match prod? https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-news
- [ ] Did you test in IE 11?

## Visual Regressions



## Relevant Screenshots/GIFs
<img width="1508" alt="screen shot 2018-10-22 at 3 31 04 pm" src="https://user-images.githubusercontent.com/2271747/47317558-83452380-d60f-11e8-9d70-f72605da090d.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
