### PR TITLE
[EWL-6524] Homepage Tablet - Article Stubs

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -6,7 +6,7 @@
 
   .ama__layout--split__left, .ama__layout--split__right {
     .ama__four-up-teaser {
-      margin: $gutter auto 0px;
+      margin: $gutter-mobile auto 0px;
 
       .ama__h5--purple--homepage {
         margin-bottom: $gutter/2;

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -24,7 +24,7 @@
         }
       }
       .ama__article-stub {
-        margin-bottom: $gutter/2;
+        margin-bottom: $gutter-mobile/2;
       }
     }
   }

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -7,6 +7,10 @@
   .ama__layout--split__left, .ama__layout--split__right {
     .ama__four-up-teaser {
       margin: $gutter auto 0px;
+
+      .ama__h5--purple--homepage {
+        margin-bottom: $gutter/2;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -3,8 +3,26 @@
   .ama__layout--one-column__content-top {
     display: none;
   }
+
+  .ama__layout--split__left, .ama__layout--split__right {
+    .ama__four-up-teaser {
+      margin: $gutter auto 0px;
+    }
+  }
+
   .ama__layout--split__right {
     border-left: none;
+
+    .ama__category__article-stub-two-up {
+      & + .ama__category__article-stub-two-up {
+        @include breakpoint($bp-small) {
+          border-top: solid $gray-20 1px;
+        }
+      }
+      .ama__article-stub {
+        margin-bottom: $gutter/2;
+      }
+    }
   }
 
   @include breakpoint($bp-small) {
@@ -47,7 +65,7 @@
           flex: 0 0 35%;
           max-width: 35%;
 
-          button{
+          button {
             // Button should have a min width so that buttons with small words do not feel cramped
             min-width: 150px;
           }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6524 | Homepage Tablet - Article Stubs](https://issues.ama-assn.org/browse/EWL-6524)

## Description
Updates homepage hero styles.

Please reference [Homepage zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5b338f950ebc3bce6cf625fc) for visual reference.


## To Test
- Pull `bugfix/EWL-6524-homepage-hero` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work affects visuals in D8 and should be tested against it to ensure there are no regressions. Update ama-d8 branch and local provision vars accordingly. 
- Go to homepage confirm vertical spacing and borders match what is on zeplin.
- Test this in IE 11, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6524-homepage-hero/html_report/index.html).


## Relevant Screenshots/GIFs
Screenshot from Drupal
![image](https://user-images.githubusercontent.com/4438120/48030405-916a6800-e116-11e8-80d4-516bf67ec74b.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
