### PR TITLE
[EWL-6491] Homepage JAMA Component Padding and Border Color

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_jama.scss
+++ b/styleguide/source/assets/scss/02-molecules/_jama.scss
@@ -67,6 +67,7 @@
   min-width: 265px;
   max-width: 100%;
   display: inline-block;
+  margin-bottom: $gutter / 2;
 }
 
 .ama__jama__title {
@@ -74,7 +75,6 @@
   text-transform: uppercase;
   font-weight: bold;
   display: flex;
-  margin-top: $gutter / 2;
   margin-bottom: $gutter / 4;
 
   .ama__icon {
@@ -152,7 +152,7 @@
         @include gutter($margin-right-full...);
         width: 25%;
         list-style: none;
-        border-top: 1px solid $gray-50;
+        border-top: 1px solid $gray-20;
 
         &:last-child {
           margin-right: 0;


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6491: A1 | Homepage JAMA component padding](https://issues.ama-assn.org/browse/EWL-6491)
- [EWL-6489: Homepage Jama component Space Padding Issue](https://issues.ama-assn.org/browse/EWL-6489)

## Description
Moves the margin to the JAMA header instead of the subtitle to ensure vertical spacing when subtitle is not used. This also corrects the border color for homepage JAMA component. Please reference [JAMA Integration Revised zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5b6b484eb3d27d76f5a9f9af) for visual reference.


## To Test
- Pull `bugfix/jama-component-padding` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work affects visuals in D8 and should be tested against it to ensure there are no regressions. Update ama-d8 branch and local provision vars accordingly. 
- Go to homepage and confirm proper vertical padding between JAMA header and article borders and top border for each article is #CBCBCB.
- Go to any news article with the JAMA component and confirm correct spacing according to Zeplin.
- Test this in IE 11, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/jama-component-padding/html_report/index.html).


## Relevant Screenshots/GIFs
[JAMA Integration Revised zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5b6b484eb3d27d76f5a9f9af) 


## Remaining Tasks
N/A


## Additional Notes
N/A
