### PR TITLE
Quick fix: Filter reset on search page doesn't clear checkboxes

### DIFF
--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -189,7 +189,11 @@
             });
           }
 
-          $('[type=checkbox]').checkboxradio();
+          $('[type=checkbox]').each( function() {
+            $('[type=checkbox]').checkboxradio();
+          });
+
+
           $('[type=radio]').checkboxradio().buttonset().find('label').css('width', '19.4%');
 
           $('.textarea').keyup(function() {

--- a/styleguide/source/assets/js/search-checkbox.js
+++ b/styleguide/source/assets/js/search-checkbox.js
@@ -22,6 +22,11 @@
           e.preventDefault();
           $categorySearchInput.val('');
           $categorySearchInput.trigger('keyup');
+
+          $('.facets-widget-checkbox ul li [type=checkbox]').each( function() {
+            $(this).prop("checked", false);
+            $('#block-exposedformacquia-searchpage').submit();
+          });
         });
       }
 


### PR DESCRIPTION
## Description
Filter reset on search page doesn't clear checkboxes

## To Test
- [ ] enable local SG2 for your D8 instance
- [ ] do a search 
- [ ] open the category facets accordion
- [ ] click on one of checkboxes
- [ ] fill in category search filter and click on any of the checkboxes
- [ ] observe the page reloads and all the filters are removed
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
n/a

## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
