### PR TITLE
EWL-5663 - Fix table text not wrapping within cells

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -46,6 +46,8 @@ thead {
     th {
       display: block;
       border: 1px solid $gray-50;
+      hyphens: auto;
+      vertical-align: top;
 
       @include breakpoint($bp-small) {
         display: table-cell;
@@ -78,6 +80,7 @@ tbody {
       display: block;
       padding: 2px 2px 2px 50%;
       position: relative;
+      hyphens: auto;
 
       @include breakpoint($bp-small) {
         display: table-cell;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-5663: SG2 | Auto-size Table Cell Width and Wrap Text](https://issues.ama-assn.org/browse/EWL-5663)

## Description
Text within table cells are not wrapping but overflowing into the next cell.

## To Test
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-resource
- [ ] click on the table icon tab on the right hand side of the page
- [ ] observe the text wraps with a hyphen if it doesn't fit in the cell
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-5663-auto-size-table-cell/html_report/index.html).



## Relevant Screenshots/GIFs
<img width="986" alt="screen shot 2018-10-23 at 4 10 08 pm" src="https://user-images.githubusercontent.com/2271747/47390924-219fba80-d6de-11e8-80a3-2cb655c091bc.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
