### PR TITLE
Add search filter text box js

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -46,7 +46,8 @@
       "source/assets/js/webforms.js",
       "source/assets/js/main-navigation.js",
       "source/assets/js/category-menu.js",
-      "source/assets/js/sign-in-dropdown.js"
+      "source/assets/js/sign-in-dropdown.js",
+      "source/assets/js/search-checkbox.js"
 
     ],
     "dest"  : "public/assets/js/"

--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -29,6 +29,9 @@
             }
           }
 
+          // jQueryUI selectmenu method
+          $('.ama__select-menu__select').selectmenu();
+
           // Start search filter
 
           var availableTags = [

--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -32,6 +32,11 @@
           // jQueryUI selectmenu method
           $('.ama__select-menu__select').selectmenu();
 
+          // Submits the search form after a select menu items has been selected
+          $('.ama__select-menu__select').on('selectmenuchange', function() {
+            $('#block-exposedformacquia-searchpage').submit();
+          });
+
           // Start search filter
 
           var availableTags = [
@@ -294,7 +299,6 @@
           }
 
           listFilter($("#ama__search__location"), $(".ama__form-group"));
-
         });
       })(jQuery);
     }

--- a/styleguide/source/assets/js/search-checkbox.js
+++ b/styleguide/source/assets/js/search-checkbox.js
@@ -1,0 +1,35 @@
+(function ($, Drupal) {
+  Drupal.behaviors.ama_search_checkbox = {
+    attach: function (context, settings) {
+
+      var $categorySearchInput = $('#search_category');
+      var $categorySearchList = $('.facets-widget-checkbox ul li');
+      var $clearSearchFilter = $('#appliedFiltersRemove');
+
+      // Filter list using jQuery filter
+      function filterList(searchBox, list) {
+        searchBox.keyup(function () {
+          var $regex = new RegExp(this.value, 'i');
+          list.hide().filter(function () {
+            return $regex.test($.trim($(this).text()));
+          }).show();
+        });
+      }
+
+      // Clear filter
+      function cleafFilterList(clearSearchFilter) {
+        clearSearchFilter.click(function (e) {
+          e.preventDefault();
+          $categorySearchInput.val('');
+          $categorySearchInput.trigger('keyup');
+        });
+      }
+
+      // Invoke filter list
+      filterList($categorySearchInput, $categorySearchList);
+
+      // Invoke clear filter
+      cleafFilterList($clearSearchFilter);
+    }
+  };
+})(jQuery, Drupal);

--- a/styleguide/source/assets/scss/00-base/_forms.scss
+++ b/styleguide/source/assets/scss/00-base/_forms.scss
@@ -26,6 +26,7 @@ textarea {
   @include font-size($p-font-sizes);
   outline: none;
   border: 1px solid $gray-7;
+  border-radius: 0;
   display: block;
   box-shadow: none;
   width: 100%;

--- a/styleguide/source/assets/scss/01-atoms/_checkbox.scss
+++ b/styleguide/source/assets/scss/01-atoms/_checkbox.scss
@@ -54,5 +54,9 @@
         background-position: -63px -143px;
       }
     }
+
+    .facet-item__count {
+      margin-left: $gutter/4;
+    }
   }
 }

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -19,11 +19,13 @@
     border: 0;
     border-bottom: 1px solid $light-blue;
     color: $gray-50;
-    line-height: initial;
+    line-height: 1.2;
     padding: 1em 28px 3px 0;
 
     &:focus,
     &:active {
+      border: 0;
+      border-bottom: 1px solid $light-blue;
       color: $black;
       font-style: normal;
     }
@@ -32,14 +34,15 @@
   .form-submit {
     @extend .icon--search;
     background-color: transparent;
-    background-size: 23px 25px;
+    background-size: 23px 45px;
+    background-position: 0 -10px;
     width: 23px;
-    height: 25px;
+    height: 45px;
     padding: 0;
     margin: 0;
     min-height: 25px;
     min-width: 25px;
-    max-height: 25px;
+    max-height: 30px;
     max-width: 25px;
     text-indent: -999px;
     overflow: hidden;
@@ -56,9 +59,12 @@
   // This has to be specific b/c it's so different.
   &__button {
     margin-left: -24px;
-    background: none;
+    background-color: transparent;
     border: none;
     padding: 0;
+    background-size: 25px 25px;
+    min-height: 25px;
+    max-height: 25px;
   }
 
   &--in-body {

--- a/styleguide/source/assets/scss/02-molecules/_applied_filters.scss
+++ b/styleguide/source/assets/scss/02-molecules/_applied_filters.scss
@@ -33,6 +33,10 @@
     display: block;
     text-decoration: underline;
     color: $purple;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   &__tag {

--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -33,7 +33,7 @@
     line-height: 0;
 
     @include breakpoint($bp-small) {
-      padding: 0;
+      padding: 0 $gutter/4;
       display: block;
       max-height: 32px;
       min-height: 32px;

--- a/styleguide/source/assets/scss/02-molecules/_search-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-header.scss
@@ -35,8 +35,8 @@
   }
 
   &__options,
-  .js-form-item-sort-by {
-    display: none;
+  .form-item.js-form-item-sort-by {
+    margin: 0;
     order: 4;
 
     .ama__form-group {
@@ -51,6 +51,10 @@
           vertical-align: initial;
         }
       }
+    }
+
+    .ui-selectmenu-button {
+      margin: 0;
     }
 
     @include breakpoint($bp-small) {
@@ -109,7 +113,6 @@
       .source-summary-count {
         display: block;
       }
-
     }
 
     .ama__search__field {
@@ -121,12 +124,11 @@
       .ui-autocomplete-input {
         @include font-size($h1-font-sizes);
         background: none !important; //only way to hide the Drupal throbber
-        padding-left: 0;
-        padding-right: 0;
         border-bottom: 1px solid $hoverBlue;
         color: $purple;
         font-style: normal;
         font-weight: 600;
+        line-height: 0;
 
         &:focus {
           border: none;

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -39,27 +39,30 @@
     }
   }
 
-  &__text {
-    flex: 2;
-  }
-
-  &__image {
-    @include gutter($margin-left-full...);
-    display: none;
-
-    .ama__image {
-      max-width: 234px;
-    }
-
-    @include breakpoint($bp-med) {
-      display: block;
-    }
-  }
 
   &--best-bet {
     margin-bottom: 0;
+
     p {
       line-height: 1.25em;
+    }
+
+    &__text {
+      width: unset;
+      flex: 2;
+    }
+
+    &__image {
+      @include gutter($margin-left-full...);
+      display: none;
+
+      .ama__image {
+        max-width: 234px;
+      }
+
+      @include breakpoint($bp-med) {
+        display: block;
+      }
     }
   }
 


### PR DESCRIPTION
## Ticket(s)

## JIRA Ticket(s)
- [EWL-6369: sort by missing](https://issues.ama-assn.org/browse/EWL-6369)
- [EWL-6372: open text search box missing](https://issues.ama-assn.org/browse/EWL-6372)
- [EWL-6371: filters missing](https://issues.ama-assn.org/browse/EWL-6371)
- [EWL-6368:  search category in reverse order](https://issues.ama-assn.org/browse/EWL-6368)

## Description:
The changes in this PR don't affect SG2. They support D8 functional and look and feel changes.
The changes include:
- jQuery UI selectmenu called for the sort dropdown with a callback for when the selectmenu dropdown changes it will submit the search form
- A text filter method using jQuery filter was added to be able to filter the checkbox facets
- Various look and feel changes were added to support including the new text filter input above the search facets
- the main search header input was also modified so the input and the sort by would line up

## To Test
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-search-results
- [ ] observe nothing the only change is that the best bets row is no longer squished. Compare it to https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-search-results
- [ ] Did you test in IE 11?

## Visual Regressions

## Relevant Screenshots/GIFs
<img width="1464" alt="screen shot 2018-10-23 at 11 40 45 am" src="https://user-images.githubusercontent.com/2271747/47376547-7fb9a700-d6b8-11e8-9673-86fc86d5a90f.png">

## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
