### PR TITLE
EWL-6374 max width of best bets image

### DIFF
--- a/styleguide/source/_patterns/02-molecules/search-result/search-result.twig
+++ b/styleguide/source/_patterns/02-molecules/search-result/search-result.twig
@@ -1,14 +1,14 @@
 {% set image = searchResult.image %}
 {% set link = searchResult.title %}
 {% set classes = [
-  searchResult.bestBet ? "ama__search-result--best-bet"
+searchResult.bestBet ? "ama__search-result--best-bet"
 ] %}
 
 {% set link = searchResult.link %}
 
 
 <div class="ama__search-result {{ classes|join(' ') }}">
-  <div class="ama__search-result__text">
+  <div class="{{ searchResult.bestBet ? 'ama__search-result--best-bet__text' : 'ama__search-result__text' }}">
     {% if searchResult.category %}
       {% include "@atoms/paragraph.twig" with { "paragraph" : searchResult.category } %}
     {% endif %}
@@ -27,7 +27,7 @@
     {% endif %}
   </div>
   {% if image %}
-    <div class="ama__search-result__image">
+    <div class={{ searchResult.bestBet ? 'ama__search-result--best-bet__image' : 'ama__search-result__image' }}>
       {% include "@atoms/image/image.twig" %}
     </div>
   {% endif %}

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -39,27 +39,35 @@
     }
   }
 
-  &__text {
-    flex: 2;
-  }
-
-  &__image {
-    @include gutter($margin-left-full...);
-    display: none;
-
-    .ama__image {
-      max-width: 234px;
-    }
-
-    @include breakpoint($bp-med) {
-      display: block;
-    }
-  }
 
   &--best-bet {
     margin-bottom: 0;
+
+    & > div {
+      width: auto;
+    }
+
     p {
       line-height: 1.25em;
+    }
+
+    &__text {
+      @include gutter($margin-right-half...);
+      width: unset;
+      flex: 2;
+    }
+
+    &__image {
+      @include gutter($margin-left-full...);
+      display: none;
+
+      .ama__image {
+        max-width: 566px;
+      }
+
+      @include breakpoint($bp-med) {
+        display: block;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -61,7 +61,7 @@
       display: none;
 
       .ama__image {
-        max-width: 566px;
+        max-width: 283px;
       }
 
       @include breakpoint($bp-med) {


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6374: A1 | Max width of best bets image](https://issues.ama-assn.org/browse/EWL-6374)


## Description:
Best bets image size is incorrect. It should be 566x370

## To Test
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-search-results
- [ ] observe best best section is no longer squished and the image has a max width of 566px
- [ ] make sure only the best bets row has not changed compare 
http://localhost:3000/?p=pages-search-results to https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-search-results

- [ ]  the rest of the instructions are in https://github.com/AmericanMedicalAssociation/ama-d8/pull/940
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6374-best-bets-image-size/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1428" alt="screen shot 2018-10-16 at 4 34 34 pm" src="https://user-images.githubusercontent.com/2271747/47049010-aed49380-d161-11e8-97cf-40c3d73b469e.png">


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
