### PR TITLE
[EWL-6511/EWL-6523] Homepage Main Content Subscribe Promo

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -14,7 +14,7 @@
       @extend .ama__button--homepage;
       display: block;
       margin: 0 auto;
-      padding:  $gutter / 2.2;
+      padding: $gutter / 2.2;
       border: 0;
       height: 49px;
 
@@ -105,7 +105,7 @@
     .ama__subscribe-promo__form form {
       flex-direction: column;
       flex-wrap: nowrap;
-      @include breakpoint($bp-small){
+      @include breakpoint($bp-small) {
         flex-direction: row;
       }
 

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -103,8 +103,11 @@
     }
 
     .ama__subscribe-promo__form form {
-      flex-direction: row;
+      flex-direction: column;
       flex-wrap: nowrap;
+      @include breakpoint($bp-small){
+        flex-direction: row;
+      }
 
       .ama__form-group {
         flex: 1;

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -105,7 +105,7 @@
     .ama__subscribe-promo__form form {
       flex-direction: column;
       flex-wrap: nowrap;
-      @include breakpoint($bp-small) {
+      @include breakpoint($bp-med) {
         flex-direction: row;
       }
 

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -111,8 +111,10 @@
 
       .ama__form-group {
         flex: 0 0 auto;
+        margin-bottom: $gutter-mobile/2;
         @include breakpoint($bp-large){
           flex: 1;
+          margin-bottom: auto;
         }
       }
 

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -105,7 +105,7 @@
     .ama__subscribe-promo__form form {
       flex-direction: column;
       flex-wrap: nowrap;
-      @include breakpoint($bp-med) {
+      @include breakpoint($bp-large) {
         flex-direction: row;
       }
 

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -110,7 +110,10 @@
       }
 
       .ama__form-group {
-        flex: 1;
+        flex: 0 0 auto;
+        @include breakpoint($bp-large){
+          flex: 1;
+        }
       }
 
       .ama__button {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6511 | Homepage - mobile](https://issues.ama-assn.org/browse/EWL-6511)
- [EWL-6523 | Homepage Tablet - Subscribe Promo](https://issues.ama-assn.org/browse/EWL-6523)

## Description
This work makes the homepage subscribe promo inputs stack on mobile and tablet for main content only.


## To Test
- Pull `bugfix/EWL-6511-subscribe-promo-main-content` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work affects visuals in D8 and should be tested against it to ensure there are no regressions. Update ama-d8 branch and local provision vars accordingly. 
- Go to homepage while viewing on mobile and confirm subscribe promo inputs stack for main content only. Footer should remain in a row.
- Go to homepage while viewing on tablet and confirm subscribe promo inputs stack for main content only. Footer should remain in a row.
- Test this in IE 11, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6511-subscribe-promo-main-content/html_report/index.html).


## Relevant Screenshots/GIFs
Screenshot from Drupal
![image](https://user-images.githubusercontent.com/4438120/48026322-5e6ea700-e10b-11e8-99eb-f5f889c474a8.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
