### PR TITLE
EWL-6460 Fixes homepage subscribe input not showing in IE11

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -56,6 +56,7 @@
     .ama__subscribe-promo__form form {
       display: flex;
       flex-direction: column;
+      width: 100%;
 
       .ama__form-group,
       .form-actions {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-6460:A1 | Homepage subscribe promo input missing in IE 11](https://issues.ama-assn.org/browse/EWL-6460)

## Description
IE11 homepage subscribe does not show up
![image](https://user-images.githubusercontent.com/2271747/47941052-b6629f00-deba-11e8-9274-9349c1d22ebf.png)


## To Test
- [ ] switch your SG2 branch to `bugfix/EWL-6460-homepage-subscribe-email-IE11`
- `gulp serve`
- enable SG2 in in your D8 instance
- visit the homepage (http://ama-one.local/) in IE11. I used https://live.browserstack.com/
- scroll down to the subscribe section 
- observe the email input shows
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="1251" alt="screen shot 2018-11-02 at 4 20 29 pm" src="https://user-images.githubusercontent.com/2271747/47941219-3be64f00-debb-11e8-8aae-4c1d9334b2de.png">


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
