### PR TITLE
[EWL-6519]  Homepage Tablet - Upcoming Events

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
+++ b/styleguide/source/assets/scss/02-molecules/_upcoming-event.scss
@@ -9,7 +9,7 @@
     padding-right: 0;
   }
 
-  @include breakpoint($bp-med) {
+  @include breakpoint($bp-large) {
     display: flex;
   }
 
@@ -37,10 +37,10 @@
     display: flex;
 
     @include breakpoint($bp-small) {
-      margin-left: 40px;
+      margin-left: 30px;
     }
 
-    @include breakpoint($bp-med) {
+    @include breakpoint($bp-large) {
       margin-left: 0;
       width: 40%;
     }
@@ -49,7 +49,7 @@
       @include gutter($margin-right-full...);
       @include font-size($small-font-sizes);
 
-      @include breakpoint($bp-small) {
+      @include breakpoint($bp-large) {
         width: 50%;
       }
 


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6519|  Homepage Tablet - Upcoming Events](https://issues.ama-assn.org/browse/EWL-6519)

## Description
Updates breakpoint for mobile styling to include tablet. Corrects left margin on grey text in mobile views.

Please reference [Homepage zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5b339f81295b80b1015f2c48) for visual reference.


## To Test
- Pull `bugfix/EWL-6519-upcoming-events-tablet` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work affects visuals in D8 and should be tested against it to ensure there are no regressions. Update ama-d8 branch and local provision vars accordingly. 
- Go to homepage and ensure upcoming events section cuts to mobile styles on tablet width.
- Check on desktop to ensure updates did not change original look.
- Test this in IE 11, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6519-upcoming-events-tablet/html_report/index.html).


## Relevant Screenshots/GIFs
Screenshot from Drupal
![image](https://user-images.githubusercontent.com/4438120/48028664-b4464d80-e111-11e8-941f-c1742ac31973.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
