### PR TITLE
EWL-6510: Target ama__layout--split on homepage, override previously …

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -140,4 +140,14 @@
     @include gutter($margin-top-full...);
     @include gutter($margin-bottom-full...);
   }
+
+  // Do some ugly things for go/no-go launch fixes.
+  // Set the split container to initial padding from _grid.scss
+  .ama__layout--split {
+    &.container {
+      @include breakpoint($bp-small max-width) {
+        padding: 0 15px;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6510: Homepage mobile - article stubs padding](https://issues.ama-assn.org/browse/EWL-6510)

## Description
Overrides the `.ama__layout--split.container` class on the homepage only, so that the article stubs at the top of the page have padding on mobile. 


## To Test
- [ ] Test this locally with your AMA One D8 site. 
- [ ] Look at the homepage at the mobile viewport.  Observe there is padding around the article stubs at the top.

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
### Before
![image](https://user-images.githubusercontent.com/4048700/48024029-1fd5ee00-e105-11e8-9e7e-e4d6d3960fda.png)


### After
![image](https://user-images.githubusercontent.com/4048700/48024001-059c1000-e105-11e8-83a9-efec1a8f1d15.png)


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
