### PR TITLE
[EWL-6502] Homepage promo ratios

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -49,8 +49,8 @@
       color: $homepagePurple;
     }
     @include breakpoint($bp-med) {
-      flex: 0 0 70%;
-      max-width: 70%;
+      flex: 0 0 55%;
+      max-width:55%;
       padding: 10px 5.5% 10px 10px;
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_four-up-lists.scss
+++ b/styleguide/source/assets/scss/03-organisms/_four-up-lists.scss
@@ -23,10 +23,15 @@
       &--desktop {
         @include gutter($margin-bottom-full...);
         @include gutter($margin-left-full...);
+
+        @include breakpoint(max-width $bp-large){
+          &:nth-child(5){
+            margin-left: 0;
+          }
+        }
         width: calc(50% - 28px);
 
-        &:first-child,
-        &:nth-child(5){
+        &:first-child {
           margin-left: 0;
         }
 

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -40,12 +40,12 @@
 
     @include breakpoint($bp-med) {
       .ama__promo--homepage {
-        flex-basis: 60%;
+        flex-basis: 50%;
 
         &:last-child {
           margin-left: -5%;
-          flex: 0 0 35%;
-          max-width: 35%;
+          flex: 0 0 50%;
+          max-width: 50%;
 
           button{
             // Button should have a min width so that buttons with small words do not feel cramped


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6502 | Homepage promo - desktop](https://issues.ama-assn.org/browse/EWL-6502)

## Description
This work makes the homepage promo ratio closer to 50/50. It also fixes missing margin on 3rd column of "Explore topics" section.

Please reference [Homepage zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5b313db4a1cee6697422dd24) for visual reference.


## To Test
- Pull `bugfix/EWL-6502-homepage-promo` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work affects visuals in D8 and should be tested against it to ensure there are no regressions. Update ama-d8 branch and local provision vars accordingly. 
- Go to homepage and check that promos are roughly 50/50. It should line up with start of third column of the "Explore products" section.
- Check that "Explore topics" section has proper horizontal spacing between 2nd and 3rd columns.
- Test this in IE 11, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6502-homepage-promo/html_report/index.html).


## Relevant Screenshots/GIFs
Screenshot from Drupal
![image](https://user-images.githubusercontent.com/4438120/48025057-01bdbd00-e108-11e8-91c1-9b99ffa07dfa.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
