### PR TITLE
EWL-6500 search mobile

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_search-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-header.scss
@@ -74,6 +74,7 @@
 
     @include breakpoint($bp-small) {
       position: relative;
+      right: 0;
       order: 2;
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/_search-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-header.scss
@@ -68,7 +68,14 @@
   }
 
   .form-actions {
-    order: 2;
+    position: absolute;
+    top: 0;
+    right: $gutter;
+
+    @include breakpoint($bp-small) {
+      position: relative;
+      order: 2;
+    }
   }
 
   &__results {
@@ -117,8 +124,14 @@
 
     .ama__search__field {
       @include gutter($margin-bottom-full...);
+      position: relative;
       margin-left: 0;
       width: 100%;
+      flex-direction: column;
+
+      @include breakpoint($bp-small) {
+        flex-direction: row;
+      }
 
       &__input,
       .ui-autocomplete-input {
@@ -148,11 +161,17 @@
       }
     }
 
+    .ama__search-header__options {
+      @include gutter($margin-top-full...);
+      width: 100%;
+    }
+
     @include breakpoint($bp-small) {
       overflow: hidden;
 
       .ama__search-header__options {
         max-width: 250px;
+        margin-top: 0;
         float: right;
       }
     }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6500:  Search Mobile - Display Issue](https://issues.ama-assn.org/browse/EWL-6500)

## Description
Fix mobile look and feel of the search input area. The select dropdown menu needs to stack under the search input field on mobile.

## To Test
- [ ] switch SG2 branch to `bugfix/EWL-6500-search-mobile`
- [ ] `gulp serve`
- [ ] enable local SG2 in D8
- [ ] in another terminal window run `scripts/build`
- [ ] in your vagrant run `drush @one.local cr`
- [ ] visit http://ama-one.local/search
- [ ] change your viewport to mobile
- [ ] observe the input search field is stacked on top of the select dropdown 
- [ ] Did you test in IE 11?

## Visual Regressions



## Relevant Screenshots/GIFs
<img width="468" alt="screen shot 2018-11-05 at 4 20 34 pm" src="https://user-images.githubusercontent.com/2271747/48030456-be1e7f80-e116-11e8-9f19-d14f1d2eee74.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
