### PR TITLE
EWL-6107 Fix indentation of homepage four up lists caused by bullet styling

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_four-up-lists.scss
+++ b/styleguide/source/assets/scss/03-organisms/_four-up-lists.scss
@@ -29,6 +29,10 @@
         &:nth-child(5){
           margin-left: 0;
         }
+
+        ul li {
+          margin-left: 0;
+        }
       }
 
       &--mobile {

--- a/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
@@ -22,11 +22,6 @@
       @extend %ama__type--small;
     }
 
-    .ama__article-stub__title {
-      padding: 0;
-    }
-
-
     @include breakpoint($bp-small) {
       @include gutter($padding-left-half...);
 

--- a/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
@@ -22,6 +22,11 @@
       @extend %ama__type--small;
     }
 
+    .ama__article-stub__title {
+      padding: 0;
+    }
+
+
     @include breakpoint($bp-small) {
       @include gutter($padding-left-half...);
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6207: Addition of SG2 styling of bullets per new zeplins](https://issues.ama-assn.org/browse/EWL-6207)

## Description
The original PR to fix the bullets on articles has caused indentation issues in the four up article stubs. This PR address those indentation.

<img width="1149" alt="default_homepage___american_medical_association" src="https://user-images.githubusercontent.com/2271747/47576591-79226e00-d90a-11e8-9d25-8cbd2a99312b.png">


## To Test
- [ ] enable local SG2 in your D8
- [ ] visit the homepage
- [ ] scroll down to the four up links
- [ ] observe the indentation has been removed
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6207-bullets-styling-causing-indentation/html_report/index.html).



## Relevant Screenshots/GIFs
<img width="1203" alt="screen shot 2018-10-26 at 10 33 45 am" src="https://user-images.githubusercontent.com/2271747/47576645-a0793b00-d90a-11e8-85b2-4e2c31ca4f58.png">

## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
