### PR TITLE
EWL-6453 removes bullets in the related links tab on resource page

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -48,6 +48,7 @@
     }
 
     + li {
+      list-style: none;
       padding-left: 4px;
     }
   }
@@ -68,6 +69,8 @@
 li {
   &.js--tab-start--mobile{
     display: block;
+    list-style: none;
+    
     @include breakpoint($bp-small) {
       display: none;
     }
@@ -201,8 +204,10 @@ li {
 }
 
 section#related_links ul {
-  list-style-type: none;
+  list-style: none;
+
   li {
+    list-style: none;
     margin: 0;
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6453: SG2 | Resource page related links list has bullets when it shouldn't](https://issues.ama-assn.org/browse/EWL-6453)

## Description
The resource page related links tab has bullets in the list. The bullets should not be there.

<img width="1301" alt="medical_ethics_of_consent___informed_consent_medical_ethics___ama" src="https://user-images.githubusercontent.com/2271747/47738314-e4d54580-dc40-11e8-9e78-a529ae1155f8.png">


## To Test
- [ ] Switch your SG2 branch to `bugfix/EWL-6453-resource-page-bullets`
- [ ] Enable local SG2 in your D8 instance
- [ ] Visit http://ama-one.local/delivering-care/ethics/code-medical-ethics-consent-communication-decision-making#related_links
- [ ] if the above link results in a 404 run `scripts/refresh-local -a one` && `drush @one.local cr`
- [ ] click on the related links tab on the right hand side of the page
- [ ] observe no bullets in the related links list
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="1522" alt="screen shot 2018-10-30 at 12 42 12 pm" src="https://user-images.githubusercontent.com/2271747/47738498-3ed60b00-dc41-11e8-94e0-5657733bd0a3.png">


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
