### PR TITLE
EWL-6421 Fix email subscription in the footer 

### DIFF
--- a/styleguide/source/assets/js/webforms.js
+++ b/styleguide/source/assets/js/webforms.js
@@ -130,6 +130,11 @@
           $(".webform-submission-form").validate().element(this);
         }
       });
+
+      // Copies email input values from email subscription and inserts into the other email subscription form on page
+      $('.webform-submission-email-subscription-form').find('input[name=email]').keyup(function(e) {
+        $('.webform-submission-email-subscription-form').find('input[name=email]').val($(this).val());
+      });
     }
   };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/scss/00-base/_forms.scss
+++ b/styleguide/source/assets/scss/00-base/_forms.scss
@@ -39,6 +39,7 @@ textarea {
 
   &.error {
     border: 1px solid $red;
+    background-color: $white;
   }
 
   &.valid {


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6421: A1 | Reuse Email Subscription Webform for Footer](https://issues.ama-assn.org/browse/EWL-6421)


## Description:
The footer email subscription form in the footer is causing validation errors in the other email subscription form on the homepage. This PR address this issue by copying the values from the first email subscription form and inserts into the other form.

## To Test:
- switch your SG2 branch to `bugfix/EWL-6421-reuse-email-subscription`
- `gulp serve`
- switch your D8 branch to `bugfix/EWL-6421-reuse-email-subscription` (https://github.com/AmericanMedicalAssociation/ama-d8/pull/968)
- enable local SG2 in your D8 instance
- `drush @one.local cr`
- visit the homepage
- scroll to the footer
- input an invalid email into the form and click submit
- scroll to other email subscription midway down the page
- observe the input has the same value you just entered in the footer and also errors
- enter a valid email in any of the two email subscription forms
- observe both forms now say thank you
- in the backend look at the email_subscription list to see if your entry exists (http://ama-one.local/admin/structure/webform/manage/email_subscription/results/submissions)


## Automated Test:
n/a

## Style Guide:
n/a

## Relevant Screenshots/GIFs:
<img width="1408" alt="screen shot 2018-10-26 at 5 05 25 pm" src="https://user-images.githubusercontent.com/2271747/47594527-59f30300-d941-11e8-9d48-395023466eb0.png">


## Additional Notes:
Anything more to add?


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
