### PR TITLE
[EWL-6355] Correct Page Mastheads

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_social-share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_social-share.scss
@@ -45,6 +45,7 @@ $social-icons: (
   display: flex;
   margin: 0;
   padding: 0;
+  min-height: 38px;
 
   li ~ li {
     margin-left: $gutter/2;

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -66,6 +66,9 @@
 
     &__container {
       overflow: hidden;
+      @include breakpoint($bp-small) {
+        display: flex;
+      }
     }
 
     .ama__h1 {
@@ -81,8 +84,7 @@
 
     &__date {
       @include gutter($padding-top-full...);
-      grid-column: 1/3;
-      grid-row: 3;
+      flex: 1 0 70%;
     }
 
     &__share {
@@ -90,8 +92,7 @@
 
       @include breakpoint($bp-small) {
         @include gutter($padding-top-full...);
-        grid-column: 4 / 5;
-        grid-row: 3;
+        flex: 0 1 auto;
         display: block;
       }
     }

--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -35,7 +35,7 @@
     }
 
     @include breakpoint($bp-med min-width) {
-      padding: 0;
+      padding: $gutter 0 0 0;
       grid-column:  1 / 3;
       grid-row: 2 / 4;
     }

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -18,6 +18,10 @@
   &__row--no-border {
     border: 0;
     padding: 0;
+    //For D8, dynamically remove border on category page hero parent div placed via layout builder
+    &:first-of-type + * + .ama__layout--two-col-right--75-25 {
+      border: 0;
+    }
   }
 
   &__row--hidden-mobile {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6355: A1 | Correct Page Mastheads](https://issues.ama-assn.org/browse/EWL-6355)

## Description
- Adds flex properties to masthead where data and social share are present, correcting event detail page regression.
- Adds style logic for category pages heroes, preventing additional top border in D8. 
- Corrects spacing inconsistencies with social share buttons in mastheads between SG2 and D8.
- Corrects spacing between page content and masthead on two column right layouts such as the News page.

### Dependencies
[EWL-6355: Correct Page Mastheads #944](https://github.com/AmericanMedicalAssociation/ama-d8/pull/944)

## To Test
- Pull `bugfix/EWL-6355-correct-page-mastheads` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work relies on template updates in [EWL-6355: Correct Page Mastheads #944](https://github.com/AmericanMedicalAssociation/ama-d8/pull/944). Update ama-d8 branch and local provision vars accordingly. 
- Ensure you have prod content before testing further.
- For every content type, confirm social share buttons have proper spacing between them and bottom border of masthead.
- Go to any category page and confirm hero no longer has thick top border.
- Go to any news article and confirm spacing exists between left content and masthead bottom border.
- Go to any event page and confirm date and social share icons are inline.
- Test this in IE 11, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6355-correct-page-mastheads/html_report/index.html).


## Relevant Screenshots/GIFs
Check JIRA ticket for screenshots of incorrect display.


## Remaining Tasks
N/A


## Additional Notes
N/A
