### PR TITLE
EWL-6429 Fix multi CTA card

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -16,10 +16,13 @@
 
   &__heading,
   & .ama__h2 {
+    @include gutter($padding-top-half...);
+    @include gutter($margin-bottom-half...);
+
     h1,
     h2 {
       @include gutter($padding-top-half...);
-      margin-bottom: 0;
+      @include gutter($margin-bottom-half...);
     }
   }
 
@@ -89,7 +92,6 @@
 
     a {
       @extend %ama__button;
-      display: block;
     }
   }
 


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6429: Hub Template - Card CTA Display Issue](https://issues.ama-assn.org/browse/EWL-6429)


## Description:
1.    For the “Text-Only CTA” card, the button spans the entire width of the card.

## To Test:
- switch you SG2 branch to `bugfix/EWL-6429-hub-carda-cta-display`
- gulp serve
- enable local SG2 in your D8 instance
- switch your D8 branch to `bugfix/EWL-6429-hub-carda-cta-display` (https://github.com/AmericanMedicalAssociation/ama-d8/pull/971)
- visit http://ama-one.local/node/24416
- if the above URL returns a 404 run `scripts/refresh-local -a one`
- clear your cache `drush @one.local cr`
- observe the cards now have a default select option `Select an Option`
- create a new multi CTA card with on link
- observe the button matches the other buttons on the page
- observe the Text only CTA button doesn't span entire width of card


## Relevant Screenshots/GIFs:
<img width="1144" alt="screen shot 2018-10-29 at 12 28 10 pm" src="https://user-images.githubusercontent.com/2271747/47668319-1fbe7700-db76-11e8-8bf4-73cfeecf74c6.png">


## Additional Notes:
n/a


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
