### PR TITLE
EWL-6401 remove bullets from hub card descriptions

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -8,11 +8,10 @@
   text-decoration: none;
   min-height: 400px;
   width: 100%;
-  
+
   &__heading,
   & .ama__h2 {
     @include gutter($margin-top-full...);
-    margin-bottom: 0;
   }
 
   &__description {
@@ -49,6 +48,15 @@
   @at-root {
     a:hover#{&} {
       background-color: darken($gray-7, 10%);
+    }
+  }
+
+  ul {
+    list-style: none;
+
+    li {
+      list-style: none;
+      line-height: inherit;
     }
   }
 

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -19,7 +19,6 @@
     h1,
     h2 {
       @include gutter($padding-top-half...);
-      margin-bottom: 0;
     }
   }
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6401: Hub Page bullets](https://issues.ama-assn.org/browse/EWL-6401)

## Description
Currently there random UL bullets showing in the hub card descriptions. This PR removes the bullets and restores the normal line height of the UL

## To Test
- [ ] this PR needs to be tested in D8
- [ ] switch your SG2 branch to `bugfix/hub-cards-bullets`
- [ ] enable local SG2 in local.yml in D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/node/23541
- [ ] observe the bullets in the hub card descriptions are removed
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/hub-cards-bullets/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1245" alt="screen shot 2018-10-25 at 10 56 52 am" src="https://user-images.githubusercontent.com/2271747/47513848-b1f80f80-d844-11e8-8228-40a5c48151fe.png">


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
