### PR TITLE
EWL-6365 Add hover style to org links

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_org-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_org-nav.scss
@@ -14,6 +14,10 @@
       font-size: .778em;
       line-height: 2.214em;
       font-weight: 600;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 }


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6365: Ticket Title](https://issues.ama-assn.org/browse/EWL-6365)


## Description:
Links in the org and prod nav should have an underline when a user hover over them

## To Test:
- switch your SG2 branch to `bugfix/EWL-6365-category-nav-links-hover`
- run `gulp serve`
- switch your D8 branch to `bugfix/EWL-6365-category-nav-links-hover`
- enable local SG2 in your D8 in your local.yml 
- in another terminal window do a `scripts/build` outside your vagrant
- visit http://ama-one.local/
- if the category or org navs don't appear on top run `scripts/refresh-local -a one`
- `drush @one.local cr`
- hover over the links 
- observe the links now have an underline

## Automated Test:
n/a

## Style Guide:


## Relevant Screenshots/GIFs:
<img width="1178" alt="screen shot 2018-11-05 at 1 05 44 pm" src="https://user-images.githubusercontent.com/2271747/48020430-8524e180-e0fb-11e8-91ac-01b2bed318e1.png">


## Additional Notes:
n/a

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
