### PR TITLE
[Release] Style Guide v2.27.0

### DIFF
--- a/styleguide/package-lock.json
+++ b/styleguide/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "ama-style-guide",
-<<<<<<< HEAD
   "version": "2.27.0",
-=======
-  "version": "2.26.6",
->>>>>>> 42989a06d4f35bc8f0813c1f463c885553258ab7
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,11 +9,11 @@
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
       "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
       "requires": {
-        "acorn": "^5.0.3",
-        "css": "^2.2.1",
-        "normalize-path": "^2.1.1",
-        "source-map": "^0.5.6",
-        "through2": "^2.0.3"
+        "acorn": "5.4.1",
+        "css": "2.2.3",
+        "normalize-path": "2.1.1",
+        "source-map": "0.5.7",
+        "through2": "2.0.3"
       }
     },
     "@gulp-sourcemaps/map-sources": {
@@ -25,8 +21,8 @@
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "requires": {
-        "normalize-path": "^2.0.1",
-        "through2": "^2.0.3"
+        "normalize-path": "2.1.1",
+        "through2": "2.0.3"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -34,8 +30,8 @@
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -73,8 +69,8 @@
       "resolved": "https://registry.npmjs.org/accept/-/accept-3.0.2.tgz",
       "integrity": "sha512-bghLXFkCOsC1Y2TZ51etWfKDs6q249SAoHTZVfzWWdlZxoij+mgkj9AmUJWQpDY48TfnrTDIe43Xem4zdMe7mQ==",
       "requires": {
-        "boom": "7.x.x",
-        "hoek": "5.x.x"
+        "boom": "7.2.0",
+        "hoek": "5.0.3"
       },
       "dependencies": {
         "boom": {
@@ -82,7 +78,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -92,7 +88,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -106,7 +102,7 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "requires": {
-        "acorn": "^4.0.3"
+        "acorn": "4.0.13"
       },
       "dependencies": {
         "acorn": {
@@ -126,7 +122,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -134,10 +130,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
       "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0",
-        "uri-js": "^4.2.1"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1",
+        "uri-js": "4.2.1"
       }
     },
     "ajv-keywords": {
@@ -150,9 +146,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -165,7 +161,7 @@
       "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.1.tgz",
       "integrity": "sha512-4UqoM8xQjwkQ78oiU4NbBK0UgYqeKMAKmwE4ec7Rz3rGU8ZEBFxzgF2sUYKOAlqIXExBDYLN6y1ShF5yQ4hwLQ==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "5.0.3"
       }
     },
     "ansi-align": {
@@ -173,7 +169,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       }
     },
     "ansi-colors": {
@@ -181,7 +177,7 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.0.1.tgz",
       "integrity": "sha512-yopkAU0ZD/WQ56Tms3xLn6jRuX3SyUMAVi0FdmDIbmmnHW3jHiI1sQFdUl3gfVddjnrsP3Y6ywFKvCRopvoVIA==",
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-cyan": {
@@ -238,8 +234,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -257,16 +253,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -274,7 +270,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -284,8 +280,8 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
           }
         },
         "expand-brackets": {
@@ -293,13 +289,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -307,7 +303,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -315,7 +311,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -323,9 +319,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -340,8 +336,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -349,7 +345,7 @@
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -359,14 +355,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -374,7 +370,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -382,7 +378,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -392,10 +388,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -403,7 +399,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -413,7 +409,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -421,7 +417,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -431,7 +427,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -439,7 +435,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -449,7 +445,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -457,7 +453,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -482,19 +478,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         },
         "nanomatch": {
@@ -502,17 +498,17 @@
           "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
           "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         },
         "to-regex": {
@@ -520,10 +516,10 @@
           "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
           },
           "dependencies": {
             "regex-not": {
@@ -531,8 +527,8 @@
               "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
               "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
               "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
               }
             }
           }
@@ -554,7 +550,7 @@
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "requires": {
-        "file-type": "^3.1.0"
+        "file-type": "3.9.0"
       }
     },
     "archy": {
@@ -567,8 +563,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
       }
     },
     "argparse": {
@@ -576,7 +572,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -584,7 +580,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -622,8 +618,8 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "array-iterate": {
@@ -641,7 +637,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -679,9 +675,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -722,7 +718,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
@@ -737,7 +733,7 @@
       "resolved": "https://registry.npmjs.org/async-chain-proxy/-/async-chain-proxy-0.1.5.tgz",
       "integrity": "sha512-JYUzBrCWkKdBQ02H2f1N8xR4JXeWGcw2V8i2AzJjeXGTz40rqqbKkDmQieL8iHNp70W1M44WXqFsvk4Cx49H1Q==",
       "requires": {
-        "babel-polyfill": "^6.23.0"
+        "babel-polyfill": "6.26.0"
       }
     },
     "async-each": {
@@ -780,12 +776,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.5.0.tgz",
       "integrity": "sha512-buY1XxFoBrXvLsoFb0jP+niSu1tCj2RwMwHj96+RfQ8DJTgb0vUhh0dg6wjJT3JzsFYBrkSj8/sGtarNdlxTFw==",
       "requires": {
-        "browserslist": "^3.2.7",
-        "caniuse-lite": "^1.0.30000839",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^6.0.22",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "3.2.7",
+        "caniuse-lite": "1.0.30000840",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "6.0.22",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -793,7 +789,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -801,9 +797,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -816,9 +812,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -831,7 +827,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -851,8 +847,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "^1.2.5",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.1",
+        "is-buffer": "1.1.6"
       }
     },
     "b64": {
@@ -865,9 +861,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "core-js": {
@@ -882,8 +878,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
@@ -908,7 +904,7 @@
       "resolved": "https://registry.npmjs.org/backstop-twentytwenty/-/backstop-twentytwenty-1.0.4.tgz",
       "integrity": "sha512-sENfpossNAbVKZjTzBU6bkbR1vIb7t6brjqH9ZMEIYh/RyCIGFM3BSgERzh+tdwpAVXHSbIV1gQRrtzBYzUrjw==",
       "requires": {
-        "react": "^15.6.2"
+        "react": "15.6.2"
       }
     },
     "backstopjs": {
@@ -916,33 +912,33 @@
       "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.5.2.tgz",
       "integrity": "sha512-2QqAbbQerk4T/M+a+YBxAPJnkZbl9nfXUuSVlzu2mAfW0Uq+gp9NYzsIUsfLjy2vISPJwBBa5ANnVMz86QcgwQ==",
       "requires": {
-        "backstop-twentytwenty": "^1.0.4",
-        "casperjs": "^1.1.0-beta5",
-        "chalk": "^1.1.3",
+        "backstop-twentytwenty": "1.0.4",
+        "casperjs": "1.1.4",
+        "chalk": "1.1.3",
         "chromy": "0.5.11",
-        "fs-extra": "^0.30.0",
-        "jump.js": "^1.0.2",
-        "junitwriter": "~0.3.1",
-        "lodash": "^4.17.4",
-        "minimist": "^1.2.0",
-        "node-resemble-js": "^0.2.0",
+        "fs-extra": "0.30.0",
+        "jump.js": "1.0.2",
+        "junitwriter": "0.3.1",
+        "lodash": "4.17.5",
+        "minimist": "1.2.0",
+        "node-resemble-js": "0.2.0",
         "object-hash": "1.1.5",
-        "opn": "^5.3.0",
-        "os": "^0.1.1",
-        "p-map": "^1.1.1",
-        "path": "^0.12.7",
-        "phantomjs-prebuilt": "^2.1.7",
-        "puppeteer": "^1.2.0-next.1523485686787",
-        "react-modal": "^3.0.3",
-        "react-redux": "^5.0.6",
-        "react-sticky": "^6.0.1",
-        "react-toggle-button": "^2.1.0",
-        "redux": "^3.7.2",
-        "sinon": "^1.17.7",
-        "styled-components": "^2.1.2",
-        "temp": "^0.8.3",
-        "webpack": "^3.5.6",
-        "webpack-dev-server": "^2.7.1"
+        "opn": "5.3.0",
+        "os": "0.1.1",
+        "p-map": "1.2.0",
+        "path": "0.12.7",
+        "phantomjs-prebuilt": "2.1.16",
+        "puppeteer": "1.6.1",
+        "react-modal": "3.5.1",
+        "react-redux": "5.0.7",
+        "react-sticky": "6.0.3",
+        "react-toggle-button": "2.2.0",
+        "redux": "3.7.2",
+        "sinon": "1.17.7",
+        "styled-components": "2.4.1",
+        "temp": "0.8.3",
+        "webpack": "3.12.0",
+        "webpack-dev-server": "2.11.2"
       },
       "dependencies": {
         "path": {
@@ -950,8 +946,8 @@
           "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
           "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
           "requires": {
-            "process": "^0.11.1",
-            "util": "^0.10.3"
+            "process": "0.11.10",
+            "util": "0.10.4"
           }
         },
         "process": {
@@ -976,13 +972,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "isobject": {
@@ -1018,7 +1014,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -1055,13 +1051,13 @@
       "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
       "optional": true,
       "requires": {
-        "archive-type": "^3.0.1",
-        "decompress": "^3.0.0",
-        "download": "^4.1.2",
-        "exec-series": "^1.0.0",
-        "rimraf": "^2.2.6",
-        "tempfile": "^1.0.0",
-        "url-regex": "^3.0.0"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "download": "4.4.3",
+        "exec-series": "1.0.3",
+        "rimraf": "2.6.2",
+        "tempfile": "1.1.1",
+        "url-regex": "3.2.0"
       },
       "dependencies": {
         "tempfile": {
@@ -1070,8 +1066,8 @@
           "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
           "optional": true,
           "requires": {
-            "os-tmpdir": "^1.0.0",
-            "uuid": "^2.0.1"
+            "os-tmpdir": "1.0.2",
+            "uuid": "2.0.3"
           }
         },
         "uuid": {
@@ -1088,7 +1084,7 @@
       "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
       "optional": true,
       "requires": {
-        "executable": "^1.0.0"
+        "executable": "1.1.0"
       }
     },
     "bin-version": {
@@ -1097,7 +1093,7 @@
       "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
       "optional": true,
       "requires": {
-        "find-versions": "^1.0.0"
+        "find-versions": "1.2.1"
       }
     },
     "bin-version-check": {
@@ -1106,10 +1102,10 @@
       "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
       "optional": true,
       "requires": {
-        "bin-version": "^1.0.0",
-        "minimist": "^1.1.0",
-        "semver": "^4.0.3",
-        "semver-truncate": "^1.0.0"
+        "bin-version": "1.0.4",
+        "minimist": "1.2.0",
+        "semver": "4.3.6",
+        "semver-truncate": "1.1.2"
       },
       "dependencies": {
         "semver": {
@@ -1126,12 +1122,12 @@
       "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
       "optional": true,
       "requires": {
-        "bin-check": "^2.0.0",
-        "bin-version-check": "^2.1.0",
-        "download": "^4.0.0",
-        "each-async": "^1.1.1",
-        "lazy-req": "^1.0.0",
-        "os-filter-obj": "^1.0.0"
+        "bin-check": "2.0.0",
+        "bin-version-check": "2.1.0",
+        "download": "4.4.3",
+        "each-async": "1.1.1",
+        "lazy-req": "1.1.0",
+        "os-filter-obj": "1.0.3"
       }
     },
     "binary-extensions": {
@@ -1144,7 +1140,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.3"
       }
     },
     "blob": {
@@ -1157,7 +1153,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "bluebird": {
@@ -1181,15 +1177,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "iconv-lite": {
@@ -1209,12 +1205,12 @@
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.2.3",
+        "multicast-dns-service-types": "1.1.0"
       }
     },
     "boolbase": {
@@ -1227,7 +1223,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "hoek": {
@@ -1242,8 +1238,8 @@
       "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
       "integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
       "requires": {
-        "boom": "7.x.x",
-        "hoek": "5.x.x"
+        "boom": "7.2.0",
+        "hoek": "5.0.3"
       },
       "dependencies": {
         "boom": {
@@ -1251,7 +1247,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -1261,13 +1257,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1275,7 +1271,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -1283,9 +1279,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -1298,7 +1294,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1308,7 +1304,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.9.tgz",
       "integrity": "sha512-/+o3o6OV1cm3WKrO7U4wykU+ZICE6HiMEuravc2d03NIuM/VaRn5iMcoQ7NyxFXjvpmRICP2EER0YOnh4yIapA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1317,9 +1313,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "breakpoint-sass": {
@@ -1337,16 +1333,16 @@
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.6.tgz",
       "integrity": "sha512-3cVW8Ft3sPQ1t9gqZXBDZhTyRce8NW4wf5KzpCYcg6fWjPbyt+vZLvEo+sTq7c7eNQhi8lInQWbjIFEpoM2f7Q==",
       "requires": {
-        "browser-sync-ui": "v1.0.1",
+        "browser-sync-ui": "1.0.1",
         "bs-recipes": "1.3.4",
         "chokidar": "1.7.0",
         "connect": "3.6.6",
-        "connect-history-api-fallback": "^1.5.0",
-        "dev-ip": "^1.0.1",
+        "connect-history-api-fallback": "1.5.0",
+        "dev-ip": "1.0.1",
         "easy-extender": "2.3.2",
         "eazy-logger": "3.0.2",
-        "etag": "^1.8.1",
-        "fresh": "^0.5.2",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
         "immutable": "3.8.2",
@@ -1355,7 +1351,7 @@
         "opn": "4.0.2",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
-        "raw-body": "^2.3.2",
+        "raw-body": "2.3.2",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
         "serve-index": "1.9.1",
@@ -1371,8 +1367,8 @@
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "requires": {
-            "micromatch": "^2.1.5",
-            "normalize-path": "^2.0.0"
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
           }
         },
         "camelcase": {
@@ -1385,15 +1381,15 @@
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "requires": {
-            "anymatch": "^1.3.0",
-            "async-each": "^1.0.0",
-            "fsevents": "^1.0.0",
-            "glob-parent": "^2.0.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^2.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0"
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.2.4",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
           }
         },
         "cliui": {
@@ -1401,9 +1397,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "eventemitter3": {
@@ -1416,8 +1412,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "fs-extra": {
@@ -1425,9 +1421,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^3.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
           }
         },
         "http-proxy": {
@@ -1435,8 +1431,8 @@
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
           "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
           "requires": {
-            "eventemitter3": "1.x.x",
-            "requires-port": "1.x.x"
+            "eventemitter3": "1.2.0",
+            "requires-port": "1.0.0"
           }
         },
         "jsonfile": {
@@ -1444,7 +1440,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         },
         "load-json-file": {
@@ -1452,11 +1448,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "opn": {
@@ -1464,8 +1460,8 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
           "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
           "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "os-locale": {
@@ -1473,7 +1469,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "parse-json": {
@@ -1481,7 +1477,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -1489,7 +1485,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -1497,9 +1493,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -1517,9 +1513,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -1527,8 +1523,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "string-width": {
@@ -1536,9 +1532,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -1546,7 +1542,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "ua-parser-js": {
@@ -1569,20 +1565,20 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.1.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         },
         "yargs-parser": {
@@ -1590,7 +1586,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -1601,11 +1597,11 @@
       "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "^1.1.0",
-        "immutable": "^3.7.6",
+        "connect-history-api-fallback": "1.5.0",
+        "immutable": "3.8.2",
         "server-destroy": "1.0.1",
         "socket.io-client": "2.0.4",
-        "stream-throttle": "^0.1.3"
+        "stream-throttle": "0.1.3"
       }
     },
     "browserify-aes": {
@@ -1613,12 +1609,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "browserify-cipher": {
@@ -1626,9 +1622,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -1636,10 +1632,10 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -1654,8 +1650,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1663,13 +1659,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.1"
       }
     },
     "browserify-zlib": {
@@ -1677,7 +1673,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
@@ -1685,8 +1681,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
       "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30000835",
-        "electron-to-chromium": "^1.3.45"
+        "caniuse-lite": "1.0.30000840",
+        "electron-to-chromium": "1.3.45"
       }
     },
     "bs-recipes": {
@@ -1699,8 +1695,8 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
       "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.12"
       }
     },
     "buffer-equal": {
@@ -1714,7 +1710,7 @@
       "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
       "optional": true,
       "requires": {
-        "is-array-buffer-x": "^1.0.13"
+        "is-array-buffer-x": "1.7.0"
       }
     },
     "buffer-indexof": {
@@ -1727,10 +1723,10 @@
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "requires": {
-        "file-type": "^3.1.0",
-        "readable-stream": "^2.0.2",
-        "uuid": "^2.0.1",
-        "vinyl": "^1.0.0"
+        "file-type": "3.9.0",
+        "readable-stream": "2.3.3",
+        "uuid": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "uuid": {
@@ -1743,8 +1739,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -1770,8 +1766,8 @@
       "resolved": "https://registry.npmjs.org/bump-regex/-/bump-regex-3.1.1.tgz",
       "integrity": "sha512-NinFibU11G1ad/2Ji3J04lRC9mLpUGr3C0vtt4Yp049cDeW21NRkmUaZZc+snwlL6gE+Ja5cQfe/hf86Ahj+WQ==",
       "requires": {
-        "semver": "^5.1.0",
-        "xtend": "^4.0.1"
+        "semver": "5.5.0",
+        "xtend": "4.0.1"
       }
     },
     "bytes": {
@@ -1784,15 +1780,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -1812,8 +1808,8 @@
       "resolved": "https://registry.npmjs.org/call/-/call-5.0.1.tgz",
       "integrity": "sha512-ollfFPSshiuYLp7AsrmpkQJ/PxCi6AzV81rCjBwWhyF2QGyUY/vPDMzoh4aUcWyucheRglG2LaS5qkIEfLRh6A==",
       "requires": {
-        "boom": "7.x.x",
-        "hoek": "5.x.x"
+        "boom": "7.2.0",
+        "hoek": "5.0.3"
       },
       "dependencies": {
         "boom": {
@@ -1821,7 +1817,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -1846,9 +1842,9 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "requires": {
-        "camelcase": "^4.1.0",
-        "map-obj": "^2.0.0",
-        "quick-lru": "^1.0.0"
+        "camelcase": "4.1.0",
+        "map-obj": "2.0.0",
+        "quick-lru": "1.1.0"
       }
     },
     "caniuse-lite": {
@@ -1876,10 +1872,10 @@
       "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.2.tgz",
       "integrity": "sha512-cTQTQeKMhWHU0lX8CADE3g1koGJu+AlcWFzAjMX/8P+XbkScGYw3tJsQpe2Oh8q68vOQbOLacz9k+6V/F3Z9DA==",
       "requires": {
-        "boom": "7.x.x",
-        "bounce": "1.x.x",
-        "hoek": "5.x.x",
-        "joi": "13.x.x"
+        "boom": "7.2.0",
+        "bounce": "1.2.0",
+        "hoek": "5.0.3",
+        "joi": "13.3.0"
       },
       "dependencies": {
         "boom": {
@@ -1887,7 +1883,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -1897,9 +1893,9 @@
       "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.2.tgz",
       "integrity": "sha512-lhWtutLVhsq3Mucxk2McxBPPibJ34WcHuWFz3xqub9u9Ve/IQYpZv3ijLhQXfQped9DXozURiaq9O3aZpP91eg==",
       "requires": {
-        "big-time": "2.x.x",
-        "boom": "7.x.x",
-        "hoek": "5.x.x"
+        "big-time": "2.0.1",
+        "boom": "7.2.0",
+        "hoek": "5.0.3"
       },
       "dependencies": {
         "boom": {
@@ -1907,7 +1903,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -1917,10 +1913,10 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "requires": {
-        "get-proxy": "^1.0.1",
-        "is-obj": "^1.0.0",
-        "object-assign": "^3.0.0",
-        "tunnel-agent": "^0.4.0"
+        "get-proxy": "1.1.0",
+        "is-obj": "1.0.1",
+        "object-assign": "3.0.0",
+        "tunnel-agent": "0.4.3"
       },
       "dependencies": {
         "object-assign": {
@@ -1945,8 +1941,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       },
       "dependencies": {
         "lazy-cache": {
@@ -1958,14 +1954,14 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "character-entities": {
@@ -1993,19 +1989,19 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.2.4",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "lodash.debounce": "4.0.8",
+        "normalize-path": "2.1.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0",
+        "upath": "1.1.0"
       },
       "dependencies": {
         "array-unique": {
@@ -2018,16 +2014,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.1"
           }
         },
         "fill-range": {
@@ -2035,10 +2031,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           }
         },
         "glob-parent": {
@@ -2046,8 +2042,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -2055,7 +2051,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -2070,7 +2066,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -2078,7 +2074,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -2093,14 +2089,14 @@
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.2.tgz",
       "integrity": "sha512-E+kTHlGgtitPPu8Rci0E4XBasirKtTn6DjqFn8tTLp/7xCUzqb6lig9Il+HLkcudzKvT/aLxJbzbyNCe03w1AA==",
       "requires": {
-        "@types/core-js": "^0.9.41",
-        "@types/mkdirp": "^0.3.29",
-        "@types/node": "^9.3.0",
-        "@types/rimraf": "^0.0.28",
-        "is-wsl": "^1.1.0",
-        "lighthouse-logger": "^1.0.0",
+        "@types/core-js": "0.9.46",
+        "@types/mkdirp": "0.3.29",
+        "@types/node": "9.6.24",
+        "@types/rimraf": "0.0.28",
+        "is-wsl": "1.1.0",
+        "lighthouse-logger": "1.0.1",
         "mkdirp": "0.5.1",
-        "rimraf": "^2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "chrome-remote-interface": {
@@ -2108,8 +2104,8 @@
       "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
       "integrity": "sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==",
       "requires": {
-        "commander": "2.11.x",
-        "ws": "3.3.x"
+        "commander": "2.11.0",
+        "ws": "3.3.3"
       }
     },
     "chromy": {
@@ -2117,12 +2113,12 @@
       "resolved": "https://registry.npmjs.org/chromy/-/chromy-0.5.11.tgz",
       "integrity": "sha512-SBz5/xPYgeQiwFGMixPNQcbgnzsRHGCJnZKNJ5S0SmauSUY77/mqA8NjotQa12SZ3tZy0NX2gyGP41BAUWI6Rg==",
       "requires": {
-        "async-chain-proxy": "^0.1.5",
-        "babel-runtime": "^6.26.0",
-        "chrome-launcher": "^0.10.2",
-        "chrome-remote-interface": "^0.25.5",
-        "jimp": "^0.2.28",
-        "uuid": "^3.2.1"
+        "async-chain-proxy": "0.1.5",
+        "babel-runtime": "6.26.0",
+        "chrome-launcher": "0.10.2",
+        "chrome-remote-interface": "0.25.7",
+        "jimp": "0.2.28",
+        "uuid": "3.2.1"
       }
     },
     "ci-info": {
@@ -2135,8 +2131,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "circular-json": {
@@ -2150,7 +2146,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3"
+        "chalk": "1.1.3"
       }
     },
     "class-utils": {
@@ -2158,10 +2154,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2169,7 +2165,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -2177,7 +2173,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2185,7 +2181,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -2195,7 +2191,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2203,7 +2199,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -2213,9 +2209,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "isobject": {
@@ -2235,8 +2231,8 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "requires": {
-        "commander": "2.8.x",
-        "source-map": "0.4.x"
+        "commander": "2.8.1",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "commander": {
@@ -2244,7 +2240,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         },
         "source-map": {
@@ -2252,7 +2248,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -2267,8 +2263,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       }
     },
@@ -2287,8 +2283,8 @@
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
       "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "1.0.0",
+        "is-supported-regexp-flag": "1.0.1"
       }
     },
     "clone-stats": {
@@ -2301,9 +2297,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^1.0.6",
-        "through2": "^2.0.1"
+        "inherits": "2.0.3",
+        "process-nextick-args": "1.0.7",
+        "through2": "2.0.3"
       }
     },
     "co": {
@@ -2317,7 +2313,7 @@
       "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
       "optional": true,
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -2335,8 +2331,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -2344,7 +2340,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -2367,7 +2363,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -2395,7 +2391,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "requires": {
-        "mime-db": ">= 1.34.0 < 2"
+        "mime-db": "1.35.0"
       },
       "dependencies": {
         "mime-db": {
@@ -2410,13 +2406,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.14",
+        "compressible": "2.0.14",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.2",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -2436,9 +2432,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
       }
     },
     "concat-with-sourcemaps": {
@@ -2446,7 +2442,7 @@
       "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
       "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -2461,12 +2457,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.1.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "connect": {
@@ -2476,7 +2472,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -2486,12 +2482,12 @@
           "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "~1.0.1",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.2",
-            "statuses": "~1.3.1",
-            "unpipe": "~1.0.0"
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
           }
         },
         "statuses": {
@@ -2511,7 +2507,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-control-strings": {
@@ -2535,7 +2531,7 @@
       "resolved": "https://registry.npmjs.org/content/-/content-4.0.5.tgz",
       "integrity": "sha512-wDP6CTWDpwCf791fNxlCCkZGRkrNzSEU/8ju9Hnr3Uc5mF/gFR5W+fcoGm6zUSlVPdSXYn5pCbySADKj7YM4Cg==",
       "requires": {
-        "boom": "7.x.x"
+        "boom": "7.2.0"
       },
       "dependencies": {
         "boom": {
@@ -2543,7 +2539,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -2593,13 +2589,13 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "requires": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.4.3",
-        "minimist": "^1.2.0",
-        "object-assign": "^4.1.0",
-        "os-homedir": "^1.0.1",
-        "parse-json": "^2.2.0",
-        "require-from-string": "^1.1.0"
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "require-from-string": "1.2.1"
       },
       "dependencies": {
         "parse-json": {
@@ -2607,7 +2603,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         }
       }
@@ -2617,8 +2613,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-error-class": {
@@ -2626,7 +2622,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "create-hash": {
@@ -2634,11 +2630,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -2646,12 +2642,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.11"
       }
     },
     "create-react-class": {
@@ -2659,9 +2655,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "cross-spawn": {
@@ -2669,9 +2665,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -2679,8 +2675,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         }
       }
@@ -2690,7 +2686,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -2698,7 +2694,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           },
           "dependencies": {
             "hoek": {
@@ -2715,17 +2711,17 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.16",
+        "public-encrypt": "4.0.2",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "crypto-random-string": {
@@ -2738,10 +2734,10 @@
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
       "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "source-map": "^0.1.38",
-        "source-map-resolve": "^0.5.1",
-        "urix": "^0.1.0"
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.5.1",
+        "urix": "0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -2749,7 +2745,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -2765,10 +2761,10 @@
       "integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
       "optional": true,
       "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "^1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-select-base-adapter": {
@@ -2782,9 +2778,9 @@
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.1.tgz",
       "integrity": "sha512-v++LRcf633phJiYZBDqtmGPj3+BVof0isd2jgwYLWZJ5YSuhCkrfYtDsNhM6oJthiEco0f9tDVJ1vUkDJNgGEA==",
       "requires": {
-        "css-color-keywords": "^1.0.0",
-        "fbjs": "^0.8.5",
-        "postcss-value-parser": "^3.3.0"
+        "css-color-keywords": "1.0.0",
+        "fbjs": "0.8.17",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "css-tree": {
@@ -2793,8 +2789,8 @@
       "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
       "optional": true,
       "requires": {
-        "mdn-data": "^1.0.0",
-        "source-map": "^0.5.3"
+        "mdn-data": "1.1.0",
+        "source-map": "0.5.7"
       }
     },
     "css-url-regex": {
@@ -2824,8 +2820,8 @@
           "integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
           "optional": true,
           "requires": {
-            "mdn-data": "^1.0.0",
-            "source-map": "^0.5.3"
+            "mdn-data": "1.1.0",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -2835,7 +2831,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -2843,7 +2839,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.38"
       }
     },
     "dashdash": {
@@ -2851,7 +2847,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "date-now": {
@@ -2864,8 +2860,8 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
       "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
       "requires": {
-        "get-stdin": "*",
-        "meow": "*"
+        "get-stdin": "5.0.1",
+        "meow": "4.0.0"
       }
     },
     "debug": {
@@ -2881,9 +2877,9 @@
       "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.0.0.tgz",
       "integrity": "sha512-dsd50qQ1atDeurcxL7XOjPp4nZCGZzWIONDujDXzl1atSyC3hMbZD+v6440etw+Vt0Pr8ce4TQzHfX3KZM05Mw==",
       "requires": {
-        "debug": "3.X",
-        "memoizee": "0.4.X",
-        "object-assign": "4.X"
+        "debug": "3.1.0",
+        "memoizee": "0.4.11",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "debug": {
@@ -2906,8 +2902,8 @@
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "map-obj": {
@@ -2927,15 +2923,15 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "requires": {
-        "buffer-to-vinyl": "^1.0.0",
-        "concat-stream": "^1.4.6",
-        "decompress-tar": "^3.0.0",
-        "decompress-tarbz2": "^3.0.0",
-        "decompress-targz": "^3.0.0",
-        "decompress-unzip": "^3.0.0",
-        "stream-combiner2": "^1.1.1",
-        "vinyl-assign": "^1.0.1",
-        "vinyl-fs": "^2.2.0"
+        "buffer-to-vinyl": "1.1.0",
+        "concat-stream": "1.6.0",
+        "decompress-tar": "3.1.0",
+        "decompress-tarbz2": "3.1.0",
+        "decompress-targz": "3.1.0",
+        "decompress-unzip": "3.4.0",
+        "stream-combiner2": "1.1.1",
+        "vinyl-assign": "1.2.1",
+        "vinyl-fs": "2.4.4"
       },
       "dependencies": {
         "glob": {
@@ -2943,11 +2939,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -2955,8 +2951,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "glob-stream": {
@@ -2964,14 +2960,14 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -2979,10 +2975,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "through2": {
@@ -2990,8 +2986,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -3001,11 +2997,11 @@
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "requires": {
-            "convert-source-map": "^1.1.1",
-            "graceful-fs": "^4.1.2",
-            "strip-bom": "^2.0.0",
-            "through2": "^2.0.0",
-            "vinyl": "^1.0.0"
+            "convert-source-map": "1.5.1",
+            "graceful-fs": "4.1.11",
+            "strip-bom": "2.0.0",
+            "through2": "2.0.3",
+            "vinyl": "1.2.0"
           }
         },
         "is-extglob": {
@@ -3018,7 +3014,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -3031,8 +3027,8 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.3"
           }
         },
         "string_decoder": {
@@ -3045,7 +3041,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "unique-stream": {
@@ -3053,8 +3049,8 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl": {
@@ -3062,8 +3058,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -3072,23 +3068,23 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.5.3",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.3",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         }
       }
@@ -3098,12 +3094,12 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "requires": {
-        "is-tar": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-tar": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -3126,10 +3122,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3142,8 +3138,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -3151,8 +3147,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -3162,13 +3158,13 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "requires": {
-        "is-bzip2": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "seek-bzip": "^1.0.3",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-bzip2": "1.0.0",
+        "object-assign": "2.1.1",
+        "seek-bzip": "1.0.5",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -3191,10 +3187,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3207,8 +3203,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -3216,8 +3212,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -3227,12 +3223,12 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "requires": {
-        "is-gzip": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-gzip": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -3255,10 +3251,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3271,8 +3267,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -3280,8 +3276,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -3291,13 +3287,13 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "requires": {
-        "is-zip": "^1.0.0",
-        "read-all-stream": "^3.0.0",
-        "stat-mode": "^0.2.0",
-        "strip-dirs": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0",
-        "yauzl": "^2.2.1"
+        "is-zip": "1.0.0",
+        "read-all-stream": "3.1.0",
+        "stat-mode": "0.2.2",
+        "strip-dirs": "1.1.1",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0",
+        "yauzl": "2.4.1"
       },
       "dependencies": {
         "vinyl": {
@@ -3305,8 +3301,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -3327,7 +3323,7 @@
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.3"
       }
     },
     "define-properties": {
@@ -3335,8 +3331,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       },
       "dependencies": {
         "object-keys": {
@@ -3351,7 +3347,7 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "requires": {
-        "is-descriptor": "^1.0.0"
+        "is-descriptor": "1.0.2"
       }
     },
     "del": {
@@ -3359,12 +3355,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -3392,8 +3388,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "destroy": {
@@ -3426,9 +3422,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "dir-glob": {
@@ -3436,8 +3432,8 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       }
     },
     "dns-equal": {
@@ -3450,8 +3446,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.1"
       }
     },
     "dns-txt": {
@@ -3459,7 +3455,7 @@
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
-        "buffer-indexof": "^1.0.0"
+        "buffer-indexof": "1.1.1"
       }
     },
     "dom-serializer": {
@@ -3467,8 +3463,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3498,7 +3494,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -3506,8 +3502,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-prop": {
@@ -3515,7 +3511,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "download": {
@@ -3523,21 +3519,21 @@
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "requires": {
-        "caw": "^1.0.1",
-        "concat-stream": "^1.4.7",
-        "each-async": "^1.0.0",
-        "filenamify": "^1.0.1",
-        "got": "^5.0.0",
-        "gulp-decompress": "^1.2.0",
-        "gulp-rename": "^1.2.0",
-        "is-url": "^1.2.0",
-        "object-assign": "^4.0.1",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.2",
-        "stream-combiner2": "^1.1.1",
-        "vinyl": "^1.0.0",
-        "vinyl-fs": "^2.2.0",
-        "ware": "^1.2.0"
+        "caw": "1.2.0",
+        "concat-stream": "1.6.0",
+        "each-async": "1.1.1",
+        "filenamify": "1.2.1",
+        "got": "5.7.1",
+        "gulp-decompress": "1.2.0",
+        "gulp-rename": "1.2.2",
+        "is-url": "1.2.2",
+        "object-assign": "4.1.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.3",
+        "stream-combiner2": "1.1.1",
+        "vinyl": "1.2.0",
+        "vinyl-fs": "2.4.4",
+        "ware": "1.3.0"
       },
       "dependencies": {
         "glob": {
@@ -3545,11 +3541,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -3557,8 +3553,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "glob-stream": {
@@ -3566,14 +3562,14 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -3581,10 +3577,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "through2": {
@@ -3592,8 +3588,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -3603,11 +3599,11 @@
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "requires": {
-            "convert-source-map": "^1.1.1",
-            "graceful-fs": "^4.1.2",
-            "strip-bom": "^2.0.0",
-            "through2": "^2.0.0",
-            "vinyl": "^1.0.0"
+            "convert-source-map": "1.5.1",
+            "graceful-fs": "4.1.11",
+            "strip-bom": "2.0.0",
+            "through2": "2.0.3",
+            "vinyl": "1.2.0"
           }
         },
         "is-extglob": {
@@ -3620,7 +3616,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -3633,8 +3629,8 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.3"
           }
         },
         "string_decoder": {
@@ -3647,7 +3643,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "unique-stream": {
@@ -3655,8 +3651,8 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl": {
@@ -3664,8 +3660,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -3674,23 +3670,23 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.5.3",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.3",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         }
       }
@@ -3705,7 +3701,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -3718,10 +3714,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3741,10 +3737,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -3752,7 +3748,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         }
       }
@@ -3762,8 +3758,8 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "requires": {
-        "onetime": "^1.0.0",
-        "set-immediate-shim": "^1.0.0"
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "easy-extender": {
@@ -3771,7 +3767,7 @@
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
       "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
       "requires": {
-        "lodash": "^3.10.1"
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -3786,7 +3782,7 @@
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "requires": {
-        "tfunk": "^3.0.1"
+        "tfunk": "3.1.0"
       }
     },
     "ecc-jsbn": {
@@ -3795,7 +3791,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "editorconfig": {
@@ -3803,10 +3799,10 @@
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
       "integrity": "sha1-jleSbZ7mmrbLmZ8CfCFxRnrM6zU=",
       "requires": {
-        "bluebird": "^3.0.5",
-        "commander": "^2.9.0",
-        "lru-cache": "^3.2.0",
-        "sigmund": "^1.0.1"
+        "bluebird": "3.5.1",
+        "commander": "2.11.0",
+        "lru-cache": "3.2.0",
+        "sigmund": "1.0.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -3814,7 +3810,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "requires": {
-            "pseudomap": "^1.0.1"
+            "pseudomap": "1.0.2"
           }
         }
       }
@@ -3834,13 +3830,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.5",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emojis-list": {
@@ -3858,7 +3854,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.23"
       }
     },
     "end-of-stream": {
@@ -3866,7 +3862,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "requires": {
-        "once": "~1.3.0"
+        "once": "1.3.3"
       },
       "dependencies": {
         "once": {
@@ -3874,7 +3870,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         }
       }
@@ -3884,12 +3880,12 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -3909,14 +3905,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3936,10 +3932,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "enhanced-resolve": {
@@ -3947,10 +3943,10 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "object-assign": "^4.0.1",
-        "tapable": "^0.2.7"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
       }
     },
     "entities": {
@@ -3963,7 +3959,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -3971,7 +3967,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -3979,11 +3975,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3991,9 +3987,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -4001,8 +3997,8 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
       "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
@@ -4010,9 +4006,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -4020,12 +4016,12 @@
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-promise": {
@@ -4038,7 +4034,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.4"
       },
       "dependencies": {
         "es6-promise": {
@@ -4053,11 +4049,11 @@
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -4065,8 +4061,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
       }
     },
     "es6-weak-map": {
@@ -4074,10 +4070,10 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
@@ -4095,10 +4091,10 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "esprima": {
@@ -4111,7 +4107,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -4129,22 +4125,22 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
       }
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       },
       "dependencies": {
         "map-stream": {
@@ -4169,7 +4165,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.1"
       }
     },
     "evp_bytestokey": {
@@ -4177,8 +4173,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "exec-buffer": {
@@ -4187,11 +4183,11 @@
       "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
       "optional": true,
       "requires": {
-        "execa": "^0.7.0",
-        "p-finally": "^1.0.0",
-        "pify": "^3.0.0",
-        "rimraf": "^2.5.4",
-        "tempfile": "^2.0.0"
+        "execa": "0.7.0",
+        "p-finally": "1.0.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2",
+        "tempfile": "2.0.0"
       },
       "dependencies": {
         "tempfile": {
@@ -4200,8 +4196,8 @@
           "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
           "optional": true,
           "requires": {
-            "temp-dir": "^1.0.0",
-            "uuid": "^3.0.1"
+            "temp-dir": "1.0.0",
+            "uuid": "3.2.1"
           }
         }
       }
@@ -4212,8 +4208,8 @@
       "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
       "optional": true,
       "requires": {
-        "async-each-series": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "async-each-series": "1.1.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "async-each-series": {
@@ -4229,13 +4225,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "execall": {
@@ -4243,7 +4239,7 @@
       "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "1.0.1"
       }
     },
     "executable": {
@@ -4252,7 +4248,7 @@
       "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
       "optional": true,
       "requires": {
-        "meow": "^3.1.0"
+        "meow": "3.7.0"
       },
       "dependencies": {
         "camelcase": {
@@ -4267,8 +4263,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "optional": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "find-up": {
@@ -4277,8 +4273,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "optional": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "get-stdin": {
@@ -4293,7 +4289,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "optional": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "load-json-file": {
@@ -4302,11 +4298,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "map-obj": {
@@ -4320,16 +4316,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "optional": true,
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "parse-json": {
@@ -4338,7 +4334,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "optional": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -4347,7 +4343,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "optional": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -4356,9 +4352,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -4372,9 +4368,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "optional": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -4383,8 +4379,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "optional": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "redent": {
@@ -4393,8 +4389,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "optional": true,
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "strip-bom": {
@@ -4403,7 +4399,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "optional": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -4412,7 +4408,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "optional": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -4438,7 +4434,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -4446,7 +4442,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-tilde": {
@@ -4454,7 +4450,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "express": {
@@ -4462,36 +4458,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -4516,7 +4512,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "^0.1.0"
+        "is-extendable": "0.1.1"
       }
     },
     "extglob": {
@@ -4524,7 +4520,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-zip": {
@@ -4548,10 +4544,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
           }
         }
       }
@@ -4566,9 +4562,9 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -4581,12 +4577,12 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.1",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.0",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.2",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -4604,16 +4600,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4621,7 +4617,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4631,8 +4627,8 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
           }
         },
         "expand-brackets": {
@@ -4640,13 +4636,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4654,7 +4650,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4662,7 +4658,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -4670,9 +4666,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -4687,8 +4683,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -4696,7 +4692,7 @@
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -4706,14 +4702,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4721,7 +4717,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -4729,7 +4725,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4739,10 +4735,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4750,7 +4746,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4760,8 +4756,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -4769,7 +4765,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -4779,7 +4775,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4787,7 +4783,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4797,7 +4793,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4805,7 +4801,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4820,7 +4816,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -4828,7 +4824,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4836,7 +4832,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4846,7 +4842,7 @@
           "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
           "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "requires": {
-            "is-number": "^4.0.0"
+            "is-number": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -4876,19 +4872,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         },
         "nanomatch": {
@@ -4896,18 +4892,18 @@
           "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
           "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         },
         "to-regex": {
@@ -4915,10 +4911,10 @@
           "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
           },
           "dependencies": {
             "regex-not": {
@@ -4926,8 +4922,8 @@
               "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
               "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
               "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
               }
             }
           }
@@ -4944,7 +4940,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fbjs": {
@@ -4952,13 +4948,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
       },
       "dependencies": {
         "promise": {
@@ -4966,7 +4962,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "~2.0.3"
+            "asap": "2.0.6"
           }
         }
       }
@@ -4976,7 +4972,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -4985,8 +4981,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "optional": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-entry-cache": {
@@ -4994,8 +4990,8 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "file-type": {
@@ -5018,9 +5014,9 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "requires": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "1.0.0",
+        "strip-outer": "1.0.0",
+        "trim-repeated": "1.0.0"
       }
     },
     "filesize": {
@@ -5033,11 +5029,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -5046,12 +5042,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       }
     },
     "find-index": {
@@ -5064,7 +5060,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "find-versions": {
@@ -5073,10 +5069,10 @@
       "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
       "optional": true,
       "requires": {
-        "array-uniq": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "meow": "^3.5.0",
-        "semver-regex": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0",
+        "semver-regex": "1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -5091,8 +5087,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "optional": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "find-up": {
@@ -5101,8 +5097,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "optional": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "get-stdin": {
@@ -5116,7 +5112,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "optional": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "load-json-file": {
@@ -5125,11 +5121,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "map-obj": {
@@ -5143,16 +5139,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "optional": true,
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "parse-json": {
@@ -5161,7 +5157,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "optional": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -5170,7 +5166,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "optional": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -5179,9 +5175,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -5195,9 +5191,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "optional": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -5206,8 +5202,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "optional": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "redent": {
@@ -5216,8 +5212,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "optional": true,
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "strip-bom": {
@@ -5226,7 +5222,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "optional": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -5235,7 +5231,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "optional": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -5251,10 +5247,10 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.5",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -5272,17 +5268,17 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
           "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.1"
           }
         },
         "expand-brackets": {
@@ -5290,13 +5286,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -5304,7 +5300,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -5314,14 +5310,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
           }
         },
         "fill-range": {
@@ -5329,10 +5325,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -5340,7 +5336,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5348,7 +5344,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5358,7 +5354,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5366,7 +5362,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5376,9 +5372,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -5398,7 +5394,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -5406,7 +5402,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5414,7 +5410,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5434,19 +5430,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
           "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.0",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "extglob": "^2.0.2",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.0",
-            "nanomatch": "^1.2.5",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.0",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.7",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
           }
         }
       }
@@ -5456,11 +5452,11 @@
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "first-chunk-stream": {
@@ -5478,10 +5474,10 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       },
       "dependencies": {
         "del": {
@@ -5489,13 +5485,13 @@
           "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "requires": {
-            "globby": "^5.0.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "rimraf": "^2.2.8"
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "globby": {
@@ -5503,12 +5499,12 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -5523,7 +5519,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
       "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5541,7 +5537,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.3"
       }
     },
     "for-in": {
@@ -5554,7 +5550,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -5577,9 +5573,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "formatio": {
@@ -5587,7 +5583,7 @@
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.1.2"
       }
     },
     "forwarded": {
@@ -5600,7 +5596,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -5618,11 +5614,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "fs.realpath": {
@@ -5636,70 +5632,82 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -5707,388 +5715,442 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -6097,10 +6159,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "function-bind": {
@@ -6113,14 +6175,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
       },
       "dependencies": {
         "string-width": {
@@ -6128,9 +6190,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -6140,7 +6202,7 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "requires": {
-        "globule": "~0.1.0"
+        "globule": "0.1.0"
       }
     },
     "get-caller-file": {
@@ -6153,7 +6215,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "requires": {
-        "rc": "^1.1.2"
+        "rc": "1.2.8"
       }
     },
     "get-stdin": {
@@ -6176,7 +6238,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "gifsicle": {
@@ -6185,9 +6247,9 @@
       "integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
       "optional": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "gift": {
@@ -6195,7 +6257,7 @@
       "resolved": "https://registry.npmjs.org/gift/-/gift-0.6.1.tgz",
       "integrity": "sha1-wWmOa2iHFk7ZeKAQlUI8/2W4558=",
       "requires": {
-        "underscore": "1.x.x"
+        "underscore": "1.8.3"
       }
     },
     "glob": {
@@ -6203,12 +6265,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -6216,8 +6278,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -6225,7 +6287,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-stream": {
@@ -6233,12 +6295,12 @@
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -6246,10 +6308,10 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -6262,18 +6324,18 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.9"
           }
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -6286,8 +6348,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -6302,7 +6364,7 @@
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "requires": {
-        "gaze": "^0.5.1"
+        "gaze": "0.5.2"
       }
     },
     "glob2base": {
@@ -6310,7 +6372,7 @@
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "global": {
@@ -6318,8 +6380,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       }
     },
     "global-dirs": {
@@ -6327,7 +6389,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -6335,9 +6397,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.1",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -6345,11 +6407,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.1",
+        "which": "1.3.0"
       }
     },
     "globby": {
@@ -6357,11 +6419,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -6381,9 +6443,9 @@
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "glob": {
@@ -6391,9 +6453,9 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "graceful-fs": {
@@ -6416,8 +6478,8 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -6427,7 +6489,7 @@
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "gonzales-pe": {
@@ -6435,7 +6497,7 @@
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
       "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "1.1.3"
       },
       "dependencies": {
         "minimist": {
@@ -6450,21 +6512,21 @@
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "requires": {
-        "create-error-class": "^3.0.1",
-        "duplexer2": "^0.1.4",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "node-status-codes": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "parse-json": "^2.1.0",
-        "pinkie-promise": "^2.0.0",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.5",
-        "timed-out": "^3.0.0",
-        "unzip-response": "^1.0.2",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer2": "0.1.4",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "node-status-codes": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.3",
+        "timed-out": "3.1.3",
+        "unzip-response": "1.0.2",
+        "url-parse-lax": "1.0.0"
       },
       "dependencies": {
         "duplexer2": {
@@ -6472,7 +6534,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.3"
           }
         },
         "parse-json": {
@@ -6480,7 +6542,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         }
       }
@@ -6500,19 +6562,19 @@
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
       },
       "dependencies": {
         "semver": {
@@ -6527,12 +6589,12 @@
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-5.0.0.tgz",
       "integrity": "sha1-gjfCeKaXdScKHK/n1vEBz81YVUQ=",
       "requires": {
-        "autoprefixer": "^8.0.0",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.1",
-        "postcss": "^6.0.1",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "autoprefixer": "8.5.0",
+        "fancy-log": "1.3.2",
+        "plugin-error": "1.0.1",
+        "postcss": "6.0.17",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -6545,8 +6607,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -6554,7 +6616,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         },
         "plugin-error": {
@@ -6562,10 +6624,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "arr-diff": "^4.0.0",
-            "arr-union": "^3.1.0",
-            "extend-shallow": "^3.0.2"
+            "ansi-colors": "1.0.1",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
           }
         }
       }
@@ -6575,11 +6637,11 @@
       "resolved": "https://registry.npmjs.org/gulp-bump/-/gulp-bump-3.1.1.tgz",
       "integrity": "sha512-4lVWz2L/8G2lYBjYGzql2BiVIa1Mml03YcHQc1pERk8jH/8nZbrdQ8dHABDnAcBNP4rKAh9AVycjNJ4/4AHkwQ==",
       "requires": {
-        "bump-regex": "^3.1.1",
-        "plugin-error": "^0.1.2",
-        "plugin-log": "^0.1.0",
-        "semver": "^5.3.0",
-        "through2": "^2.0.1"
+        "bump-regex": "3.1.1",
+        "plugin-error": "0.1.2",
+        "plugin-log": "0.1.0",
+        "semver": "5.5.0",
+        "through2": "2.0.3"
       }
     },
     "gulp-clean": {
@@ -6587,11 +6649,11 @@
       "resolved": "https://registry.npmjs.org/gulp-clean/-/gulp-clean-0.4.0.tgz",
       "integrity": "sha512-DARK8rNMo4lHOFLGTiHEJdf19GuoBDHqGUaypz+fOhrvOs3iFO7ntdYtdpNxv+AzSJBx/JfypF0yEj9ks1IStQ==",
       "requires": {
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^0.1.2",
-        "rimraf": "^2.6.2",
-        "through2": "^2.0.3",
-        "vinyl": "^2.1.0"
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2",
+        "rimraf": "2.6.2",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -6614,12 +6676,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.0.0",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -6629,9 +6691,9 @@
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "requires": {
-        "concat-with-sourcemaps": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.0"
+        "concat-with-sourcemaps": "1.1.0",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -6654,12 +6716,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.0.0",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -6669,13 +6731,13 @@
       "resolved": "https://registry.npmjs.org/gulp-cssmin/-/gulp-cssmin-0.2.0.tgz",
       "integrity": "sha1-h6s8ad05sg1dljVcZQStakR7HnI=",
       "requires": {
-        "clean-css": "^3.1.9",
-        "filesize": "~2.0.0",
-        "graceful-fs": "~4.1.4",
-        "gulp-rename": "~1.1.0",
-        "gulp-util": "~2.2.0",
+        "clean-css": "3.4.28",
+        "filesize": "2.0.4",
+        "graceful-fs": "4.1.11",
+        "gulp-rename": "1.1.0",
+        "gulp-util": "2.2.20",
         "map-stream": "0.0.4",
-        "temp-write": "~0.1.0"
+        "temp-write": "0.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6693,11 +6755,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "gulp-rename": {
@@ -6705,7 +6767,7 @@
           "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.1.0.tgz",
           "integrity": "sha1-kwkKqvTThsB/IFOKaIjxXvunJ6E=",
           "requires": {
-            "map-stream": ">=0.0.4"
+            "map-stream": "0.0.4"
           }
         },
         "gulp-util": {
@@ -6713,14 +6775,14 @@
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "requires": {
-            "chalk": "^0.5.0",
-            "dateformat": "^1.0.7-1.2.3",
-            "lodash._reinterpolate": "^2.4.1",
-            "lodash.template": "^2.4.1",
-            "minimist": "^0.2.0",
-            "multipipe": "^0.1.0",
-            "through2": "^0.5.0",
-            "vinyl": "^0.2.1"
+            "chalk": "0.5.1",
+            "dateformat": "1.0.11",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
           }
         },
         "has-ansi": {
@@ -6728,7 +6790,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "isarray": {
@@ -6746,9 +6808,9 @@
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "requires": {
-            "lodash._escapehtmlchar": "~2.4.1",
-            "lodash._reunescapedhtml": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.keys": {
@@ -6756,9 +6818,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         },
         "lodash.template": {
@@ -6766,13 +6828,13 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "requires": {
-            "lodash._escapestringchar": "~2.4.1",
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.defaults": "~2.4.1",
-            "lodash.escape": "~2.4.1",
-            "lodash.keys": "~2.4.1",
-            "lodash.templatesettings": "~2.4.1",
-            "lodash.values": "~2.4.1"
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -6780,8 +6842,8 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "requires": {
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.escape": "~2.4.1"
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
           }
         },
         "minimist": {
@@ -6794,10 +6856,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -6810,7 +6872,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -6823,8 +6885,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
+            "readable-stream": "1.0.34",
+            "xtend": "3.0.0"
           }
         },
         "vinyl": {
@@ -6832,7 +6894,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "requires": {
-            "clone-stats": "~0.0.1"
+            "clone-stats": "0.0.1"
           }
         },
         "xtend": {
@@ -6847,10 +6909,10 @@
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "requires": {
-        "archive-type": "^3.0.0",
-        "decompress": "^3.0.0",
-        "gulp-util": "^3.0.1",
-        "readable-stream": "^2.0.2"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.3"
       }
     },
     "gulp-filter": {
@@ -6858,9 +6920,9 @@
       "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
       "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
       "requires": {
-        "multimatch": "^2.0.0",
-        "plugin-error": "^0.1.2",
-        "streamfilter": "^1.0.5"
+        "multimatch": "2.1.0",
+        "plugin-error": "0.1.2",
+        "streamfilter": "1.0.7"
       }
     },
     "gulp-gh-pages": {
@@ -6868,12 +6930,12 @@
       "resolved": "https://registry.npmjs.org/gulp-gh-pages/-/gulp-gh-pages-0.5.4.tgz",
       "integrity": "sha1-pnMspHWrm1pTJTwcJHNMQMIbZUY=",
       "requires": {
-        "gift": "^0.6.1",
-        "gulp-util": "^3.0.7",
-        "readable-stream": "^2.0.2",
-        "rimraf": "^2.4.3",
-        "vinyl-fs": "^2.2.1",
-        "wrap-promise": "^1.0.1"
+        "gift": "0.6.1",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.3",
+        "rimraf": "2.6.2",
+        "vinyl-fs": "2.4.4",
+        "wrap-promise": "1.0.1"
       },
       "dependencies": {
         "glob": {
@@ -6881,11 +6943,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -6893,8 +6955,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "glob-stream": {
@@ -6902,14 +6964,14 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -6917,10 +6979,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "through2": {
@@ -6928,8 +6990,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -6939,11 +7001,11 @@
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "requires": {
-            "convert-source-map": "^1.1.1",
-            "graceful-fs": "^4.1.2",
-            "strip-bom": "^2.0.0",
-            "through2": "^2.0.0",
-            "vinyl": "^1.0.0"
+            "convert-source-map": "1.5.1",
+            "graceful-fs": "4.1.11",
+            "strip-bom": "2.0.0",
+            "through2": "2.0.3",
+            "vinyl": "1.2.0"
           }
         },
         "is-extglob": {
@@ -6956,7 +7018,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -6969,8 +7031,8 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.3"
           }
         },
         "string_decoder": {
@@ -6983,7 +7045,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "unique-stream": {
@@ -6991,8 +7053,8 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl": {
@@ -7000,8 +7062,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -7010,23 +7072,23 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.5.3",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.3",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         }
       }
@@ -7036,14 +7098,14 @@
       "resolved": "https://registry.npmjs.org/gulp-git/-/gulp-git-2.6.0.tgz",
       "integrity": "sha512-//Nf/1nG03rpDI5M4AxkhNVUUBx5qLboLg5kUSERirtCXviYYvIjnVgoRskgCyP1aljycbksnX0U13o3r1ABYQ==",
       "requires": {
-        "any-shell-escape": "^0.1.1",
-        "fancy-log": "^1.3.2",
-        "lodash.template": "^4.4.0",
-        "plugin-error": "^0.1.2",
-        "require-dir": "^1.0.0",
-        "strip-bom-stream": "^3.0.0",
-        "through2": "^2.0.3",
-        "vinyl": "^2.0.1"
+        "any-shell-escape": "0.1.1",
+        "fancy-log": "1.3.2",
+        "lodash.template": "4.4.0",
+        "plugin-error": "0.1.2",
+        "require-dir": "1.0.0",
+        "strip-bom-stream": "3.0.0",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -7061,7 +7123,7 @@
           "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.3"
           }
         },
         "lodash.template": {
@@ -7069,8 +7131,8 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -7078,7 +7140,7 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "replace-ext": {
@@ -7091,8 +7153,8 @@
           "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
           "integrity": "sha1-lWvMXYRDD2klapDtgjdlzYWOFZw=",
           "requires": {
-            "first-chunk-stream": "^2.0.0",
-            "strip-bom-buf": "^1.0.0"
+            "first-chunk-stream": "2.0.0",
+            "strip-bom-buf": "1.0.0"
           }
         },
         "vinyl": {
@@ -7100,12 +7162,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.0.0",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -7115,9 +7177,9 @@
       "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "requires": {
-        "gulp-match": "^1.0.3",
-        "ternary-stream": "^2.0.1",
-        "through2": "^2.0.1"
+        "gulp-match": "1.0.3",
+        "ternary-stream": "2.0.1",
+        "through2": "2.0.3"
       }
     },
     "gulp-imagemin": {
@@ -7125,17 +7187,17 @@
       "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-4.1.0.tgz",
       "integrity": "sha512-6nWkrMNY5ub+34+DwlgQdWg21Z4DWAOARLpnyuZ773pGPJrfiyQrkOzdz9DgQSGBQjU1zuw6gd+9clLi6eicuw==",
       "requires": {
-        "chalk": "^2.1.0",
-        "fancy-log": "^1.3.2",
-        "imagemin": "^5.3.1",
-        "imagemin-gifsicle": "^5.2.0",
-        "imagemin-jpegtran": "^5.0.2",
-        "imagemin-optipng": "^5.2.1",
-        "imagemin-svgo": "^6.0.0",
-        "plugin-error": "^0.1.2",
-        "plur": "^2.1.2",
-        "pretty-bytes": "^4.0.2",
-        "through2-concurrent": "^1.1.1"
+        "chalk": "2.3.0",
+        "fancy-log": "1.3.2",
+        "imagemin": "5.3.1",
+        "imagemin-gifsicle": "5.2.0",
+        "imagemin-jpegtran": "5.0.2",
+        "imagemin-optipng": "5.2.1",
+        "imagemin-svgo": "6.0.0",
+        "plugin-error": "0.1.2",
+        "plur": "2.1.2",
+        "pretty-bytes": "4.0.2",
+        "through2-concurrent": "1.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7143,7 +7205,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -7151,9 +7213,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "supports-color": {
@@ -7161,7 +7223,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -7171,14 +7233,14 @@
       "resolved": "https://registry.npmjs.org/gulp-lintspaces/-/gulp-lintspaces-1.0.0.tgz",
       "integrity": "sha512-Lt/weXK2PnyqN0C3ncGltJviKgYSlCfzOZI03tdTfQvHFvNd8EM556mdrj5lCdUtuRhRFN79WNFr9lEvRcm+ww==",
       "requires": {
-        "ansi-colors": "^1.1.0",
-        "app-root-path": "^1.0.0",
-        "colors": "^1.0.3",
-        "event-stream": "^3.1.1",
-        "lintspaces": "^0.5.0",
-        "log-symbols": "^1.0.2",
-        "path": "^0.11.14",
-        "plugin-error": "^1.0.1"
+        "ansi-colors": "1.1.0",
+        "app-root-path": "1.4.0",
+        "colors": "1.1.2",
+        "event-stream": "3.3.4",
+        "lintspaces": "0.5.1",
+        "log-symbols": "1.0.2",
+        "path": "0.11.14",
+        "plugin-error": "1.0.1"
       },
       "dependencies": {
         "ansi-colors": {
@@ -7186,7 +7248,7 @@
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
           "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
           "requires": {
-            "ansi-wrap": "^0.1.0"
+            "ansi-wrap": "0.1.0"
           }
         },
         "arr-diff": {
@@ -7199,8 +7261,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -7208,7 +7270,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         },
         "plugin-error": {
@@ -7216,10 +7278,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "arr-diff": "^4.0.0",
-            "arr-union": "^3.1.0",
-            "extend-shallow": "^3.0.2"
+            "ansi-colors": "1.1.0",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
           }
         }
       }
@@ -7229,7 +7291,7 @@
       "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "requires": {
-        "minimatch": "^3.0.3"
+        "minimatch": "3.0.4"
       }
     },
     "gulp-plumber": {
@@ -7238,10 +7300,10 @@
       "integrity": "sha512-L/LJftsbKoHbVj6dN5pvMsyJn9jYI0wT0nMg3G6VZhDac4NesezecYTi8/48rHi+yEic3sUpw6jlSc7qNWh32A==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^0.1.2",
-        "through2": "^2.0.3"
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.3"
       }
     },
     "gulp-postcss": {
@@ -7249,11 +7311,11 @@
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.1.tgz",
       "integrity": "sha1-Pxw22xGXFAw5nCUt3/M5EpY445U=",
       "requires": {
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^0.1.2",
-        "postcss": "^6.0.0",
-        "postcss-load-config": "^1.2.0",
-        "vinyl-sourcemaps-apply": "^0.2.1"
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2",
+        "postcss": "6.0.17",
+        "postcss-load-config": "1.2.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-rename": {
@@ -7266,14 +7328,14 @@
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-4.0.1.tgz",
       "integrity": "sha512-OMQEgWNggpog8Tc5v1MuI6eo+5iiPkVeLL76iBhDoEEScLUPfZlpvzmgTnLkpcqdrNodZxpz5qcv6mS2rulk3g==",
       "requires": {
-        "chalk": "^2.3.0",
-        "lodash.clonedeep": "^4.3.2",
-        "node-sass": "^4.8.3",
-        "plugin-error": "^1.0.1",
-        "replace-ext": "^1.0.0",
-        "strip-ansi": "^4.0.0",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "chalk": "2.4.1",
+        "lodash.clonedeep": "4.5.0",
+        "node-sass": "4.9.2",
+        "plugin-error": "1.0.1",
+        "replace-ext": "1.0.0",
+        "strip-ansi": "4.0.0",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7286,7 +7348,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "arr-diff": {
@@ -7299,9 +7361,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "extend-shallow": {
@@ -7309,8 +7371,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "has-flag": {
@@ -7323,7 +7385,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         },
         "plugin-error": {
@@ -7331,10 +7393,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "arr-diff": "^4.0.0",
-            "arr-union": "^3.1.0",
-            "extend-shallow": "^3.0.2"
+            "ansi-colors": "1.0.1",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
           }
         },
         "replace-ext": {
@@ -7347,7 +7409,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -7355,7 +7417,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7366,11 +7428,11 @@
       "integrity": "sha512-5NgvOYE8OrYj3hmxL4Tf79qdxRTJXe2UdAM+L6R/qu4h9ZPvoujtPYk/CmpNReuBJdDXR2DNWeq6t58NFARYUA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.2",
-        "minimatch": "^3.0.4",
-        "safe-buffer": "^5.1.1",
-        "slash": "^2.0.0",
-        "through2": "^2.0.3"
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "safe-buffer": "5.1.1",
+        "slash": "2.0.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "slash": {
@@ -7386,13 +7448,13 @@
       "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.6.5.tgz",
       "integrity": "sha512-f3m1WcS0o2B72/PGj1Jbv9zYR9rynBh/EQJv64n01xQUo7j7anols0eww9GG/WtDTzGVQLrupVDYkifRFnj5Zg==",
       "requires": {
-        "async": "^2.1.5",
-        "chalk": "^2.3.0",
-        "fancy-log": "^1.3.2",
-        "lodash": "^4.17.4",
-        "lodash.template": "^4.4.0",
-        "plugin-error": "^0.1.2",
-        "through2": "^2.0.3"
+        "async": "2.6.0",
+        "chalk": "2.3.0",
+        "fancy-log": "1.3.2",
+        "lodash": "4.17.5",
+        "lodash.template": "4.4.0",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7400,7 +7462,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "async": {
@@ -7408,7 +7470,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "chalk": {
@@ -7416,9 +7478,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "lodash.template": {
@@ -7426,8 +7488,8 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -7435,7 +7497,7 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "supports-color": {
@@ -7443,7 +7505,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -7453,17 +7515,17 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz",
       "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
       "requires": {
-        "@gulp-sourcemaps/identity-map": "1.X",
-        "@gulp-sourcemaps/map-sources": "1.X",
-        "acorn": "5.X",
-        "convert-source-map": "1.X",
-        "css": "2.X",
-        "debug-fabulous": "1.X",
-        "detect-newline": "2.X",
-        "graceful-fs": "4.X",
-        "source-map": "~0.6.0",
-        "strip-bom-string": "1.X",
-        "through2": "2.X"
+        "@gulp-sourcemaps/identity-map": "1.0.1",
+        "@gulp-sourcemaps/map-sources": "1.0.0",
+        "acorn": "5.4.1",
+        "convert-source-map": "1.5.1",
+        "css": "2.2.3",
+        "debug-fabulous": "1.0.0",
+        "detect-newline": "2.1.0",
+        "graceful-fs": "4.1.11",
+        "source-map": "0.6.1",
+        "strip-bom-string": "1.0.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "source-map": {
@@ -7478,15 +7540,15 @@
       "resolved": "https://registry.npmjs.org/gulp-stylelint/-/gulp-stylelint-7.0.0.tgz",
       "integrity": "sha512-0PI+tNTzaJz5+qO3i9Jyd04ZPSb+NCN7bZ2GaIArvbQpuyJha9p3lpWxPG+XJtrVT42bIiyLeYKPnLe7uW4dQQ==",
       "requires": {
-        "chalk": "^2.3.0",
-        "deep-extend": "^0.5.0",
-        "fancy-log": "^1.3.2",
-        "mkdirp": "^0.5.1",
-        "plugin-error": "^1.0.1",
-        "promise": "^8.0.1",
-        "source-map": "^0.5.6",
-        "strip-ansi": "^4.0.0",
-        "through2": "^2.0.3"
+        "chalk": "2.4.1",
+        "deep-extend": "0.5.1",
+        "fancy-log": "1.3.2",
+        "mkdirp": "0.5.1",
+        "plugin-error": "1.0.1",
+        "promise": "8.0.1",
+        "source-map": "0.5.7",
+        "strip-ansi": "4.0.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7499,7 +7561,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "arr-diff": {
@@ -7512,9 +7574,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "deep-extend": {
@@ -7527,8 +7589,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "has-flag": {
@@ -7541,7 +7603,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         },
         "plugin-error": {
@@ -7549,10 +7611,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "arr-diff": "^4.0.0",
-            "arr-union": "^3.1.0",
-            "extend-shallow": "^3.0.2"
+            "ansi-colors": "1.0.1",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
           }
         },
         "strip-ansi": {
@@ -7560,7 +7622,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -7568,7 +7630,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7579,8 +7641,8 @@
       "integrity": "sha1-pKqeJhXPEQXvVVrqhuhilswg4nM=",
       "dev": true,
       "requires": {
-        "gulp-util": "^3.0.4",
-        "svgo": "^0.7.0"
+        "gulp-util": "3.0.8",
+        "svgo": "0.7.2"
       },
       "dependencies": {
         "coa": {
@@ -7589,7 +7651,7 @@
           "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
           "dev": true,
           "requires": {
-            "q": "^1.1.2"
+            "q": "1.5.1"
           }
         },
         "csso": {
@@ -7598,8 +7660,8 @@
           "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
           "dev": true,
           "requires": {
-            "clap": "^1.0.9",
-            "source-map": "^0.5.3"
+            "clap": "1.2.3",
+            "source-map": "0.5.7"
           }
         },
         "esprima": {
@@ -7614,8 +7676,8 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^2.6.0"
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
           }
         },
         "svgo": {
@@ -7624,13 +7686,13 @@
           "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
           "dev": true,
           "requires": {
-            "coa": "~1.0.1",
-            "colors": "~1.1.2",
-            "csso": "~2.3.1",
-            "js-yaml": "~3.7.0",
-            "mkdirp": "~0.5.1",
-            "sax": "~1.2.1",
-            "whet.extend": "~0.9.9"
+            "coa": "1.0.4",
+            "colors": "1.1.2",
+            "csso": "2.3.2",
+            "js-yaml": "3.7.0",
+            "mkdirp": "0.5.1",
+            "sax": "1.2.4",
+            "whet.extend": "0.9.9"
           }
         }
       }
@@ -7640,10 +7702,10 @@
       "resolved": "https://registry.npmjs.org/gulp-tag-version/-/gulp-tag-version-1.3.1.tgz",
       "integrity": "sha512-bt1LbmGeg6OaiKEdQ+hmi9KeawTXYnunDVCd9cvNoVT89KKXyZEEdR2DCSFR8zk+nunatRnSD3Zaa4R9JGC4Tw==",
       "requires": {
-        "ansi-colors": "~1.0.1",
-        "fancy-log": "~1.3.2",
-        "gulp-git": "^2.4.2",
-        "map-stream": "~0.1.0"
+        "ansi-colors": "1.0.1",
+        "fancy-log": "1.3.2",
+        "gulp-git": "2.6.0",
+        "map-stream": "0.1.0"
       },
       "dependencies": {
         "map-stream": {
@@ -7658,13 +7720,13 @@
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
       "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
       "requires": {
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash": "^4.13.1",
-        "make-error-cause": "^1.1.1",
-        "through2": "^2.0.0",
-        "uglify-js": "^3.0.5",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash": "4.17.5",
+        "make-error-cause": "1.2.2",
+        "through2": "2.0.3",
+        "uglify-js": "3.3.10",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-util": {
@@ -7672,24 +7734,24 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "dateformat": {
@@ -7709,7 +7771,7 @@
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "handle-thing": {
@@ -7722,23 +7784,23 @@
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.4.0.tgz",
       "integrity": "sha512-ZxzvlGVs0lb7MW4AGxFQ/TM4rOvH6aeR4O0kj47eWy0VjGshlTZFPTighstJQPJy/bKTrlMaThn5ES87fwmGTA==",
       "requires": {
-        "accept": "3.x.x",
-        "ammo": "3.x.x",
-        "boom": "7.x.x",
-        "bounce": "1.x.x",
-        "call": "5.x.x",
-        "catbox": "10.x.x",
-        "catbox-memory": "3.x.x",
-        "heavy": "6.x.x",
-        "hoek": "5.x.x",
-        "joi": "13.x.x",
-        "mimos": "4.x.x",
-        "podium": "3.x.x",
-        "shot": "4.x.x",
-        "statehood": "6.x.x",
-        "subtext": "6.x.x",
-        "teamwork": "3.x.x",
-        "topo": "3.x.x"
+        "accept": "3.0.2",
+        "ammo": "3.0.1",
+        "boom": "7.2.0",
+        "bounce": "1.2.0",
+        "call": "5.0.1",
+        "catbox": "10.0.2",
+        "catbox-memory": "3.1.2",
+        "heavy": "6.1.0",
+        "hoek": "5.0.3",
+        "joi": "13.3.0",
+        "mimos": "4.0.0",
+        "podium": "3.1.2",
+        "shot": "4.0.5",
+        "statehood": "6.0.6",
+        "subtext": "6.0.7",
+        "teamwork": "3.0.1",
+        "topo": "3.0.0"
       },
       "dependencies": {
         "boom": {
@@ -7746,7 +7808,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -7761,8 +7823,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -7770,10 +7832,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "fast-deep-equal": {
@@ -7788,7 +7850,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -7796,7 +7858,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -7829,7 +7891,7 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "has-own-property-x": {
@@ -7838,9 +7900,9 @@
       "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
       "optional": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "to-object-x": "^1.5.0",
-        "to-property-key-x": "^2.0.2"
+        "cached-constructors-x": "1.0.0",
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
       }
     },
     "has-symbol-support-x": {
@@ -7853,7 +7915,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.1"
       }
     },
     "has-unicode": {
@@ -7866,9 +7928,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -7883,8 +7945,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7892,7 +7954,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7900,7 +7962,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7910,7 +7972,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7920,8 +7982,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "hash.js": {
@@ -7929,8 +7991,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "hasha": {
@@ -7938,8 +8000,8 @@
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hawk": {
@@ -7947,10 +8009,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       },
       "dependencies": {
         "hoek": {
@@ -7965,9 +8027,9 @@
       "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.0.tgz",
       "integrity": "sha512-TKS9DC9NOTGulHQI31Lx+bmeWmNOstbJbGMiN3pX6bF+Zc2GKSpbbym4oasNnB6yPGkqJ9TQXXYDGohqNSJRxA==",
       "requires": {
-        "boom": "7.x.x",
-        "hoek": "5.x.x",
-        "joi": "13.x.x"
+        "boom": "7.2.0",
+        "hoek": "5.0.3",
+        "joi": "13.3.0"
       },
       "dependencies": {
         "boom": {
@@ -7975,7 +8037,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -7985,9 +8047,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.5",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -8005,7 +8067,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -8018,10 +8080,10 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.3",
+        "wbuf": "1.7.3"
       }
     },
     "html-comment-regex": {
@@ -8045,12 +8107,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.2",
+        "domutils": "1.5.1",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       }
     },
     "http-deceiver": {
@@ -8063,10 +8125,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -8079,9 +8141,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.5.1",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -8089,10 +8151,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^3.1.0",
-        "lodash": "^4.17.2",
-        "micromatch": "^2.3.11"
+        "http-proxy": "1.17.0",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.5",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -8105,7 +8167,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -8115,9 +8177,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "https-browserify": {
@@ -8130,8 +8192,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -8149,7 +8211,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -8167,12 +8229,12 @@
       "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
       "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
       "requires": {
-        "file-type": "^4.1.0",
-        "globby": "^6.1.0",
-        "make-dir": "^1.0.0",
-        "p-pipe": "^1.1.0",
-        "pify": "^2.3.0",
-        "replace-ext": "^1.0.0"
+        "file-type": "4.4.0",
+        "globby": "6.1.0",
+        "make-dir": "1.1.0",
+        "p-pipe": "1.2.0",
+        "pify": "2.3.0",
+        "replace-ext": "1.0.0"
       },
       "dependencies": {
         "file-type": {
@@ -8198,9 +8260,9 @@
       "integrity": "sha512-K01m5QuPK+0en8oVhiOOAicF7KjrHlCZxS++mfLI2mV/Ksfq/Y9nCXCWDz6jRv13wwlqe5T7hXT+ji2DnLc2yQ==",
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "gifsicle": "^3.0.0",
-        "is-gif": "^1.0.0"
+        "exec-buffer": "3.2.0",
+        "gifsicle": "3.0.4",
+        "is-gif": "1.0.0"
       }
     },
     "imagemin-jpegtran": {
@@ -8209,9 +8271,9 @@
       "integrity": "sha1-5ogiY7j3kW/duABkDPddLpcNKtY=",
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-jpg": "^1.0.0",
-        "jpegtran-bin": "^3.0.0"
+        "exec-buffer": "3.2.0",
+        "is-jpg": "1.0.0",
+        "jpegtran-bin": "3.2.0"
       }
     },
     "imagemin-optipng": {
@@ -8220,9 +8282,9 @@
       "integrity": "sha1-0i2kEsCfX/AKQzmWC5ioix2+hpU=",
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-png": "^1.0.0",
-        "optipng-bin": "^3.0.0"
+        "exec-buffer": "3.2.0",
+        "is-png": "1.1.0",
+        "optipng-bin": "3.1.4"
       }
     },
     "imagemin-svgo": {
@@ -8231,9 +8293,9 @@
       "integrity": "sha512-xwjBZQKpbkklHtJYnCOwRJjTRJA/nR0hQzKMh+CUZRvm/L0QwKKPJQ9tkPWQHrg+cydPu2i1vLgHuy2E0hKEkg==",
       "optional": true,
       "requires": {
-        "buffer-from": "^0.1.1",
-        "is-svg": "^2.0.0",
-        "svgo": "^1.0.0"
+        "buffer-from": "0.1.1",
+        "is-svg": "2.1.0",
+        "svgo": "1.0.4"
       }
     },
     "immutable": {
@@ -8251,8 +8313,8 @@
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -8291,8 +8353,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -8310,7 +8372,7 @@
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
       "requires": {
-        "meow": "^3.3.0"
+        "meow": "3.7.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8323,8 +8385,8 @@
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "find-up": {
@@ -8332,8 +8394,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "get-stdin": {
@@ -8346,7 +8408,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "load-json-file": {
@@ -8354,11 +8416,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "map-obj": {
@@ -8371,16 +8433,16 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "parse-json": {
@@ -8388,7 +8450,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -8396,7 +8458,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -8404,9 +8466,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -8419,9 +8481,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -8429,8 +8491,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "redent": {
@@ -8438,8 +8500,8 @@
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "strip-bom": {
@@ -8447,7 +8509,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -8455,7 +8517,7 @@
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -8475,7 +8537,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -8503,9 +8565,9 @@
       "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
       "integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
       "requires": {
-        "boom": "7.x.x",
-        "cryptiles": "4.x.x",
-        "hoek": "5.x.x"
+        "boom": "7.2.0",
+        "cryptiles": "4.1.1",
+        "hoek": "5.0.3"
       },
       "dependencies": {
         "boom": {
@@ -8513,7 +8575,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         },
         "cryptiles": {
@@ -8521,7 +8583,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
           "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
           "requires": {
-            "boom": "7.x.x"
+            "boom": "7.2.0"
           }
         }
       }
@@ -8536,8 +8598,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.1"
       }
     },
     "is-accessor-descriptor": {
@@ -8545,7 +8607,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8570,8 +8632,8 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2"
       }
     },
     "is-array-buffer-x": {
@@ -8580,11 +8642,11 @@
       "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
       "optional": true,
       "requires": {
-        "attempt-x": "^1.1.0",
-        "has-to-string-tag-x": "^1.4.1",
-        "is-object-like-x": "^1.5.1",
-        "object-get-own-property-descriptor-x": "^3.2.0",
-        "to-string-tag-x": "^1.4.1"
+        "attempt-x": "1.1.1",
+        "has-to-string-tag-x": "1.4.1",
+        "is-object-like-x": "1.6.0",
+        "object-get-own-property-descriptor-x": "3.2.0",
+        "to-string-tag-x": "1.4.2"
       }
     },
     "is-arrayish": {
@@ -8597,7 +8659,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -8610,7 +8672,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-bzip2": {
@@ -8628,7 +8690,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -8636,7 +8698,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8661,9 +8723,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "requires": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8688,7 +8750,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -8706,7 +8768,7 @@
       "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
       "integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
       "requires": {
-        "to-boolean-x": "^1.0.1"
+        "to-boolean-x": "1.0.1"
       }
     },
     "is-finite": {
@@ -8714,7 +8776,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-finite-x": {
@@ -8723,8 +8785,8 @@
       "integrity": "sha512-HyFrxJZsgmP5RtR1PVlVvHSP4VslZOqr4uoq4x3rDrSOFaYp4R9tfmiWtAzQxPzixXhac3cYEno3NuVn0OHk2Q==",
       "optional": true,
       "requires": {
-        "infinity-x": "^1.0.0",
-        "is-nan-x": "^1.0.1"
+        "infinity-x": "1.0.0",
+        "is-nan-x": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -8732,7 +8794,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-function": {
@@ -8745,14 +8807,14 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
       "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
       "requires": {
-        "attempt-x": "^1.1.1",
-        "has-to-string-tag-x": "^1.4.1",
-        "is-falsey-x": "^1.0.1",
-        "is-primitive": "^2.0.0",
-        "normalize-space-x": "^3.0.0",
-        "replace-comments-x": "^2.0.0",
-        "to-boolean-x": "^1.0.1",
-        "to-string-tag-x": "^1.4.2"
+        "attempt-x": "1.1.1",
+        "has-to-string-tag-x": "1.4.1",
+        "is-falsey-x": "1.0.1",
+        "is-primitive": "2.0.0",
+        "normalize-space-x": "3.0.0",
+        "replace-comments-x": "2.0.0",
+        "to-boolean-x": "1.0.1",
+        "to-string-tag-x": "1.4.2"
       }
     },
     "is-gif": {
@@ -8766,7 +8828,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-gzip": {
@@ -8785,11 +8847,11 @@
       "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
       "optional": true,
       "requires": {
-        "math-clamp-x": "^1.2.0",
-        "max-safe-integer": "^1.0.1",
-        "to-integer-x": "^3.0.0",
-        "to-number-x": "^2.0.0",
-        "to-string-symbols-supported-x": "^1.0.0"
+        "math-clamp-x": "1.2.0",
+        "max-safe-integer": "1.0.1",
+        "to-integer-x": "3.0.0",
+        "to-number-x": "2.0.0",
+        "to-string-symbols-supported-x": "1.0.0"
       }
     },
     "is-installed-globally": {
@@ -8797,8 +8859,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-jpg": {
@@ -8822,8 +8884,8 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz",
       "integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
       "requires": {
-        "lodash.isnull": "^3.0.0",
-        "validate.io-undefined": "^1.0.3"
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
       }
     },
     "is-npm": {
@@ -8836,7 +8898,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-number-like": {
@@ -8844,7 +8906,7 @@
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "requires": {
-        "lodash.isfinite": "^3.3.2"
+        "lodash.isfinite": "3.3.2"
       }
     },
     "is-obj": {
@@ -8858,8 +8920,8 @@
       "integrity": "sha512-mc3dBMv1jEOdk0f1i2RkJFsZDux0MuHqGwHOoRo770ShUOf4VE6tWThAW8dAZARr9a5RN+iNX1yzMDA5ad1clQ==",
       "optional": true,
       "requires": {
-        "is-function-x": "^3.3.0",
-        "is-primitive": "^2.0.0"
+        "is-function-x": "3.3.0",
+        "is-primitive": "2.0.0"
       }
     },
     "is-odd": {
@@ -8867,7 +8929,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
       "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
       "requires": {
-        "is-number": "^3.0.0"
+        "is-number": "3.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8875,7 +8937,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -8890,7 +8952,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -8898,7 +8960,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -8911,7 +8973,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8952,7 +9014,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-regexp": {
@@ -8965,7 +9027,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-retry-allowed": {
@@ -8995,7 +9057,7 @@
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "optional": true,
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.1"
       }
     },
     "is-symbol": {
@@ -9018,7 +9080,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-url": {
@@ -9071,7 +9133,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
       "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -9099,8 +9161,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -9113,22 +9175,22 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
       "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "requires": {
-        "bignumber.js": "^2.1.0",
+        "bignumber.js": "2.4.0",
         "bmp-js": "0.0.3",
-        "es6-promise": "^3.0.2",
-        "exif-parser": "^0.1.9",
-        "file-type": "^3.1.0",
-        "jpeg-js": "^0.2.0",
-        "load-bmfont": "^1.2.3",
-        "mime": "^1.3.4",
+        "es6-promise": "3.3.1",
+        "exif-parser": "0.1.12",
+        "file-type": "3.9.0",
+        "jpeg-js": "0.2.0",
+        "load-bmfont": "1.3.0",
+        "mime": "1.6.0",
         "mkdirp": "0.5.1",
-        "pixelmatch": "^4.0.0",
-        "pngjs": "^3.0.0",
-        "read-chunk": "^1.0.1",
-        "request": "^2.65.0",
-        "stream-to-buffer": "^0.1.0",
-        "tinycolor2": "^1.1.2",
-        "url-regex": "^3.0.0"
+        "pixelmatch": "4.0.2",
+        "pngjs": "3.3.3",
+        "read-chunk": "1.0.1",
+        "request": "2.85.0",
+        "stream-to-buffer": "0.1.0",
+        "tinycolor2": "1.4.1",
+        "url-regex": "3.2.0"
       }
     },
     "joi": {
@@ -9136,9 +9198,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.3.0.tgz",
       "integrity": "sha512-iF6jEYVfBIoYXztYymia1JfuoVbxBNuOcwdbsdoGin9/jjhBLhonKmfTQOvePss8r8v4tU4JOcNmYPHZzKEFag==",
       "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
+        "hoek": "5.0.3",
+        "isemail": "3.1.2",
+        "topo": "3.0.0"
       }
     },
     "jpeg-js": {
@@ -9152,9 +9214,9 @@
       "integrity": "sha1-9g7PSumZwL2tLp+83ytvCYHnops=",
       "optional": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "js-base64": {
@@ -9172,8 +9234,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -9207,7 +9269,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -9230,7 +9292,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
@@ -9288,7 +9350,7 @@
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
           "integrity": "sha1-+Rb20Q1F3BcbG+Lm5nP7bgzDXQo=",
           "requires": {
-            "lodash": "~3.5.0"
+            "lodash": "3.5.0"
           }
         }
       }
@@ -9308,7 +9370,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -9316,7 +9378,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "known-css-properties": {
@@ -9329,7 +9391,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazy-cache": {
@@ -9337,7 +9399,7 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "requires": {
-        "set-getter": "^0.1.0"
+        "set-getter": "0.1.0"
       }
     },
     "lazy-req": {
@@ -9351,7 +9413,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.3"
       }
     },
     "lcid": {
@@ -9359,7 +9421,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "liftoff": {
@@ -9367,14 +9429,14 @@
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.5.0"
       }
     },
     "lighthouse-logger": {
@@ -9382,7 +9444,7 @@
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.0.1.tgz",
       "integrity": "sha1-8HPYP3rLyWcpvxAKEhyPAGmRrmE=",
       "requires": {
-        "debug": "^2.6.8"
+        "debug": "2.6.9"
       }
     },
     "limiter": {
@@ -9405,10 +9467,10 @@
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~1.0.4"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "1.0.4"
           }
         },
         "strip-json-comments": {
@@ -9424,12 +9486,12 @@
       "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.0",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
+        "mime": "1.6.0",
+        "parse-bmfont-ascii": "1.0.6",
+        "parse-bmfont-binary": "1.0.6",
+        "parse-bmfont-xml": "1.1.3",
+        "xhr": "2.5.0",
+        "xtend": "4.0.1"
       }
     },
     "load-json-file": {
@@ -9437,10 +9499,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "loader-runner": {
@@ -9453,9 +9515,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
       }
     },
     "localtunnel": {
@@ -9479,9 +9541,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "debug": {
@@ -9497,8 +9559,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "load-json-file": {
@@ -9506,11 +9568,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "os-locale": {
@@ -9518,7 +9580,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "parse-json": {
@@ -9526,7 +9588,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -9534,7 +9596,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -9542,9 +9604,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -9557,9 +9619,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -9567,8 +9629,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "string-width": {
@@ -9576,9 +9638,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -9586,7 +9648,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "which-module": {
@@ -9599,19 +9661,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         },
         "yargs-parser": {
@@ -9619,7 +9681,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -9629,8 +9691,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -9663,7 +9725,7 @@
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "requires": {
-        "lodash._htmlescapes": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -9716,8 +9778,8 @@
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "requires": {
-        "lodash._htmlescapes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9725,9 +9787,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -9742,7 +9804,7 @@
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.assign": {
@@ -9765,8 +9827,8 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "requires": {
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._objecttypes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9774,9 +9836,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -9786,7 +9848,7 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.isarguments": {
@@ -9819,7 +9881,7 @@
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.keys": {
@@ -9827,9 +9889,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.mergewith": {
@@ -9847,15 +9909,15 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -9863,8 +9925,8 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lodash.values": {
@@ -9872,7 +9934,7 @@
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "requires": {
-        "lodash.keys": "~2.4.1"
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9880,9 +9942,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -9892,7 +9954,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "logalot": {
@@ -9901,8 +9963,8 @@
       "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
       "optional": true,
       "requires": {
-        "figures": "^1.3.5",
-        "squeak": "^1.0.0"
+        "figures": "1.7.0",
+        "squeak": "1.3.0"
       }
     },
     "loglevel": {
@@ -9930,7 +9992,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "loud-rejection": {
@@ -9938,8 +10000,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -9953,10 +10015,10 @@
       "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
       "optional": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "indent-string": "^2.1.0",
-        "longest": "^1.0.0",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "indent-string": "2.1.0",
+        "longest": "1.0.1",
+        "meow": "3.7.0"
       },
       "dependencies": {
         "camelcase": {
@@ -9971,8 +10033,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "optional": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "find-up": {
@@ -9981,8 +10043,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "optional": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "get-stdin": {
@@ -9995,7 +10057,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "load-json-file": {
@@ -10004,11 +10066,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "map-obj": {
@@ -10022,16 +10084,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "optional": true,
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "parse-json": {
@@ -10040,7 +10102,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "optional": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -10049,7 +10111,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "optional": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -10058,9 +10120,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -10074,9 +10136,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "optional": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -10085,8 +10147,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "optional": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "redent": {
@@ -10095,8 +10157,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "optional": true,
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "strip-bom": {
@@ -10105,7 +10167,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "optional": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -10114,7 +10176,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "optional": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -10135,7 +10197,7 @@
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "~0.10.2"
+        "es5-ext": "0.10.38"
       }
     },
     "make-dir": {
@@ -10143,7 +10205,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-error": {
@@ -10156,7 +10218,7 @@
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "requires": {
-        "make-error": "^1.2.0"
+        "make-error": "1.3.3"
       }
     },
     "make-iterator": {
@@ -10164,7 +10226,7 @@
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
       "requires": {
-        "kind-of": "^3.1.0"
+        "kind-of": "3.2.2"
       }
     },
     "map-cache": {
@@ -10187,7 +10249,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "markdown-escapes": {
@@ -10206,7 +10268,7 @@
       "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
       "optional": true,
       "requires": {
-        "to-number-x": "^2.0.0"
+        "to-number-x": "2.0.0"
       }
     },
     "math-random": {
@@ -10220,8 +10282,8 @@
       "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
       "optional": true,
       "requires": {
-        "is-nan-x": "^1.0.1",
-        "to-number-x": "^2.0.0"
+        "is-nan-x": "1.0.1",
+        "to-number-x": "2.0.0"
       }
     },
     "mathml-tag-names": {
@@ -10240,8 +10302,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "mdast-util-compact": {
@@ -10249,8 +10311,8 @@
       "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
       "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
       "requires": {
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit": "^1.1.0"
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "mdn-data": {
@@ -10268,7 +10330,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memoizee": {
@@ -10276,14 +10338,14 @@
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.11.tgz",
       "integrity": "sha1-vemBdmPJ5A/bKk6hw2cpYIeujI8=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.30",
-        "es6-weak-map": "^2.0.2",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.1",
-        "lru-queue": "0.1",
-        "next-tick": "1",
-        "timers-ext": "^0.1.2"
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-weak-map": "2.0.2",
+        "event-emitter": "0.3.5",
+        "is-promise": "2.1.0",
+        "lru-queue": "0.1.0",
+        "next-tick": "1.0.0",
+        "timers-ext": "0.1.2"
       }
     },
     "memory-fs": {
@@ -10291,8 +10353,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.3"
       }
     },
     "meow": {
@@ -10300,15 +10362,15 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
       "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
       "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist": "^1.1.3",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0"
+        "camelcase-keys": "4.2.0",
+        "decamelize-keys": "1.1.0",
+        "loud-rejection": "1.6.0",
+        "minimist": "1.2.0",
+        "minimist-options": "3.0.2",
+        "normalize-package-data": "2.4.0",
+        "read-pkg-up": "3.0.0",
+        "redent": "2.0.0",
+        "trim-newlines": "2.0.0"
       }
     },
     "merge": {
@@ -10326,7 +10388,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.3"
       }
     },
     "merge2": {
@@ -10344,19 +10406,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
@@ -10364,8 +10426,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -10383,7 +10445,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -10396,8 +10458,8 @@
       "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.0.tgz",
       "integrity": "sha512-JvlvRLqGIlk+AYypWrbrDmhsM+6JVx/xBM5S3AMwTBz1trPCEoPN/swO2L4Wu653fL7oJdgk8DMQyG/Gq3JkZg==",
       "requires": {
-        "hoek": "5.x.x",
-        "mime-db": "1.x.x"
+        "hoek": "5.0.3",
+        "mime-db": "1.33.0"
       }
     },
     "min-document": {
@@ -10405,7 +10467,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.1"
       }
     },
     "minimalistic-assert": {
@@ -10423,12 +10485,12 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.9"
       }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -10436,8 +10498,8 @@
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "mixin-deep": {
@@ -10445,8 +10507,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -10454,14 +10516,14 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -10469,7 +10531,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -10484,8 +10546,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "requires": {
-        "dns-packet": "^1.3.1",
-        "thunky": "^1.0.2"
+        "dns-packet": "1.3.1",
+        "thunky": "1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -10498,10 +10560,10 @@
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "multipipe": {
@@ -10527,17 +10589,17 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
       "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^1.0.0",
-        "kind-of": "^5.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "is-odd": "1.0.0",
+        "kind-of": "5.1.0",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -10582,8 +10644,8 @@
       "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.1.tgz",
       "integrity": "sha512-kCVtUG9JyD//tsYrZY+/Y+2gUrANVSba8y23QkM5Znx0FOxlnl9Z4OVPBODmstKWTOvigfTO+Va1VPOu3eWSOQ==",
       "requires": {
-        "hoek": "5.x.x",
-        "vise": "3.x.x"
+        "hoek": "5.0.3",
+        "vise": "3.0.0"
       }
     },
     "node-fetch": {
@@ -10591,8 +10653,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-forge": {
@@ -10605,19 +10667,19 @@
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "2",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.5",
+        "request": "2.85.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "semver": {
@@ -10632,28 +10694,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.3",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.3",
+        "string_decoder": "1.0.3",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.4",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -10662,9 +10724,9 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
+            "base64-js": "1.3.0",
+            "ieee754": "1.1.12",
+            "isarray": "1.0.0"
           }
         },
         "process": {
@@ -10680,7 +10742,7 @@
       "integrity": "sha1-ijbGZ4ph5dhFX+xYAJsbAnGxkJo=",
       "requires": {
         "jpeg-js": "0.2.0",
-        "pngjs": "~2.2.0"
+        "pngjs": "2.2.0"
       },
       "dependencies": {
         "pngjs": {
@@ -10695,25 +10757,25 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
       "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
       "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
-        "node-gyp": "^3.3.1",
-        "npmlog": "^4.0.0",
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.3",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.1",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.10.0",
+        "node-gyp": "3.6.2",
+        "npmlog": "4.1.2",
         "request": "2.87.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
       },
       "dependencies": {
         "camelcase": {
@@ -10726,8 +10788,8 @@
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "cross-spawn": {
@@ -10735,8 +10797,8 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
           }
         },
         "find-up": {
@@ -10744,8 +10806,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "gaze": {
@@ -10753,7 +10815,7 @@
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
           "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
           "requires": {
-            "globule": "^1.0.0"
+            "globule": "1.2.1"
           }
         },
         "get-stdin": {
@@ -10766,9 +10828,9 @@
           "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
           "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
           "requires": {
-            "glob": "~7.1.1",
-            "lodash": "~4.17.10",
-            "minimatch": "~3.0.2"
+            "glob": "7.1.2",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4"
           }
         },
         "indent-string": {
@@ -10776,7 +10838,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "load-json-file": {
@@ -10784,11 +10846,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "lodash": {
@@ -10801,8 +10863,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "map-obj": {
@@ -10815,16 +10877,16 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "parse-json": {
@@ -10832,7 +10894,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -10840,7 +10902,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -10848,9 +10910,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -10863,9 +10925,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -10873,8 +10935,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "redent": {
@@ -10882,8 +10944,8 @@
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "request": {
@@ -10891,26 +10953,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.1",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           }
         },
         "strip-bom": {
@@ -10918,7 +10980,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -10926,7 +10988,7 @@
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -10946,7 +11008,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -10954,10 +11016,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -10965,7 +11027,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -10983,9 +11045,9 @@
       "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
       "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "trim-x": "^3.0.0",
-        "white-space-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "trim-x": "3.0.0",
+        "white-space-x": "3.0.0"
       }
     },
     "npm-run-path": {
@@ -10993,7 +11055,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -11001,10 +11063,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "nth-check": {
@@ -11013,7 +11075,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "optional": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "num2fraction": {
@@ -11046,9 +11108,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -11056,7 +11118,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -11064,7 +11126,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-data-descriptor": {
@@ -11072,7 +11134,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -11080,9 +11142,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -11100,16 +11162,16 @@
       "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
       "optional": true,
       "requires": {
-        "attempt-x": "^1.1.0",
-        "has-own-property-x": "^3.1.1",
-        "has-symbol-support-x": "^1.4.1",
-        "is-falsey-x": "^1.0.0",
-        "is-index-x": "^1.0.0",
-        "is-primitive": "^2.0.0",
-        "is-string": "^1.0.4",
-        "property-is-enumerable-x": "^1.1.0",
-        "to-object-x": "^1.4.1",
-        "to-property-key-x": "^2.0.1"
+        "attempt-x": "1.1.1",
+        "has-own-property-x": "3.2.0",
+        "has-symbol-support-x": "1.4.1",
+        "is-falsey-x": "1.0.1",
+        "is-index-x": "1.1.0",
+        "is-primitive": "2.0.0",
+        "is-string": "1.0.4",
+        "property-is-enumerable-x": "1.1.0",
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
       }
     },
     "object-hash": {
@@ -11127,7 +11189,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -11142,10 +11204,10 @@
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -11153,7 +11215,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -11169,8 +11231,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "optional": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "object.map": {
@@ -11178,8 +11240,8 @@
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.0"
       },
       "dependencies": {
         "for-own": {
@@ -11187,7 +11249,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -11197,8 +11259,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -11206,7 +11268,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -11222,10 +11284,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "optional": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
       }
     },
     "obuf": {
@@ -11251,12 +11313,12 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "openurl": {
@@ -11269,7 +11331,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optipng-bin": {
@@ -11278,9 +11340,9 @@
       "integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
       "optional": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "orchestrator": {
@@ -11288,9 +11350,9 @@
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.0"
       }
     },
     "ordered-read-streams": {
@@ -11303,7 +11365,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
       "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
       "requires": {
-        "url-parse": "~1.4.0"
+        "url-parse": "1.4.3"
       }
     },
     "os": {
@@ -11332,9 +11394,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "os-tmpdir": {
@@ -11347,8 +11409,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "p-finally": {
@@ -11361,7 +11423,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -11369,7 +11431,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
@@ -11397,10 +11459,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "got": {
@@ -11408,17 +11470,17 @@
           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "timed-out": {
@@ -11443,11 +11505,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-bmfont-ascii": {
@@ -11465,8 +11527,8 @@
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
       "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
       "requires": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
+        "xml-parse-from-string": "1.0.1",
+        "xml2js": "0.4.19"
       }
     },
     "parse-entities": {
@@ -11474,12 +11536,12 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities": "1.2.2",
+        "character-entities-legacy": "1.1.2",
+        "character-reference-invalid": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "parse-filepath": {
@@ -11487,9 +11549,9 @@
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -11497,10 +11559,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-headers": {
@@ -11508,7 +11570,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "^0.3.2",
+        "for-each": "0.3.3",
         "trim": "0.0.1"
       }
     },
@@ -11517,10 +11579,10 @@
       "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
       "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "nan-x": "^1.0.0",
-        "to-string-x": "^1.4.2",
-        "trim-left-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "nan-x": "1.0.0",
+        "to-string-x": "1.4.2",
+        "trim-left-x": "3.0.0"
       }
     },
     "parse-json": {
@@ -11528,8 +11590,8 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.1",
+        "json-parse-better-errors": "1.0.1"
       }
     },
     "parse-passwd": {
@@ -11542,7 +11604,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -11550,7 +11612,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -11568,14 +11630,14 @@
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-5.1.1.tgz",
       "integrity": "sha512-bO+vfFGgTVTtv89kXWGEMIPnrYhhhMtbOnJKStfIhNWUxperVjlI++1ixksi0YPCMPGuFy9W3zsKHxIITV2r2A==",
       "requires": {
-        "chalk": "^1.1.3",
-        "cross-spawn": "^5.1.0",
-        "fs-extra": "^4.0.1",
-        "minimist": "^1.2.0",
-        "rimraf": "^2.6.1",
-        "slash": "^1.0.0",
-        "tmp": "^0.0.31",
-        "update-notifier": "^2.2.0"
+        "chalk": "1.1.3",
+        "cross-spawn": "5.1.0",
+        "fs-extra": "4.0.3",
+        "minimist": "1.2.0",
+        "rimraf": "2.6.2",
+        "slash": "1.0.0",
+        "tmp": "0.0.31",
+        "update-notifier": "2.5.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -11583,9 +11645,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "jsonfile": {
@@ -11593,7 +11655,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -11643,7 +11705,7 @@
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -11661,7 +11723,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "pause-stream": {
@@ -11669,7 +11731,7 @@
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       }
     },
     "pbkdf2": {
@@ -11677,11 +11739,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.11"
       }
     },
     "pend": {
@@ -11699,11 +11761,11 @@
       "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.2.tgz",
       "integrity": "sha512-HuPxmGxHsEFPWhdkwBs2gIrHhFqktIxMtudISTFN95RQ85ZZAOl8Ki6u3nnN/X8OUaGlIGldk/l8p2IR4/i76w==",
       "requires": {
-        "b64": "4.x.x",
-        "boom": "7.x.x",
-        "content": "4.x.x",
-        "hoek": "5.x.x",
-        "nigel": "3.x.x"
+        "b64": "4.0.0",
+        "boom": "7.2.0",
+        "content": "4.0.5",
+        "hoek": "5.0.3",
+        "nigel": "3.0.1"
       },
       "dependencies": {
         "boom": {
@@ -11711,7 +11773,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -11721,15 +11783,15 @@
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
+        "es6-promise": "4.2.4",
+        "extract-zip": "1.6.7",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.85.0",
+        "request-progress": "2.0.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -11742,9 +11804,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1"
           }
         }
       }
@@ -11764,7 +11826,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pixelmatch": {
@@ -11772,7 +11834,7 @@
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "requires": {
-        "pngjs": "^3.0.0"
+        "pngjs": "3.3.3"
       }
     },
     "pkg-dir": {
@@ -11780,7 +11842,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       }
     },
     "plugin-error": {
@@ -11788,11 +11850,11 @@
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "requires": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -11800,8 +11862,8 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -11819,7 +11881,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -11834,8 +11896,8 @@
       "resolved": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
       "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
       "requires": {
-        "chalk": "^1.1.1",
-        "dateformat": "^1.0.11"
+        "chalk": "1.1.3",
+        "dateformat": "1.0.11"
       }
     },
     "plur": {
@@ -11843,7 +11905,7 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pngjs": {
@@ -11856,8 +11918,8 @@
       "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.2.tgz",
       "integrity": "sha512-18VrjJAduIdPv7d9zWsfmKxTj3cQTYC5Pv5gtKxcWujYBpGbV+mhNSPYhlHW5xeWoazYyKfB9FEsPT12r5rY1A==",
       "requires": {
-        "hoek": "5.x.x",
-        "joi": "13.x.x"
+        "hoek": "5.0.3",
+        "joi": "13.3.0"
       }
     },
     "portfinder": {
@@ -11865,9 +11927,9 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "requires": {
-        "async": "^1.5.2",
-        "debug": "^2.2.0",
-        "mkdirp": "0.5.x"
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "async": {
@@ -11883,7 +11945,7 @@
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
       "requires": {
         "async": "1.5.2",
-        "is-number-like": "^1.0.3"
+        "is-number-like": "1.0.8"
       },
       "dependencies": {
         "async": {
@@ -11903,9 +11965,9 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
       "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
       "requires": {
-        "chalk": "^2.3.0",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.1.0"
+        "chalk": "2.3.0",
+        "source-map": "0.6.1",
+        "supports-color": "5.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11913,7 +11975,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -11921,9 +11983,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11931,7 +11993,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
               "requires": {
-                "has-flag": "^2.0.0"
+                "has-flag": "2.0.0"
               }
             }
           }
@@ -11946,7 +12008,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -11956,7 +12018,7 @@
       "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.28.0.tgz",
       "integrity": "sha512-H+ucbGVR+lsZySspOApeQU9yC6Q3t75lwJYa3Im93fKAUt5DScKOSErShC0aC7USdn2jsT1LxubcC5vYu/VJYw==",
       "requires": {
-        "htmlparser2": "^3.9.2"
+        "htmlparser2": "3.9.2"
       }
     },
     "postcss-less": {
@@ -11964,7 +12026,7 @@
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-2.0.0.tgz",
       "integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
       "requires": {
-        "postcss": "^5.2.16"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "has-flag": {
@@ -11977,10 +12039,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -11988,7 +12050,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -11998,10 +12060,10 @@
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "requires": {
-        "cosmiconfig": "^2.1.0",
-        "object-assign": "^4.1.0",
-        "postcss-load-options": "^1.2.0",
-        "postcss-load-plugins": "^2.3.0"
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1",
+        "postcss-load-options": "1.2.0",
+        "postcss-load-plugins": "2.3.0"
       }
     },
     "postcss-load-options": {
@@ -12009,8 +12071,8 @@
       "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "requires": {
-        "cosmiconfig": "^2.1.0",
-        "object-assign": "^4.1.0"
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
       }
     },
     "postcss-load-plugins": {
@@ -12018,8 +12080,8 @@
       "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "requires": {
-        "cosmiconfig": "^2.1.1",
-        "object-assign": "^4.1.0"
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
       }
     },
     "postcss-markdown": {
@@ -12027,8 +12089,8 @@
       "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.28.0.tgz",
       "integrity": "sha512-F0Vc8eHKDKTmensntXpd35LSAoXXtykhPY+IRfn4AnN4m+irav3QawmtSWLhsmbElKna8l1/HObYnbiM/Wok9Q==",
       "requires": {
-        "remark": "^9.0.0",
-        "unist-util-find-all-after": "^1.0.2"
+        "remark": "9.0.0",
+        "unist-util-find-all-after": "1.0.2"
       }
     },
     "postcss-media-query-parser": {
@@ -12041,10 +12103,10 @@
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
       "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
       "requires": {
-        "chalk": "^2.0.1",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "postcss": "^6.0.8"
+        "chalk": "2.3.0",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12052,7 +12114,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -12060,9 +12122,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "log-symbols": {
@@ -12070,7 +12132,7 @@
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "requires": {
-            "chalk": "^2.0.1"
+            "chalk": "2.3.0"
           }
         },
         "supports-color": {
@@ -12078,7 +12140,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -12093,7 +12155,7 @@
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
       "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "requires": {
-        "postcss": "^6.0.6"
+        "postcss": "6.0.17"
       }
     },
     "postcss-sass": {
@@ -12110,7 +12172,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -12118,9 +12180,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -12133,9 +12195,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -12148,7 +12210,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12158,7 +12220,7 @@
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.5.tgz",
       "integrity": "sha512-gJB1tKYMkBy0MU+COt6WXA4ZiRctAKoWLa6qD7a6bbEbBMqrpa/BhfQdN80eYMV+JkKddZVEpZlOggnGShpvyg==",
       "requires": {
-        "postcss": "^6.0.21"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12166,7 +12228,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -12174,9 +12236,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -12189,9 +12251,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -12204,7 +12266,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12214,9 +12276,9 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
       "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
       "requires": {
-        "dot-prop": "^4.1.1",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "dot-prop": "4.2.0",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-syntax": {
@@ -12269,7 +12331,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
       "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "prop-types": {
@@ -12277,8 +12339,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "property-is-enumerable-x": {
@@ -12287,8 +12349,8 @@
       "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
       "optional": true,
       "requires": {
-        "to-object-x": "^1.4.1",
-        "to-property-key-x": "^2.0.1"
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
       }
     },
     "proxy-addr": {
@@ -12296,7 +12358,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -12320,11 +12382,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.1",
+        "randombytes": "2.0.6"
       }
     },
     "punycode": {
@@ -12337,14 +12399,14 @@
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.6.1.tgz",
       "integrity": "sha512-qz6DLwK+PhlBMjJZOMOsgVCnweYLtmiqnmJYUDPT++ElMz+cQgbsCNKPw4YDVpg3RTbsRX/pqQqr20zrp0cuKw==",
       "requires": {
-        "debug": "^3.1.0",
-        "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^2.2.1",
-        "mime": "^2.0.3",
-        "progress": "^2.0.0",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^5.1.1"
+        "debug": "3.1.0",
+        "extract-zip": "1.6.7",
+        "https-proxy-agent": "2.2.1",
+        "mime": "2.3.1",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "5.2.2"
       },
       "dependencies": {
         "debug": {
@@ -12370,7 +12432,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "requires": {
-            "async-limiter": "~1.0.0"
+            "async-limiter": "1.0.0"
           }
         }
       }
@@ -12410,7 +12472,7 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
       "requires": {
-        "performance-now": "^2.1.0"
+        "performance-now": "2.1.0"
       }
     },
     "randomatic": {
@@ -12418,9 +12480,9 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -12440,7 +12502,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "randomfill": {
@@ -12448,8 +12510,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "range-parser": {
@@ -12481,7 +12543,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.4.0"
           }
         },
         "iconv-lite": {
@@ -12501,10 +12563,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "deep-extend": {
@@ -12519,11 +12581,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "create-react-class": "15.6.3",
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-lifecycles-compat": {
@@ -12536,10 +12598,10 @@
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
       "integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
       "requires": {
-        "exenv": "^1.2.0",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^3.0.0"
+        "exenv": "1.2.2",
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4",
+        "warning": "3.0.0"
       }
     },
     "react-motion": {
@@ -12547,9 +12609,9 @@
       "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
       "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
       "requires": {
-        "performance-now": "^0.2.0",
-        "prop-types": "^15.5.8",
-        "raf": "^3.1.0"
+        "performance-now": "0.2.0",
+        "prop-types": "15.6.2",
+        "raf": "3.4.0"
       },
       "dependencies": {
         "performance-now": {
@@ -12564,12 +12626,12 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
       "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
       "requires": {
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.0.0",
-        "lodash": "^4.17.5",
-        "lodash-es": "^4.17.5",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.0"
+        "hoist-non-react-statics": "2.5.5",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.10",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2"
       }
     },
     "react-sticky": {
@@ -12577,8 +12639,8 @@
       "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.3.tgz",
       "integrity": "sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==",
       "requires": {
-        "prop-types": "^15.5.8",
-        "raf": "^3.3.0"
+        "prop-types": "15.6.2",
+        "raf": "3.4.0"
       }
     },
     "react-toggle-button": {
@@ -12586,8 +12648,8 @@
       "resolved": "https://registry.npmjs.org/react-toggle-button/-/react-toggle-button-2.2.0.tgz",
       "integrity": "sha1-obkhQ6oN9BRkL8sUHwh59UW8Wok=",
       "requires": {
-        "prop-types": "^15.6.0",
-        "react-motion": "^0.5.2"
+        "prop-types": "15.6.2",
+        "react-motion": "0.5.2"
       }
     },
     "read-all-stream": {
@@ -12595,8 +12657,8 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.3"
       }
     },
     "read-chunk": {
@@ -12609,9 +12671,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
@@ -12619,8 +12681,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
       "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "3.0.0"
       }
     },
     "readable-stream": {
@@ -12628,13 +12690,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -12642,10 +12704,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "rechoir": {
@@ -12653,7 +12715,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.5.0"
       }
     },
     "redent": {
@@ -12661,8 +12723,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "requires": {
-        "indent-string": "^3.0.0",
-        "strip-indent": "^2.0.0"
+        "indent-string": "3.2.0",
+        "strip-indent": "2.0.0"
       }
     },
     "redux": {
@@ -12670,10 +12732,10 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.10",
+        "loose-envify": "1.4.0",
+        "symbol-observable": "1.2.0"
       }
     },
     "regenerator-runtime": {
@@ -12686,7 +12748,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -12694,7 +12756,7 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
       "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       }
     },
     "registry-auth-token": {
@@ -12702,8 +12764,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.1"
       }
     },
     "registry-url": {
@@ -12711,7 +12773,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "remark": {
@@ -12719,9 +12781,9 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
       "integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
       "requires": {
-        "remark-parse": "^5.0.0",
-        "remark-stringify": "^5.0.0",
-        "unified": "^6.0.0"
+        "remark-parse": "5.0.0",
+        "remark-stringify": "5.0.0",
+        "unified": "6.2.0"
       }
     },
     "remark-parse": {
@@ -12729,21 +12791,21 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
       "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
       "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
+        "collapse-white-space": "1.0.4",
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "is-word-character": "1.0.2",
+        "markdown-escapes": "1.0.2",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
         "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
+        "trim-trailing-lines": "1.1.1",
+        "unherit": "1.1.1",
+        "unist-util-remove-position": "1.1.2",
+        "vfile-location": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "remark-stringify": {
@@ -12751,20 +12813,20 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
       "integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
       "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "longest-streak": "2.0.2",
+        "markdown-escapes": "1.0.2",
+        "markdown-table": "1.1.2",
+        "mdast-util-compact": "1.0.1",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
+        "stringify-entities": "1.3.2",
+        "unherit": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -12787,7 +12849,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-comments-x": {
@@ -12795,8 +12857,8 @@
       "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
       "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
       "requires": {
-        "require-coercible-to-string-x": "^1.0.0",
-        "to-string-x": "^1.4.2"
+        "require-coercible-to-string-x": "1.0.0",
+        "to-string-x": "1.4.2"
       }
     },
     "replace-ext": {
@@ -12809,28 +12871,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.6",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "request-progress": {
@@ -12838,7 +12900,7 @@
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "requires": {
-        "throttleit": "^1.0.0"
+        "throttleit": "1.0.0"
       }
     },
     "require-coercible-to-string-x": {
@@ -12846,8 +12908,8 @@
       "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
       "integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
       "requires": {
-        "require-object-coercible-x": "^1.4.1",
-        "to-string-x": "^1.4.2"
+        "require-object-coercible-x": "1.4.1",
+        "to-string-x": "1.4.2"
       }
     },
     "require-dir": {
@@ -12875,7 +12937,7 @@
       "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
       "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
       "requires": {
-        "is-nil-x": "^1.4.1"
+        "is-nil-x": "1.4.1"
       }
     },
     "requires-port": {
@@ -12888,7 +12950,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -12896,7 +12958,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -12904,8 +12966,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -12923,8 +12985,8 @@
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "requires": {
-        "debug": "^2.2.0",
-        "minimatch": "^3.0.2"
+        "debug": "2.6.9",
+        "minimatch": "3.0.4"
       }
     },
     "ret": {
@@ -12937,7 +12999,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -12945,7 +13007,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -12953,8 +13015,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "run-sequence": {
@@ -12963,9 +13025,9 @@
       "integrity": "sha512-qkzZnQWMZjcKbh3CNly2srtrkaO/2H/SI5f2eliMCapdRD3UhMrwjfOAZJAnZ2H8Ju4aBzFZkBGXUqFs9V0yxw==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^0.1.2"
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2"
       }
     },
     "rx": {
@@ -12983,7 +13045,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -13001,7 +13063,7 @@
       "resolved": "https://registry.npmjs.org/sass-breakpoints/-/sass-breakpoints-1.0.0.tgz",
       "integrity": "sha1-LNOUbr86an+WG5XobuWiJHGgopk=",
       "requires": {
-        "sass-ems": "^1.0.3"
+        "sass-ems": "1.0.3"
       }
     },
     "sass-ems": {
@@ -13014,10 +13076,10 @@
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -13030,9 +13092,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "find-up": {
@@ -13040,8 +13102,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "load-json-file": {
@@ -13049,11 +13111,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "os-locale": {
@@ -13061,7 +13123,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "parse-json": {
@@ -13069,7 +13131,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -13077,7 +13139,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -13085,9 +13147,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -13100,9 +13162,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -13110,8 +13172,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "string-width": {
@@ -13119,9 +13181,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -13129,7 +13191,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "which-module": {
@@ -13142,19 +13204,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         },
         "yargs-parser": {
@@ -13162,7 +13224,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -13172,7 +13234,7 @@
       "resolved": "https://registry.npmjs.org/sass-grid/-/sass-grid-3.0.0.tgz",
       "integrity": "sha1-iFXIcPcgyaTIR2oxbbxx+as4WQE=",
       "requires": {
-        "sass-breakpoints": "^1.0.0"
+        "sass-breakpoints": "1.0.0"
       }
     },
     "sax": {
@@ -13185,8 +13247,8 @@
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
+        "js-base64": "2.4.3",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "source-map": {
@@ -13194,7 +13256,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -13204,7 +13266,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
-        "commander": "~2.8.1"
+        "commander": "2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -13212,7 +13274,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -13240,7 +13302,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "semver-regex": {
@@ -13255,7 +13317,7 @@
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "optional": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -13264,18 +13326,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -13295,13 +13357,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
       }
     },
     "serve-static": {
@@ -13309,9 +13371,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -13330,7 +13392,7 @@
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "requires": {
-        "to-object-path": "^0.3.0"
+        "to-object-path": "0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -13343,10 +13405,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       }
     },
     "setimmediate": {
@@ -13364,8 +13426,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "shebang-command": {
@@ -13373,7 +13435,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -13386,8 +13448,8 @@
       "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.5.tgz",
       "integrity": "sha1-x+dFXRHWD2ts08Q+FaO0McF+VWY=",
       "requires": {
-        "hoek": "5.x.x",
-        "joi": "13.x.x"
+        "hoek": "5.0.3",
+        "joi": "13.3.0"
       }
     },
     "sigmund": {
@@ -13408,7 +13470,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "util": "0.10.4"
       }
     },
     "slash": {
@@ -13421,7 +13483,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -13436,14 +13498,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^2.0.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -13451,7 +13513,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -13459,7 +13521,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13467,7 +13529,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13477,7 +13539,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13485,7 +13547,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13495,9 +13557,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -13512,9 +13574,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -13529,7 +13591,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -13537,7 +13599,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       },
       "dependencies": {
         "hoek": {
@@ -13552,12 +13614,12 @@
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -13575,14 +13637,14 @@
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
-            "debug": "~3.1.0",
-            "engine.io-parser": "~2.1.1",
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "ws": "~3.3.1",
-            "xmlhttprequest-ssl": "~1.5.4",
+            "ws": "3.3.3",
+            "xmlhttprequest-ssl": "1.5.5",
             "yeast": "0.1.2"
           }
         },
@@ -13600,15 +13662,15 @@
             "base64-arraybuffer": "0.1.5",
             "component-bind": "1.0.0",
             "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
-            "engine.io-client": "~3.2.0",
-            "has-binary2": "~1.0.2",
+            "debug": "3.1.0",
+            "engine.io-client": "3.2.1",
+            "has-binary2": "1.0.3",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "socket.io-parser": "~3.2.0",
+            "socket.io-parser": "3.2.0",
             "to-array": "0.1.4"
           }
         },
@@ -13618,7 +13680,7 @@
           "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
           "requires": {
             "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
+            "debug": "3.1.0",
             "isarray": "2.0.1"
           }
         }
@@ -13638,14 +13700,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.6",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
+        "socket.io-parser": "3.1.3",
         "to-array": "0.1.4"
       }
     },
@@ -13655,8 +13717,8 @@
       "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "has-binary2": "1.0.3",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -13680,8 +13742,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.2.1"
       }
     },
     "sockjs-client": {
@@ -13689,12 +13751,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.9",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.4.3"
       },
       "dependencies": {
         "faye-websocket": {
@@ -13702,7 +13764,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         }
       }
@@ -13722,11 +13784,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -13744,7 +13806,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -13762,12 +13824,12 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
-        "debug": "^2.6.8",
-        "handle-thing": "^1.2.5",
-        "http-deceiver": "^1.2.7",
-        "safe-buffer": "^5.0.1",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^2.0.18"
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.1.0"
       }
     },
     "spdy-transport": {
@@ -13775,13 +13837,13 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
       "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "requires": {
-        "debug": "^2.6.8",
-        "detect-node": "^2.0.3",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.1",
-        "readable-stream": "^2.2.9",
-        "safe-buffer": "^5.0.1",
-        "wbuf": "^1.7.2"
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.3"
       }
     },
     "specificity": {
@@ -13794,7 +13856,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-string": {
@@ -13802,7 +13864,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -13810,8 +13872,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -13819,7 +13881,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -13835,9 +13897,9 @@
       "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
       "optional": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "console-stream": "^0.1.1",
-        "lpad-align": "^1.0.1"
+        "chalk": "1.1.3",
+        "console-stream": "0.1.1",
+        "lpad-align": "1.1.2"
       }
     },
     "sshpk": {
@@ -13845,14 +13907,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stable": {
@@ -13876,12 +13938,12 @@
       "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.6.tgz",
       "integrity": "sha512-jR45n5ZMAkasw0xoE9j9TuLmJv4Sa3AkXe+6yIFT6a07kXYHgSbuD2OVGECdZGFxTmvNqLwL1iRIgvq6O6rq+A==",
       "requires": {
-        "boom": "7.x.x",
-        "bounce": "1.x.x",
-        "cryptiles": "4.x.x",
-        "hoek": "5.x.x",
-        "iron": "5.x.x",
-        "joi": "13.x.x"
+        "boom": "7.2.0",
+        "bounce": "1.2.0",
+        "cryptiles": "4.1.1",
+        "hoek": "5.0.3",
+        "iron": "5.0.4",
+        "joi": "13.3.0"
       },
       "dependencies": {
         "boom": {
@@ -13889,7 +13951,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         },
         "cryptiles": {
@@ -13897,7 +13959,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
           "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
           "requires": {
-            "boom": "7.x.x"
+            "boom": "7.2.0"
           }
         }
       }
@@ -13907,8 +13969,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13916,7 +13978,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -13924,7 +13986,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13932,7 +13994,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13942,7 +14004,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13950,7 +14012,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13960,9 +14022,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -13982,7 +14044,7 @@
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.3"
       }
     },
     "stream-browserify": {
@@ -13990,8 +14052,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       }
     },
     "stream-combiner": {
@@ -13999,7 +14061,7 @@
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "stream-combiner2": {
@@ -14007,8 +14069,8 @@
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "requires": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "duplexer2": {
@@ -14016,7 +14078,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.3"
           }
         }
       }
@@ -14031,11 +14093,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -14048,13 +14110,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -14062,7 +14124,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -14077,8 +14139,8 @@
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "requires": {
-        "commander": "^2.2.0",
-        "limiter": "^1.0.5"
+        "commander": "2.11.0",
+        "limiter": "1.1.3"
       }
     },
     "stream-to": {
@@ -14091,7 +14153,7 @@
       "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
       "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
       "requires": {
-        "stream-to": "~0.2.0"
+        "stream-to": "0.2.2"
       }
     },
     "streamfilter": {
@@ -14099,7 +14161,7 @@
       "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
       "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.3"
       }
     },
     "string-width": {
@@ -14107,8 +14169,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14126,7 +14188,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -14136,7 +14198,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {
@@ -14144,10 +14206,10 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities-html4": "1.1.2",
+        "character-entities-legacy": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "stringstream": {
@@ -14160,7 +14222,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -14173,7 +14235,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
       "requires": {
-        "is-utf8": "^0.2.1"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -14181,8 +14243,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -14190,7 +14252,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -14205,12 +14267,12 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "requires": {
-        "chalk": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "is-absolute": "^0.1.5",
-        "is-natural-number": "^2.0.0",
-        "minimist": "^1.1.0",
-        "sum-up": "^1.0.1"
+        "chalk": "1.1.3",
+        "get-stdin": "4.0.1",
+        "is-absolute": "0.1.7",
+        "is-natural-number": "2.1.1",
+        "minimist": "1.2.0",
+        "sum-up": "1.0.3"
       },
       "dependencies": {
         "get-stdin": {
@@ -14223,7 +14285,7 @@
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
           "requires": {
-            "is-relative": "^0.1.0"
+            "is-relative": "0.1.3"
           }
         },
         "is-relative": {
@@ -14253,7 +14315,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
       "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "style-search": {
@@ -14266,14 +14328,14 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.4.1.tgz",
       "integrity": "sha1-ZjvQSF1LarRvlGIQ3APSOY0a3nQ=",
       "requires": {
-        "buffer": "^5.0.3",
-        "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.9",
-        "hoist-non-react-statics": "^1.2.0",
-        "is-plain-object": "^2.0.1",
-        "prop-types": "^15.5.4",
-        "stylis": "^3.4.0",
-        "supports-color": "^3.2.3"
+        "buffer": "5.2.0",
+        "css-to-react-native": "2.2.1",
+        "fbjs": "0.8.17",
+        "hoist-non-react-statics": "1.2.0",
+        "is-plain-object": "2.0.4",
+        "prop-types": "15.6.2",
+        "stylis": "3.5.3",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -14291,7 +14353,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -14301,49 +14363,49 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.3.0.tgz",
       "integrity": "sha512-u59pWTlrdwjqriJtTvO1a0wRK1mfbQQp7jLt27SX4zl2HmtVHOM/I1wd43xHTvUJZDKp1PTOpqRAamU3gFvmOA==",
       "requires": {
-        "autoprefixer": "^8.0.0",
-        "balanced-match": "^1.0.0",
-        "chalk": "^2.4.1",
-        "cosmiconfig": "^5.0.0",
-        "debug": "^3.0.0",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^2.0.0",
-        "get-stdin": "^6.0.0",
-        "globby": "^8.0.0",
-        "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^3.3.3",
-        "import-lazy": "^3.1.0",
-        "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.6.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "mathml-tag-names": "^2.0.1",
-        "meow": "^5.0.0",
-        "micromatch": "^2.3.11",
-        "normalize-selector": "^0.2.0",
-        "pify": "^3.0.0",
-        "postcss": "^6.0.16",
-        "postcss-html": "^0.28.0",
-        "postcss-less": "^2.0.0",
-        "postcss-markdown": "^0.28.0",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^5.0.0",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^3.0.1",
-        "postcss-sass": "^0.3.0",
-        "postcss-scss": "^1.0.2",
-        "postcss-selector-parser": "^3.1.0",
-        "postcss-syntax": "^0.28.0",
-        "postcss-value-parser": "^3.3.0",
-        "resolve-from": "^4.0.0",
-        "signal-exit": "^3.0.2",
-        "specificity": "^0.3.1",
-        "string-width": "^2.1.0",
-        "style-search": "^0.1.0",
-        "sugarss": "^1.0.0",
-        "svg-tags": "^1.0.0",
-        "table": "^4.0.1"
+        "autoprefixer": "8.5.0",
+        "balanced-match": "1.0.0",
+        "chalk": "2.4.1",
+        "cosmiconfig": "5.0.5",
+        "debug": "3.1.0",
+        "execall": "1.0.0",
+        "file-entry-cache": "2.0.0",
+        "get-stdin": "6.0.0",
+        "globby": "8.0.1",
+        "globjoin": "0.1.4",
+        "html-tags": "2.0.0",
+        "ignore": "3.3.10",
+        "import-lazy": "3.1.0",
+        "imurmurhash": "0.1.4",
+        "known-css-properties": "0.6.1",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "mathml-tag-names": "2.1.0",
+        "meow": "5.0.0",
+        "micromatch": "2.3.11",
+        "normalize-selector": "0.2.0",
+        "pify": "3.0.0",
+        "postcss": "6.0.17",
+        "postcss-html": "0.28.0",
+        "postcss-less": "2.0.0",
+        "postcss-markdown": "0.28.0",
+        "postcss-media-query-parser": "0.2.3",
+        "postcss-reporter": "5.0.0",
+        "postcss-resolve-nested-selector": "0.1.1",
+        "postcss-safe-parser": "3.0.1",
+        "postcss-sass": "0.3.2",
+        "postcss-scss": "1.0.5",
+        "postcss-selector-parser": "3.1.1",
+        "postcss-syntax": "0.28.0",
+        "postcss-value-parser": "3.3.0",
+        "resolve-from": "4.0.0",
+        "signal-exit": "3.0.2",
+        "specificity": "0.3.2",
+        "string-width": "2.1.1",
+        "style-search": "0.1.0",
+        "sugarss": "1.0.1",
+        "svg-tags": "1.0.0",
+        "table": "4.0.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14351,7 +14413,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14359,9 +14421,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "cosmiconfig": {
@@ -14369,9 +14431,9 @@
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
           "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.10.0",
+            "parse-json": "4.0.0"
           }
         },
         "debug": {
@@ -14392,13 +14454,13 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "fast-glob": "^2.0.2",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "fast-glob": "2.2.2",
+            "glob": "7.1.2",
+            "ignore": "3.3.10",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           }
         },
         "has-flag": {
@@ -14416,7 +14478,7 @@
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "requires": {
-            "chalk": "^2.0.1"
+            "chalk": "2.4.1"
           }
         },
         "meow": {
@@ -14424,15 +14486,15 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
           "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0",
-            "yargs-parser": "^10.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0",
+            "yargs-parser": "10.0.0"
           }
         },
         "resolve-from": {
@@ -14445,7 +14507,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "yargs-parser": {
@@ -14453,7 +14515,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
           "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -14468,11 +14530,11 @@
       "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.7.tgz",
       "integrity": "sha512-IcJUvRjeR+NB437Iq+LORFNJW4L6Knqkj3oQrBrkdhIaS2VKJvx/9aYEq7vi+PEx5/OuehOL/40SkSZotLi/MA==",
       "requires": {
-        "boom": "7.x.x",
-        "content": "4.x.x",
-        "hoek": "5.x.x",
-        "pez": "4.x.x",
-        "wreck": "14.x.x"
+        "boom": "7.2.0",
+        "content": "4.0.5",
+        "hoek": "5.0.3",
+        "pez": "4.0.2",
+        "wreck": "14.0.2"
       },
       "dependencies": {
         "boom": {
@@ -14480,7 +14542,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -14490,7 +14552,7 @@
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
       "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
       "requires": {
-        "postcss": "^6.0.14"
+        "postcss": "6.0.17"
       }
     },
     "sum-up": {
@@ -14498,7 +14560,7 @@
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "supports-color": {
@@ -14517,20 +14579,20 @@
       "integrity": "sha512-DR9ieoaBoeySY4pnIJMM3Hez6kcVj+Uzj8AUJkr3435qstozP9i+mZ9yzcbq64A44i9YKh3I1Laex+mAyc69Rg==",
       "optional": true,
       "requires": {
-        "coa": "~2.0.1",
-        "colors": "~1.1.2",
-        "css-select": "~1.3.0-rc0",
-        "css-select-base-adapter": "~0.1.0",
+        "coa": "2.0.1",
+        "colors": "1.1.2",
+        "css-select": "1.3.0-rc0",
+        "css-select-base-adapter": "0.1.0",
         "css-tree": "1.0.0-alpha25",
-        "css-url-regex": "^1.1.0",
-        "csso": "^3.5.0",
-        "js-yaml": "~3.10.0",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.0.4",
-        "sax": "~1.2.4",
-        "stable": "~0.1.6",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
+        "css-url-regex": "1.1.0",
+        "csso": "3.5.0",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "object.values": "1.0.4",
+        "sax": "1.2.4",
+        "stable": "0.1.6",
+        "unquote": "1.1.1",
+        "util.promisify": "1.0.0"
       }
     },
     "symbol-observable": {
@@ -14543,12 +14605,12 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "6.5.0",
+        "ajv-keywords": "3.2.0",
+        "chalk": "2.4.1",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14556,7 +14618,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14564,9 +14626,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -14579,7 +14641,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14594,9 +14656,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
       }
     },
     "tar-stream": {
@@ -14604,10 +14666,10 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "^1.0.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "end-of-stream": {
@@ -14615,7 +14677,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         }
       }
@@ -14630,8 +14692,8 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "rimraf": {
@@ -14652,8 +14714,8 @@
       "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-0.1.1.tgz",
       "integrity": "sha1-C2Rng43Xf79/YqDJPah5cy/9qTI=",
       "requires": {
-        "graceful-fs": "~2.0.0",
-        "tempfile": "~0.1.2"
+        "graceful-fs": "2.0.3",
+        "tempfile": "0.1.3"
       },
       "dependencies": {
         "graceful-fs": {
@@ -14668,7 +14730,7 @@
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
       "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
       "requires": {
-        "uuid": "~1.4.0"
+        "uuid": "1.4.2"
       },
       "dependencies": {
         "uuid": {
@@ -14683,7 +14745,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "ternary-stream": {
@@ -14691,10 +14753,10 @@
       "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "requires": {
-        "duplexify": "^3.5.0",
-        "fork-stream": "^0.0.4",
-        "merge-stream": "^1.0.0",
-        "through2": "^2.0.1"
+        "duplexify": "3.5.3",
+        "fork-stream": "0.0.4",
+        "merge-stream": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "tfunk": {
@@ -14702,8 +14764,8 @@
       "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "requires": {
-        "chalk": "^1.1.1",
-        "object-path": "^0.9.0"
+        "chalk": "1.1.3",
+        "object-path": "0.9.2"
       }
     },
     "throttleit": {
@@ -14721,8 +14783,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       }
     },
     "through2-concurrent": {
@@ -14730,7 +14792,7 @@
       "resolved": "https://registry.npmjs.org/through2-concurrent/-/through2-concurrent-1.1.1.tgz",
       "integrity": "sha1-EctOpMnjG8puTB5tukjRxyjDUks=",
       "requires": {
-        "through2": "^2.0.0"
+        "through2": "2.0.3"
       }
     },
     "through2-filter": {
@@ -14738,8 +14800,8 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "thunky": {
@@ -14752,7 +14814,7 @@
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -14770,7 +14832,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "timers-ext": {
@@ -14778,8 +14840,8 @@
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "requires": {
-        "es5-ext": "~0.10.14",
-        "next-tick": "1"
+        "es5-ext": "0.10.38",
+        "next-tick": "1.0.0"
       }
     },
     "tinycolor2": {
@@ -14792,7 +14854,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -14800,7 +14862,7 @@
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       }
     },
     "to-array": {
@@ -14824,10 +14886,10 @@
       "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
       "optional": true,
       "requires": {
-        "is-finite-x": "^3.0.2",
-        "is-nan-x": "^1.0.1",
-        "math-sign-x": "^3.0.0",
-        "to-number-x": "^2.0.0"
+        "is-finite-x": "3.0.2",
+        "is-nan-x": "1.0.1",
+        "math-sign-x": "3.0.0",
+        "to-number-x": "2.0.0"
       }
     },
     "to-number-x": {
@@ -14835,11 +14897,11 @@
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
       "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "nan-x": "^1.0.0",
-        "parse-int-x": "^2.0.0",
-        "to-primitive-x": "^1.1.0",
-        "trim-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "nan-x": "1.0.0",
+        "parse-int-x": "2.0.0",
+        "to-primitive-x": "1.1.0",
+        "trim-x": "3.0.0"
       }
     },
     "to-object-path": {
@@ -14847,7 +14909,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-object-x": {
@@ -14855,8 +14917,8 @@
       "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
       "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-object-coercible-x": "^1.4.1"
+        "cached-constructors-x": "1.0.0",
+        "require-object-coercible-x": "1.4.1"
       }
     },
     "to-primitive-x": {
@@ -14864,14 +14926,14 @@
       "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
       "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
       "requires": {
-        "has-symbol-support-x": "^1.4.1",
-        "is-date-object": "^1.0.1",
-        "is-function-x": "^3.2.0",
-        "is-nil-x": "^1.4.1",
-        "is-primitive": "^2.0.0",
-        "is-symbol": "^1.0.1",
-        "require-object-coercible-x": "^1.4.1",
-        "validate.io-undefined": "^1.0.3"
+        "has-symbol-support-x": "1.4.1",
+        "is-date-object": "1.0.1",
+        "is-function-x": "3.3.0",
+        "is-nil-x": "1.4.1",
+        "is-primitive": "2.0.0",
+        "is-symbol": "1.0.1",
+        "require-object-coercible-x": "1.4.1",
+        "validate.io-undefined": "1.0.3"
       }
     },
     "to-property-key-x": {
@@ -14879,9 +14941,9 @@
       "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
       "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
       "requires": {
-        "has-symbol-support-x": "^1.4.1",
-        "to-primitive-x": "^1.1.0",
-        "to-string-x": "^1.4.2"
+        "has-symbol-support-x": "1.4.1",
+        "to-primitive-x": "1.1.0",
+        "to-string-x": "1.4.2"
       }
     },
     "to-regex": {
@@ -14889,9 +14951,9 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
       "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
       "requires": {
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "regex-not": "^1.0.0"
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "regex-not": "1.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -14899,7 +14961,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -14907,7 +14969,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14915,7 +14977,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -14925,7 +14987,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14933,7 +14995,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -14943,9 +15005,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -14960,8 +15022,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -14969,7 +15031,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -14980,9 +15042,9 @@
       "integrity": "sha512-HbVH673pybrUmhzESGHUm17BBJvqb7BU8HciOvuEYm9ipuDyjmddhvkVqpVW6sM/C5/zhJo17n7O7I/24loJIQ==",
       "optional": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "has-symbol-support-x": "^1.4.1",
-        "is-symbol": "^1.0.1"
+        "cached-constructors-x": "1.0.0",
+        "has-symbol-support-x": "1.4.1",
+        "is-symbol": "1.0.1"
       }
     },
     "to-string-tag-x": {
@@ -14990,8 +15052,8 @@
       "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
       "integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
       "requires": {
-        "lodash.isnull": "^3.0.0",
-        "validate.io-undefined": "^1.0.3"
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
       }
     },
     "to-string-x": {
@@ -14999,7 +15061,7 @@
       "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.2.tgz",
       "integrity": "sha512-/WP5arlwtCpAAexCCHiQBW0eXwse84osWyP1Qtaz71nsYSuUpOkT6tBm8nQ4IIUfSh5hji0hDupUCD2xbbOL6A==",
       "requires": {
-        "is-symbol": "^1.0.1"
+        "is-symbol": "1.0.1"
       }
     },
     "topo": {
@@ -15007,7 +15069,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
       "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "5.0.3"
       }
     },
     "tough-cookie": {
@@ -15015,7 +15077,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "trim": {
@@ -15028,9 +15090,9 @@
       "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
       "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-coercible-to-string-x": "^1.0.0",
-        "white-space-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "require-coercible-to-string-x": "1.0.0",
+        "white-space-x": "3.0.0"
       }
     },
     "trim-newlines": {
@@ -15043,7 +15105,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "trim-right-x": {
@@ -15051,9 +15113,9 @@
       "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
       "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-coercible-to-string-x": "^1.0.0",
-        "white-space-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "require-coercible-to-string-x": "1.0.0",
+        "white-space-x": "3.0.0"
       }
     },
     "trim-trailing-lines": {
@@ -15066,8 +15128,8 @@
       "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
       "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
       "requires": {
-        "trim-left-x": "^3.0.0",
-        "trim-right-x": "^3.0.0"
+        "trim-left-x": "3.0.0",
+        "trim-right-x": "3.0.0"
       }
     },
     "trough": {
@@ -15080,7 +15142,7 @@
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "requires": {
-        "glob": "^6.0.4"
+        "glob": "6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -15088,11 +15150,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -15107,7 +15169,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -15122,7 +15184,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.18"
       }
     },
     "typedarray": {
@@ -15140,8 +15202,8 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.10.tgz",
       "integrity": "sha512-dNib7aUDNZFJNTXFyq0CDmLRVOsnY1F+IQgt2FAOdZFx2+LvKVLbbIb/fL+BYKCv3YH3bPCE/6M/JaxChtQLHQ==",
       "requires": {
-        "commander": "~2.14.1",
-        "source-map": "~0.6.1"
+        "commander": "2.14.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -15167,9 +15229,9 @@
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
       "requires": {
-        "source-map": "^0.5.6",
-        "uglify-js": "^2.8.29",
-        "webpack-sources": "^1.0.1"
+        "source-map": "0.5.7",
+        "uglify-js": "2.8.29",
+        "webpack-sources": "1.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -15182,9 +15244,9 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           }
         },
         "yargs": {
@@ -15192,9 +15254,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -15220,8 +15282,8 @@
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "unified": {
@@ -15229,12 +15291,12 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
       "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-string": "^0.1.0"
+        "bail": "1.0.3",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.2",
+        "vfile": "2.3.0",
+        "x-is-string": "0.1.0"
       }
     },
     "union-value": {
@@ -15242,10 +15304,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -15253,10 +15315,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -15276,7 +15338,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unist-util-find-all-after": {
@@ -15284,7 +15346,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
       "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "2.1.2"
       }
     },
     "unist-util-is": {
@@ -15297,7 +15359,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
       "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
       "requires": {
-        "array-iterate": "^1.0.0"
+        "array-iterate": "1.1.2"
       }
     },
     "unist-util-remove-position": {
@@ -15305,7 +15367,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
       "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "1.3.1"
       }
     },
     "unist-util-stringify-position": {
@@ -15318,7 +15380,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
       "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-is": "2.1.2"
       }
     },
     "universalify": {
@@ -15342,8 +15404,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -15351,9 +15413,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -15393,16 +15455,16 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15410,7 +15472,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -15418,9 +15480,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -15433,7 +15495,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -15443,7 +15505,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
       "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -15479,8 +15541,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.0.0",
+        "requires-port": "1.0.0"
       }
     },
     "url-parse-lax": {
@@ -15488,7 +15550,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-regex": {
@@ -15496,7 +15558,7 @@
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "requires": {
-        "ip-regex": "^1.0.1"
+        "ip-regex": "1.0.3"
       }
     },
     "use": {
@@ -15504,9 +15566,9 @@
       "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "requires": {
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2"
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -15514,7 +15576,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -15522,7 +15584,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15530,7 +15592,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -15540,7 +15602,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15548,7 +15610,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -15558,9 +15620,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "isobject": {
@@ -15599,8 +15661,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "optional": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utils-merge": {
@@ -15618,7 +15680,7 @@
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "vali-date": {
@@ -15631,8 +15693,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "validate.io-undefined": {
@@ -15650,9 +15712,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vfile": {
@@ -15660,10 +15722,10 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
-        "is-buffer": "^1.1.4",
+        "is-buffer": "1.1.6",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "1.1.2",
+        "vfile-message": "1.0.1"
       },
       "dependencies": {
         "replace-ext": {
@@ -15683,7 +15745,7 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
       "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "unist-util-stringify-position": "1.1.2"
       }
     },
     "vinyl": {
@@ -15691,8 +15753,8 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -15701,8 +15763,8 @@
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.0"
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.3"
       }
     },
     "vinyl-fs": {
@@ -15710,14 +15772,14 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "requires": {
-        "defaults": "^1.0.0",
-        "glob-stream": "^3.1.5",
-        "glob-watcher": "^0.0.6",
-        "graceful-fs": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "strip-bom": "^1.0.0",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.0"
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -15730,7 +15792,7 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.1"
           }
         },
         "isarray": {
@@ -15740,13 +15802,13 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -15759,8 +15821,8 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
           "requires": {
-            "first-chunk-stream": "^1.0.0",
-            "is-utf8": "^0.2.0"
+            "first-chunk-stream": "1.0.0",
+            "is-utf8": "0.2.1"
           }
         },
         "through2": {
@@ -15768,8 +15830,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -15777,8 +15839,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -15788,7 +15850,7 @@
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       }
     },
     "vise": {
@@ -15796,7 +15858,7 @@
       "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.0.tgz",
       "integrity": "sha512-kBFZLmiL1Vm3rHXphkhvvAcsjgeQXRrOFCbJb0I50YZZP4HGRNH+xGzK3matIMcpbsfr3I02u9odj4oCD0TWgA==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "5.0.3"
       }
     },
     "vm-browserify": {
@@ -15812,7 +15874,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "^0.1.0"
+        "wrap-fn": "0.1.5"
       }
     },
     "warning": {
@@ -15820,7 +15882,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "watchpack": {
@@ -15828,9 +15890,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "requires": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "chokidar": "2.0.4",
+        "graceful-fs": "4.1.11",
+        "neo-async": "2.5.1"
       }
     },
     "wbuf": {
@@ -15838,7 +15900,7 @@
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.1"
       }
     },
     "webpack": {
@@ -15846,28 +15908,28 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
       "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
       "requires": {
-        "acorn": "^5.0.0",
-        "acorn-dynamic-import": "^2.0.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "async": "^2.1.2",
-        "enhanced-resolve": "^3.4.0",
-        "escope": "^3.6.0",
-        "interpret": "^1.0.0",
-        "json-loader": "^0.5.4",
-        "json5": "^0.5.1",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^2.0.0",
-        "source-map": "^0.5.3",
-        "supports-color": "^4.2.1",
-        "tapable": "^0.2.7",
-        "uglifyjs-webpack-plugin": "^0.4.6",
-        "watchpack": "^1.4.0",
-        "webpack-sources": "^1.0.1",
-        "yargs": "^8.0.2"
+        "acorn": "5.4.1",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "6.5.0",
+        "ajv-keywords": "3.2.0",
+        "async": "2.6.1",
+        "enhanced-resolve": "3.4.1",
+        "escope": "3.6.0",
+        "interpret": "1.1.0",
+        "json-loader": "0.5.7",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.1.0",
+        "source-map": "0.5.7",
+        "supports-color": "4.5.0",
+        "tapable": "0.2.8",
+        "uglifyjs-webpack-plugin": "0.4.6",
+        "watchpack": "1.6.0",
+        "webpack-sources": "1.1.0",
+        "yargs": "8.0.2"
       },
       "dependencies": {
         "supports-color": {
@@ -15875,7 +15937,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -15885,11 +15947,11 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^1.5.0",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "time-stamp": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "1.6.0",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "time-stamp": "2.0.1"
       },
       "dependencies": {
         "time-stamp": {
@@ -15905,30 +15967,30 @@
       "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
       "requires": {
         "ansi-html": "0.0.7",
-        "array-includes": "^3.0.3",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.0.0",
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "debug": "^3.1.0",
-        "del": "^3.0.0",
-        "express": "^4.16.2",
-        "html-entities": "^1.2.0",
-        "http-proxy-middleware": "~0.17.4",
-        "import-local": "^1.0.0",
+        "array-includes": "3.0.3",
+        "bonjour": "3.5.0",
+        "chokidar": "2.0.4",
+        "compression": "1.7.3",
+        "connect-history-api-fallback": "1.5.0",
+        "debug": "3.1.0",
+        "del": "3.0.0",
+        "express": "4.16.3",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.17.4",
+        "import-local": "1.0.0",
         "internal-ip": "1.2.0",
-        "ip": "^1.1.5",
-        "killable": "^1.0.0",
-        "loglevel": "^1.4.1",
-        "opn": "^5.1.0",
-        "portfinder": "^1.0.9",
-        "selfsigned": "^1.9.1",
-        "serve-index": "^1.7.2",
+        "ip": "1.1.5",
+        "killable": "1.0.0",
+        "loglevel": "1.6.1",
+        "opn": "5.3.0",
+        "portfinder": "1.0.13",
+        "selfsigned": "1.10.3",
+        "serve-index": "1.9.1",
         "sockjs": "0.3.19",
         "sockjs-client": "1.1.4",
-        "spdy": "^3.4.1",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^5.1.0",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "5.4.0",
         "webpack-dev-middleware": "1.12.2",
         "yargs": "6.6.0"
       },
@@ -15943,9 +16005,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "debug": {
@@ -15961,8 +16023,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "has-flag": {
@@ -15975,11 +16037,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "os-locale": {
@@ -15987,7 +16049,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "parse-json": {
@@ -15995,7 +16057,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -16003,7 +16065,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -16011,9 +16073,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -16026,9 +16088,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -16036,8 +16098,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "string-width": {
@@ -16045,9 +16107,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -16055,7 +16117,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "supports-color": {
@@ -16063,7 +16125,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "which-module": {
@@ -16076,19 +16138,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         },
         "yargs-parser": {
@@ -16096,7 +16158,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -16106,8 +16168,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+        "source-list-map": "2.0.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -16122,8 +16184,8 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.13",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -16147,7 +16209,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -16165,7 +16227,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "string-width": {
@@ -16173,9 +16235,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -16185,7 +16247,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "window-size": {
@@ -16203,8 +16265,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -16212,9 +16274,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -16239,7 +16301,7 @@
       "resolved": "https://registry.npmjs.org/wrap-promise/-/wrap-promise-1.0.1.tgz",
       "integrity": "sha1-sBn0I2zL8ftWCSG0tIcLe9ovUlU=",
       "requires": {
-        "es6-promise": "^2.3.0"
+        "es6-promise": "2.3.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -16259,8 +16321,8 @@
       "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
       "integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
       "requires": {
-        "boom": "7.x.x",
-        "hoek": "5.x.x"
+        "boom": "7.2.0",
+        "hoek": "5.0.3"
       },
       "dependencies": {
         "boom": {
@@ -16268,7 +16330,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "5.0.3"
           }
         }
       }
@@ -16278,7 +16340,7 @@
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -16286,9 +16348,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -16296,9 +16358,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.1"
       }
     },
     "x-is-string": {
@@ -16316,10 +16378,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
       "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
       }
     },
     "xml-parse-from-string": {
@@ -16332,8 +16394,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -16366,19 +16428,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "requires": {
-        "camelcase": "^4.1.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "read-pkg-up": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^7.0.0"
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
       },
       "dependencies": {
         "cliui": {
@@ -16386,9 +16448,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -16396,9 +16458,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -16408,10 +16470,10 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "parse-json": {
@@ -16419,7 +16481,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-type": {
@@ -16427,7 +16489,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "pify": {
@@ -16440,9 +16502,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -16450,8 +16512,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         }
       }
@@ -16461,7 +16523,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {
@@ -16469,7 +16531,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {

--- a/styleguide/package-lock.json
+++ b/styleguide/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ama-style-guide",
-  "version": "2.26.5",
+  "version": "2.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,11 +9,11 @@
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
       "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
       "requires": {
-        "acorn": "5.4.1",
-        "css": "2.2.3",
-        "normalize-path": "2.1.1",
-        "source-map": "0.5.7",
-        "through2": "2.0.3"
+        "acorn": "^5.0.3",
+        "css": "^2.2.1",
+        "normalize-path": "^2.1.1",
+        "source-map": "^0.5.6",
+        "through2": "^2.0.3"
       }
     },
     "@gulp-sourcemaps/map-sources": {
@@ -21,8 +21,8 @@
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "requires": {
-        "normalize-path": "2.1.1",
-        "through2": "2.0.3"
+        "normalize-path": "^2.0.1",
+        "through2": "^2.0.3"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -30,8 +30,8 @@
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -69,8 +69,8 @@
       "resolved": "https://registry.npmjs.org/accept/-/accept-3.0.2.tgz",
       "integrity": "sha512-bghLXFkCOsC1Y2TZ51etWfKDs6q249SAoHTZVfzWWdlZxoij+mgkj9AmUJWQpDY48TfnrTDIe43Xem4zdMe7mQ==",
       "requires": {
-        "boom": "7.2.0",
-        "hoek": "5.0.3"
+        "boom": "7.x.x",
+        "hoek": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -78,7 +78,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -88,7 +88,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -102,7 +102,7 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -122,7 +122,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -130,10 +130,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
       "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1",
-        "uri-js": "4.2.1"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0",
+        "uri-js": "^4.2.1"
       }
     },
     "ajv-keywords": {
@@ -146,9 +146,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -161,7 +161,7 @@
       "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.1.tgz",
       "integrity": "sha512-4UqoM8xQjwkQ78oiU4NbBK0UgYqeKMAKmwE4ec7Rz3rGU8ZEBFxzgF2sUYKOAlqIXExBDYLN6y1ShF5yQ4hwLQ==",
       "requires": {
-        "hoek": "5.0.3"
+        "hoek": "5.x.x"
       }
     },
     "ansi-align": {
@@ -169,7 +169,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       }
     },
     "ansi-colors": {
@@ -177,7 +177,7 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.0.1.tgz",
       "integrity": "sha512-yopkAU0ZD/WQ56Tms3xLn6jRuX3SyUMAVi0FdmDIbmmnHW3jHiI1sQFdUl3gfVddjnrsP3Y6ywFKvCRopvoVIA==",
       "requires": {
-        "ansi-wrap": "0.1.0"
+        "ansi-wrap": "^0.1.0"
       }
     },
     "ansi-cyan": {
@@ -234,8 +234,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -253,16 +253,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -270,7 +270,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -280,8 +280,8 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "expand-brackets": {
@@ -289,13 +289,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -303,7 +303,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -311,7 +311,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-descriptor": {
@@ -319,9 +319,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -336,8 +336,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -345,7 +345,7 @@
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -355,14 +355,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -370,7 +370,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -378,7 +378,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -388,10 +388,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -399,7 +399,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -409,7 +409,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -417,7 +417,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -427,7 +427,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -435,7 +435,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -445,7 +445,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -453,7 +453,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -478,19 +478,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.13",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "nanomatch": {
@@ -498,17 +498,17 @@
           "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
           "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "to-regex": {
@@ -516,10 +516,10 @@
           "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           },
           "dependencies": {
             "regex-not": {
@@ -527,8 +527,8 @@
               "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
               "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
               "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
               }
             }
           }
@@ -550,7 +550,7 @@
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "requires": {
-        "file-type": "3.9.0"
+        "file-type": "^3.1.0"
       }
     },
     "archy": {
@@ -563,8 +563,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -572,7 +572,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -580,7 +580,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -618,8 +618,8 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-iterate": {
@@ -637,7 +637,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -675,9 +675,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -718,7 +718,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "lodash": {
@@ -733,7 +733,7 @@
       "resolved": "https://registry.npmjs.org/async-chain-proxy/-/async-chain-proxy-0.1.5.tgz",
       "integrity": "sha512-JYUzBrCWkKdBQ02H2f1N8xR4JXeWGcw2V8i2AzJjeXGTz40rqqbKkDmQieL8iHNp70W1M44WXqFsvk4Cx49H1Q==",
       "requires": {
-        "babel-polyfill": "6.26.0"
+        "babel-polyfill": "^6.23.0"
       }
     },
     "async-each": {
@@ -776,12 +776,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.5.0.tgz",
       "integrity": "sha512-buY1XxFoBrXvLsoFb0jP+niSu1tCj2RwMwHj96+RfQ8DJTgb0vUhh0dg6wjJT3JzsFYBrkSj8/sGtarNdlxTFw==",
       "requires": {
-        "browserslist": "3.2.7",
-        "caniuse-lite": "1.0.30000840",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "6.0.22",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "^3.2.7",
+        "caniuse-lite": "^1.0.30000839",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^6.0.22",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -789,7 +789,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -797,9 +797,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -812,9 +812,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.4.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         },
         "source-map": {
@@ -827,7 +827,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -847,8 +847,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "1.5.1",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.2.5",
+        "is-buffer": "^1.1.5"
       }
     },
     "b64": {
@@ -861,9 +861,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "core-js": {
@@ -878,8 +878,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -904,7 +904,7 @@
       "resolved": "https://registry.npmjs.org/backstop-twentytwenty/-/backstop-twentytwenty-1.0.4.tgz",
       "integrity": "sha512-sENfpossNAbVKZjTzBU6bkbR1vIb7t6brjqH9ZMEIYh/RyCIGFM3BSgERzh+tdwpAVXHSbIV1gQRrtzBYzUrjw==",
       "requires": {
-        "react": "15.6.2"
+        "react": "^15.6.2"
       }
     },
     "backstopjs": {
@@ -912,33 +912,33 @@
       "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.5.2.tgz",
       "integrity": "sha512-2QqAbbQerk4T/M+a+YBxAPJnkZbl9nfXUuSVlzu2mAfW0Uq+gp9NYzsIUsfLjy2vISPJwBBa5ANnVMz86QcgwQ==",
       "requires": {
-        "backstop-twentytwenty": "1.0.4",
-        "casperjs": "1.1.4",
-        "chalk": "1.1.3",
+        "backstop-twentytwenty": "^1.0.4",
+        "casperjs": "^1.1.0-beta5",
+        "chalk": "^1.1.3",
         "chromy": "0.5.11",
-        "fs-extra": "0.30.0",
-        "jump.js": "1.0.2",
-        "junitwriter": "0.3.1",
-        "lodash": "4.17.5",
-        "minimist": "1.2.0",
-        "node-resemble-js": "0.2.0",
+        "fs-extra": "^0.30.0",
+        "jump.js": "^1.0.2",
+        "junitwriter": "~0.3.1",
+        "lodash": "^4.17.4",
+        "minimist": "^1.2.0",
+        "node-resemble-js": "^0.2.0",
         "object-hash": "1.1.5",
-        "opn": "5.3.0",
-        "os": "0.1.1",
-        "p-map": "1.2.0",
-        "path": "0.12.7",
-        "phantomjs-prebuilt": "2.1.16",
-        "puppeteer": "1.6.1",
-        "react-modal": "3.5.1",
-        "react-redux": "5.0.7",
-        "react-sticky": "6.0.3",
-        "react-toggle-button": "2.2.0",
-        "redux": "3.7.2",
-        "sinon": "1.17.7",
-        "styled-components": "2.4.1",
-        "temp": "0.8.3",
-        "webpack": "3.12.0",
-        "webpack-dev-server": "2.11.2"
+        "opn": "^5.3.0",
+        "os": "^0.1.1",
+        "p-map": "^1.1.1",
+        "path": "^0.12.7",
+        "phantomjs-prebuilt": "^2.1.7",
+        "puppeteer": "^1.2.0-next.1523485686787",
+        "react-modal": "^3.0.3",
+        "react-redux": "^5.0.6",
+        "react-sticky": "^6.0.1",
+        "react-toggle-button": "^2.1.0",
+        "redux": "^3.7.2",
+        "sinon": "^1.17.7",
+        "styled-components": "^2.1.2",
+        "temp": "^0.8.3",
+        "webpack": "^3.5.6",
+        "webpack-dev-server": "^2.7.1"
       },
       "dependencies": {
         "path": {
@@ -946,8 +946,8 @@
           "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
           "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
           "requires": {
-            "process": "0.11.10",
-            "util": "0.10.4"
+            "process": "^0.11.1",
+            "util": "^0.10.3"
           }
         },
         "process": {
@@ -972,13 +972,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "isobject": {
@@ -1014,7 +1014,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "beeper": {
@@ -1051,13 +1051,13 @@
       "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
       "optional": true,
       "requires": {
-        "archive-type": "3.2.0",
-        "decompress": "3.0.0",
-        "download": "4.4.3",
-        "exec-series": "1.0.3",
-        "rimraf": "2.6.2",
-        "tempfile": "1.1.1",
-        "url-regex": "3.2.0"
+        "archive-type": "^3.0.1",
+        "decompress": "^3.0.0",
+        "download": "^4.1.2",
+        "exec-series": "^1.0.0",
+        "rimraf": "^2.2.6",
+        "tempfile": "^1.0.0",
+        "url-regex": "^3.0.0"
       },
       "dependencies": {
         "tempfile": {
@@ -1066,8 +1066,8 @@
           "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
           "optional": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "uuid": "2.0.3"
+            "os-tmpdir": "^1.0.0",
+            "uuid": "^2.0.1"
           }
         },
         "uuid": {
@@ -1084,7 +1084,7 @@
       "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
       "optional": true,
       "requires": {
-        "executable": "1.1.0"
+        "executable": "^1.0.0"
       }
     },
     "bin-version": {
@@ -1093,7 +1093,7 @@
       "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
       "optional": true,
       "requires": {
-        "find-versions": "1.2.1"
+        "find-versions": "^1.0.0"
       }
     },
     "bin-version-check": {
@@ -1102,10 +1102,10 @@
       "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
       "optional": true,
       "requires": {
-        "bin-version": "1.0.4",
-        "minimist": "1.2.0",
-        "semver": "4.3.6",
-        "semver-truncate": "1.1.2"
+        "bin-version": "^1.0.0",
+        "minimist": "^1.1.0",
+        "semver": "^4.0.3",
+        "semver-truncate": "^1.0.0"
       },
       "dependencies": {
         "semver": {
@@ -1122,12 +1122,12 @@
       "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
       "optional": true,
       "requires": {
-        "bin-check": "2.0.0",
-        "bin-version-check": "2.1.0",
-        "download": "4.4.3",
-        "each-async": "1.1.1",
-        "lazy-req": "1.1.0",
-        "os-filter-obj": "1.0.3"
+        "bin-check": "^2.0.0",
+        "bin-version-check": "^2.1.0",
+        "download": "^4.0.0",
+        "each-async": "^1.1.1",
+        "lazy-req": "^1.0.0",
+        "os-filter-obj": "^1.0.0"
       }
     },
     "binary-extensions": {
@@ -1140,7 +1140,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "blob": {
@@ -1153,7 +1153,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -1177,15 +1177,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "iconv-lite": {
@@ -1205,12 +1205,12 @@
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
-        "array-flatten": "2.1.1",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.3",
-        "multicast-dns-service-types": "1.1.0"
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
       }
     },
     "boolbase": {
@@ -1223,7 +1223,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -1238,8 +1238,8 @@
       "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
       "integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
       "requires": {
-        "boom": "7.2.0",
-        "hoek": "5.0.3"
+        "boom": "7.x.x",
+        "hoek": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1247,7 +1247,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -1257,13 +1257,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.4.1",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1271,7 +1271,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -1279,9 +1279,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -1294,7 +1294,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1304,7 +1304,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.9.tgz",
       "integrity": "sha512-/+o3o6OV1cm3WKrO7U4wykU+ZICE6HiMEuravc2d03NIuM/VaRn5iMcoQ7NyxFXjvpmRICP2EER0YOnh4yIapA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1313,9 +1313,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "breakpoint-sass": {
@@ -1333,16 +1333,16 @@
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.6.tgz",
       "integrity": "sha512-3cVW8Ft3sPQ1t9gqZXBDZhTyRce8NW4wf5KzpCYcg6fWjPbyt+vZLvEo+sTq7c7eNQhi8lInQWbjIFEpoM2f7Q==",
       "requires": {
-        "browser-sync-ui": "1.0.1",
+        "browser-sync-ui": "v1.0.1",
         "bs-recipes": "1.3.4",
         "chokidar": "1.7.0",
         "connect": "3.6.6",
-        "connect-history-api-fallback": "1.5.0",
-        "dev-ip": "1.0.1",
+        "connect-history-api-fallback": "^1.5.0",
+        "dev-ip": "^1.0.1",
         "easy-extender": "2.3.2",
         "eazy-logger": "3.0.2",
-        "etag": "1.8.1",
-        "fresh": "0.5.2",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
         "immutable": "3.8.2",
@@ -1351,7 +1351,7 @@
         "opn": "4.0.2",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
-        "raw-body": "2.3.2",
+        "raw-body": "^2.3.2",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
         "serve-index": "1.9.1",
@@ -1367,8 +1367,8 @@
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "requires": {
-            "micromatch": "2.3.11",
-            "normalize-path": "2.1.1"
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
           }
         },
         "camelcase": {
@@ -1381,15 +1381,15 @@
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "requires": {
-            "anymatch": "1.3.2",
-            "async-each": "1.0.1",
-            "fsevents": "1.2.4",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
           }
         },
         "cliui": {
@@ -1397,9 +1397,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "eventemitter3": {
@@ -1412,8 +1412,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "fs-extra": {
@@ -1421,9 +1421,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "3.0.1",
-            "universalify": "0.1.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^3.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "http-proxy": {
@@ -1431,8 +1431,8 @@
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
           "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
           "requires": {
-            "eventemitter3": "1.2.0",
-            "requires-port": "1.0.0"
+            "eventemitter3": "1.x.x",
+            "requires-port": "1.x.x"
           }
         },
         "jsonfile": {
@@ -1440,7 +1440,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "load-json-file": {
@@ -1448,11 +1448,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "opn": {
@@ -1460,8 +1460,8 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
           "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "os-locale": {
@@ -1469,7 +1469,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "parse-json": {
@@ -1477,7 +1477,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -1485,7 +1485,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -1493,9 +1493,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -1513,9 +1513,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -1523,8 +1523,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "string-width": {
@@ -1532,9 +1532,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -1542,7 +1542,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "ua-parser-js": {
@@ -1565,20 +1565,20 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.1.0"
           }
         },
         "yargs-parser": {
@@ -1586,7 +1586,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -1597,11 +1597,11 @@
       "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "1.5.0",
-        "immutable": "3.8.2",
+        "connect-history-api-fallback": "^1.1.0",
+        "immutable": "^3.7.6",
         "server-destroy": "1.0.1",
         "socket.io-client": "2.0.4",
-        "stream-throttle": "0.1.3"
+        "stream-throttle": "^0.1.3"
       }
     },
     "browserify-aes": {
@@ -1609,12 +1609,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -1622,9 +1622,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1632,10 +1632,10 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -1650,8 +1650,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -1659,13 +1659,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -1673,7 +1673,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -1681,8 +1681,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
       "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000840",
-        "electron-to-chromium": "1.3.45"
+        "caniuse-lite": "^1.0.30000835",
+        "electron-to-chromium": "^1.3.45"
       }
     },
     "bs-recipes": {
@@ -1695,8 +1695,8 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
       "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-equal": {
@@ -1710,7 +1710,7 @@
       "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
       "optional": true,
       "requires": {
-        "is-array-buffer-x": "1.7.0"
+        "is-array-buffer-x": "^1.0.13"
       }
     },
     "buffer-indexof": {
@@ -1723,10 +1723,10 @@
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "requires": {
-        "file-type": "3.9.0",
-        "readable-stream": "2.3.3",
-        "uuid": "2.0.3",
-        "vinyl": "1.2.0"
+        "file-type": "^3.1.0",
+        "readable-stream": "^2.0.2",
+        "uuid": "^2.0.1",
+        "vinyl": "^1.0.0"
       },
       "dependencies": {
         "uuid": {
@@ -1739,8 +1739,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -1766,8 +1766,8 @@
       "resolved": "https://registry.npmjs.org/bump-regex/-/bump-regex-3.1.1.tgz",
       "integrity": "sha512-NinFibU11G1ad/2Ji3J04lRC9mLpUGr3C0vtt4Yp049cDeW21NRkmUaZZc+snwlL6gE+Ja5cQfe/hf86Ahj+WQ==",
       "requires": {
-        "semver": "5.5.0",
-        "xtend": "4.0.1"
+        "semver": "^5.1.0",
+        "xtend": "^4.0.1"
       }
     },
     "bytes": {
@@ -1780,15 +1780,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -1808,8 +1808,8 @@
       "resolved": "https://registry.npmjs.org/call/-/call-5.0.1.tgz",
       "integrity": "sha512-ollfFPSshiuYLp7AsrmpkQJ/PxCi6AzV81rCjBwWhyF2QGyUY/vPDMzoh4aUcWyucheRglG2LaS5qkIEfLRh6A==",
       "requires": {
-        "boom": "7.2.0",
-        "hoek": "5.0.3"
+        "boom": "7.x.x",
+        "hoek": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1817,7 +1817,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -1842,9 +1842,9 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
       }
     },
     "caniuse-lite": {
@@ -1872,10 +1872,10 @@
       "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.2.tgz",
       "integrity": "sha512-cTQTQeKMhWHU0lX8CADE3g1koGJu+AlcWFzAjMX/8P+XbkScGYw3tJsQpe2Oh8q68vOQbOLacz9k+6V/F3Z9DA==",
       "requires": {
-        "boom": "7.2.0",
-        "bounce": "1.2.0",
-        "hoek": "5.0.3",
-        "joi": "13.3.0"
+        "boom": "7.x.x",
+        "bounce": "1.x.x",
+        "hoek": "5.x.x",
+        "joi": "13.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1883,7 +1883,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -1893,9 +1893,9 @@
       "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.2.tgz",
       "integrity": "sha512-lhWtutLVhsq3Mucxk2McxBPPibJ34WcHuWFz3xqub9u9Ve/IQYpZv3ijLhQXfQped9DXozURiaq9O3aZpP91eg==",
       "requires": {
-        "big-time": "2.0.1",
-        "boom": "7.2.0",
-        "hoek": "5.0.3"
+        "big-time": "2.x.x",
+        "boom": "7.x.x",
+        "hoek": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1903,7 +1903,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -1913,10 +1913,10 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "requires": {
-        "get-proxy": "1.1.0",
-        "is-obj": "1.0.1",
-        "object-assign": "3.0.0",
-        "tunnel-agent": "0.4.3"
+        "get-proxy": "^1.0.1",
+        "is-obj": "^1.0.0",
+        "object-assign": "^3.0.0",
+        "tunnel-agent": "^0.4.0"
       },
       "dependencies": {
         "object-assign": {
@@ -1941,8 +1941,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -1954,14 +1954,14 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "character-entities": {
@@ -1989,19 +1989,19 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.2",
-        "fsevents": "1.2.4",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.0",
-        "lodash.debounce": "4.0.8",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0",
-        "upath": "1.1.0"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
       },
       "dependencies": {
         "array-unique": {
@@ -2014,16 +2014,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.1"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           }
         },
         "fill-range": {
@@ -2031,10 +2031,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           }
         },
         "glob-parent": {
@@ -2042,8 +2042,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -2051,7 +2051,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -2066,7 +2066,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -2074,7 +2074,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -2089,14 +2089,14 @@
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.2.tgz",
       "integrity": "sha512-E+kTHlGgtitPPu8Rci0E4XBasirKtTn6DjqFn8tTLp/7xCUzqb6lig9Il+HLkcudzKvT/aLxJbzbyNCe03w1AA==",
       "requires": {
-        "@types/core-js": "0.9.46",
-        "@types/mkdirp": "0.3.29",
-        "@types/node": "9.6.24",
-        "@types/rimraf": "0.0.28",
-        "is-wsl": "1.1.0",
-        "lighthouse-logger": "1.0.1",
+        "@types/core-js": "^0.9.41",
+        "@types/mkdirp": "^0.3.29",
+        "@types/node": "^9.3.0",
+        "@types/rimraf": "^0.0.28",
+        "is-wsl": "^1.1.0",
+        "lighthouse-logger": "^1.0.0",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "rimraf": "^2.6.1"
       }
     },
     "chrome-remote-interface": {
@@ -2104,8 +2104,8 @@
       "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
       "integrity": "sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==",
       "requires": {
-        "commander": "2.11.0",
-        "ws": "3.3.3"
+        "commander": "2.11.x",
+        "ws": "3.3.x"
       }
     },
     "chromy": {
@@ -2113,12 +2113,12 @@
       "resolved": "https://registry.npmjs.org/chromy/-/chromy-0.5.11.tgz",
       "integrity": "sha512-SBz5/xPYgeQiwFGMixPNQcbgnzsRHGCJnZKNJ5S0SmauSUY77/mqA8NjotQa12SZ3tZy0NX2gyGP41BAUWI6Rg==",
       "requires": {
-        "async-chain-proxy": "0.1.5",
-        "babel-runtime": "6.26.0",
-        "chrome-launcher": "0.10.2",
-        "chrome-remote-interface": "0.25.7",
-        "jimp": "0.2.28",
-        "uuid": "3.2.1"
+        "async-chain-proxy": "^0.1.5",
+        "babel-runtime": "^6.26.0",
+        "chrome-launcher": "^0.10.2",
+        "chrome-remote-interface": "^0.25.5",
+        "jimp": "^0.2.28",
+        "uuid": "^3.2.1"
       }
     },
     "ci-info": {
@@ -2131,8 +2131,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -2146,7 +2146,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       }
     },
     "class-utils": {
@@ -2154,10 +2154,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2165,7 +2165,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2173,7 +2173,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2181,7 +2181,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2191,7 +2191,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2199,7 +2199,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2209,9 +2209,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "isobject": {
@@ -2231,8 +2231,8 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "requires": {
-        "commander": "2.8.1",
-        "source-map": "0.4.4"
+        "commander": "2.8.x",
+        "source-map": "0.4.x"
       },
       "dependencies": {
         "commander": {
@@ -2240,7 +2240,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "source-map": {
@@ -2248,7 +2248,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2263,8 +2263,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -2283,8 +2283,8 @@
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
       "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "requires": {
-        "is-regexp": "1.0.0",
-        "is-supported-regexp-flag": "1.0.1"
+        "is-regexp": "^1.0.0",
+        "is-supported-regexp-flag": "^1.0.0"
       }
     },
     "clone-stats": {
@@ -2297,9 +2297,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^1.0.6",
+        "through2": "^2.0.1"
       }
     },
     "co": {
@@ -2313,7 +2313,7 @@
       "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
       "optional": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -2331,8 +2331,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -2340,7 +2340,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -2363,7 +2363,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2391,7 +2391,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "requires": {
-        "mime-db": "1.35.0"
+        "mime-db": ">= 1.34.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -2406,13 +2406,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.14",
+        "compressible": "~2.0.14",
         "debug": "2.6.9",
-        "on-headers": "1.0.1",
+        "on-headers": "~1.0.1",
         "safe-buffer": "5.1.2",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -2432,9 +2432,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "concat-with-sourcemaps": {
@@ -2442,7 +2442,7 @@
       "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
       "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -2457,12 +2457,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "connect": {
@@ -2472,7 +2472,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -2482,12 +2482,12 @@
           "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           }
         },
         "statuses": {
@@ -2507,7 +2507,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -2531,7 +2531,7 @@
       "resolved": "https://registry.npmjs.org/content/-/content-4.0.5.tgz",
       "integrity": "sha512-wDP6CTWDpwCf791fNxlCCkZGRkrNzSEU/8ju9Hnr3Uc5mF/gFR5W+fcoGm6zUSlVPdSXYn5pCbySADKj7YM4Cg==",
       "requires": {
-        "boom": "7.2.0"
+        "boom": "7.x.x"
       },
       "dependencies": {
         "boom": {
@@ -2539,7 +2539,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -2589,13 +2589,13 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.10.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "require-from-string": "1.2.1"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.4.3",
+        "minimist": "^1.2.0",
+        "object-assign": "^4.1.0",
+        "os-homedir": "^1.0.1",
+        "parse-json": "^2.2.0",
+        "require-from-string": "^1.1.0"
       },
       "dependencies": {
         "parse-json": {
@@ -2603,7 +2603,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         }
       }
@@ -2613,8 +2613,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-error-class": {
@@ -2622,7 +2622,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -2630,11 +2630,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2642,12 +2642,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-react-class": {
@@ -2655,9 +2655,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
-        "fbjs": "0.8.17",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "cross-spawn": {
@@ -2665,9 +2665,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "lru-cache": {
@@ -2675,8 +2675,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         }
       }
@@ -2686,7 +2686,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -2694,7 +2694,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           },
           "dependencies": {
             "hoek": {
@@ -2711,17 +2711,17 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "crypto-random-string": {
@@ -2734,10 +2734,10 @@
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
       "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
       "requires": {
-        "inherits": "2.0.3",
-        "source-map": "0.1.43",
-        "source-map-resolve": "0.5.1",
-        "urix": "0.1.0"
+        "inherits": "^2.0.1",
+        "source-map": "^0.1.38",
+        "source-map-resolve": "^0.5.1",
+        "urix": "^0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -2745,7 +2745,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2761,10 +2761,10 @@
       "integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
       "optional": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "^1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "^1.0.1"
       }
     },
     "css-select-base-adapter": {
@@ -2778,9 +2778,9 @@
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.1.tgz",
       "integrity": "sha512-v++LRcf633phJiYZBDqtmGPj3+BVof0isd2jgwYLWZJ5YSuhCkrfYtDsNhM6oJthiEco0f9tDVJ1vUkDJNgGEA==",
       "requires": {
-        "css-color-keywords": "1.0.0",
-        "fbjs": "0.8.17",
-        "postcss-value-parser": "3.3.0"
+        "css-color-keywords": "^1.0.0",
+        "fbjs": "^0.8.5",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "css-tree": {
@@ -2789,8 +2789,8 @@
       "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
       "optional": true,
       "requires": {
-        "mdn-data": "1.1.0",
-        "source-map": "0.5.7"
+        "mdn-data": "^1.0.0",
+        "source-map": "^0.5.3"
       }
     },
     "css-url-regex": {
@@ -2820,8 +2820,8 @@
           "integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
           "optional": true,
           "requires": {
-            "mdn-data": "1.1.0",
-            "source-map": "0.5.7"
+            "mdn-data": "^1.0.0",
+            "source-map": "^0.5.3"
           }
         }
       }
@@ -2831,7 +2831,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "d": {
@@ -2839,7 +2839,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -2847,7 +2847,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -2860,8 +2860,8 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
       "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
       "requires": {
-        "get-stdin": "5.0.1",
-        "meow": "4.0.0"
+        "get-stdin": "*",
+        "meow": "*"
       }
     },
     "debug": {
@@ -2877,9 +2877,9 @@
       "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.0.0.tgz",
       "integrity": "sha512-dsd50qQ1atDeurcxL7XOjPp4nZCGZzWIONDujDXzl1atSyC3hMbZD+v6440etw+Vt0Pr8ce4TQzHfX3KZM05Mw==",
       "requires": {
-        "debug": "3.1.0",
-        "memoizee": "0.4.11",
-        "object-assign": "4.1.1"
+        "debug": "3.X",
+        "memoizee": "0.4.X",
+        "object-assign": "4.X"
       },
       "dependencies": {
         "debug": {
@@ -2902,8 +2902,8 @@
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "map-obj": {
@@ -2923,15 +2923,15 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "requires": {
-        "buffer-to-vinyl": "1.1.0",
-        "concat-stream": "1.6.0",
-        "decompress-tar": "3.1.0",
-        "decompress-tarbz2": "3.1.0",
-        "decompress-targz": "3.1.0",
-        "decompress-unzip": "3.4.0",
-        "stream-combiner2": "1.1.1",
-        "vinyl-assign": "1.2.1",
-        "vinyl-fs": "2.4.4"
+        "buffer-to-vinyl": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "decompress-tar": "^3.0.0",
+        "decompress-tarbz2": "^3.0.0",
+        "decompress-targz": "^3.0.0",
+        "decompress-unzip": "^3.0.0",
+        "stream-combiner2": "^1.1.1",
+        "vinyl-assign": "^1.0.1",
+        "vinyl-fs": "^2.2.0"
       },
       "dependencies": {
         "glob": {
@@ -2939,11 +2939,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -2951,8 +2951,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           }
         },
         "glob-stream": {
@@ -2960,14 +2960,14 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "requires": {
-            "extend": "3.0.1",
-            "glob": "5.0.15",
-            "glob-parent": "3.1.0",
-            "micromatch": "2.3.11",
-            "ordered-read-streams": "0.3.0",
-            "through2": "0.6.5",
-            "to-absolute-glob": "0.1.1",
-            "unique-stream": "2.2.1"
+            "extend": "^3.0.0",
+            "glob": "^5.0.3",
+            "glob-parent": "^3.0.0",
+            "micromatch": "^2.3.7",
+            "ordered-read-streams": "^0.3.0",
+            "through2": "^0.6.0",
+            "to-absolute-glob": "^0.1.1",
+            "unique-stream": "^2.0.2"
           },
           "dependencies": {
             "readable-stream": {
@@ -2975,10 +2975,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "through2": {
@@ -2986,8 +2986,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
               }
             }
           }
@@ -2997,11 +2997,11 @@
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "requires": {
-            "convert-source-map": "1.5.1",
-            "graceful-fs": "4.1.11",
-            "strip-bom": "2.0.0",
-            "through2": "2.0.3",
-            "vinyl": "1.2.0"
+            "convert-source-map": "^1.1.1",
+            "graceful-fs": "^4.1.2",
+            "strip-bom": "^2.0.0",
+            "through2": "^2.0.0",
+            "vinyl": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -3014,7 +3014,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "isarray": {
@@ -3027,8 +3027,8 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "requires": {
-            "is-stream": "1.1.0",
-            "readable-stream": "2.3.3"
+            "is-stream": "^1.0.1",
+            "readable-stream": "^2.0.1"
           }
         },
         "string_decoder": {
@@ -3041,7 +3041,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "unique-stream": {
@@ -3049,8 +3049,8 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
+            "json-stable-stringify": "^1.0.0",
+            "through2-filter": "^2.0.0"
           }
         },
         "vinyl": {
@@ -3058,8 +3058,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -3068,23 +3068,23 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "3.5.3",
-            "glob-stream": "5.3.5",
-            "graceful-fs": "4.1.11",
+            "duplexify": "^3.2.0",
+            "glob-stream": "^5.3.2",
+            "graceful-fs": "^4.0.0",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "0.3.0",
-            "lazystream": "1.0.0",
-            "lodash.isequal": "4.5.0",
-            "merge-stream": "1.0.1",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "readable-stream": "2.3.3",
-            "strip-bom": "2.0.0",
-            "strip-bom-stream": "1.0.0",
-            "through2": "2.0.3",
-            "through2-filter": "2.0.0",
-            "vali-date": "1.0.0",
-            "vinyl": "1.2.0"
+            "is-valid-glob": "^0.3.0",
+            "lazystream": "^1.0.0",
+            "lodash.isequal": "^4.0.0",
+            "merge-stream": "^1.0.0",
+            "mkdirp": "^0.5.0",
+            "object-assign": "^4.0.0",
+            "readable-stream": "^2.0.4",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^1.0.0",
+            "through2": "^2.0.0",
+            "through2-filter": "^2.0.0",
+            "vali-date": "^1.0.0",
+            "vinyl": "^1.0.0"
           }
         }
       }
@@ -3094,12 +3094,12 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "requires": {
-        "is-tar": "1.0.0",
-        "object-assign": "2.1.1",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.5",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "is-tar": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
       },
       "dependencies": {
         "clone": {
@@ -3122,10 +3122,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3138,8 +3138,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "vinyl": {
@@ -3147,8 +3147,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -3158,13 +3158,13 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "requires": {
-        "is-bzip2": "1.0.0",
-        "object-assign": "2.1.1",
-        "seek-bzip": "1.0.5",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.5",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "is-bzip2": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "seek-bzip": "^1.0.3",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
       },
       "dependencies": {
         "clone": {
@@ -3187,10 +3187,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3203,8 +3203,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "vinyl": {
@@ -3212,8 +3212,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -3223,12 +3223,12 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "requires": {
-        "is-gzip": "1.0.0",
-        "object-assign": "2.1.1",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.5",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "is-gzip": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
       },
       "dependencies": {
         "clone": {
@@ -3251,10 +3251,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3267,8 +3267,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "vinyl": {
@@ -3276,8 +3276,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -3287,13 +3287,13 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "requires": {
-        "is-zip": "1.0.0",
-        "read-all-stream": "3.1.0",
-        "stat-mode": "0.2.2",
-        "strip-dirs": "1.1.1",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "yauzl": "2.4.1"
+        "is-zip": "^1.0.0",
+        "read-all-stream": "^3.0.0",
+        "stat-mode": "^0.2.0",
+        "strip-dirs": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0",
+        "yauzl": "^2.2.1"
       },
       "dependencies": {
         "vinyl": {
@@ -3301,8 +3301,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -3323,7 +3323,7 @@
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "1.0.3"
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -3331,8 +3331,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       },
       "dependencies": {
         "object-keys": {
@@ -3347,7 +3347,7 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "requires": {
-        "is-descriptor": "1.0.2"
+        "is-descriptor": "^1.0.0"
       }
     },
     "del": {
@@ -3355,12 +3355,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "p-map": "1.2.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2"
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -3388,8 +3388,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -3422,9 +3422,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dir-glob": {
@@ -3432,8 +3432,8 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
       }
     },
     "dns-equal": {
@@ -3446,8 +3446,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "dns-txt": {
@@ -3455,7 +3455,7 @@
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
-        "buffer-indexof": "1.1.1"
+        "buffer-indexof": "^1.0.0"
       }
     },
     "dom-serializer": {
@@ -3463,8 +3463,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3494,7 +3494,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -3502,8 +3502,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -3511,7 +3511,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "download": {
@@ -3519,21 +3519,21 @@
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "requires": {
-        "caw": "1.2.0",
-        "concat-stream": "1.6.0",
-        "each-async": "1.1.1",
-        "filenamify": "1.2.1",
-        "got": "5.7.1",
-        "gulp-decompress": "1.2.0",
-        "gulp-rename": "1.2.2",
-        "is-url": "1.2.2",
-        "object-assign": "4.1.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "stream-combiner2": "1.1.1",
-        "vinyl": "1.2.0",
-        "vinyl-fs": "2.4.4",
-        "ware": "1.3.0"
+        "caw": "^1.0.1",
+        "concat-stream": "^1.4.7",
+        "each-async": "^1.0.0",
+        "filenamify": "^1.0.1",
+        "got": "^5.0.0",
+        "gulp-decompress": "^1.2.0",
+        "gulp-rename": "^1.2.0",
+        "is-url": "^1.2.0",
+        "object-assign": "^4.0.1",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.2",
+        "stream-combiner2": "^1.1.1",
+        "vinyl": "^1.0.0",
+        "vinyl-fs": "^2.2.0",
+        "ware": "^1.2.0"
       },
       "dependencies": {
         "glob": {
@@ -3541,11 +3541,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -3553,8 +3553,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           }
         },
         "glob-stream": {
@@ -3562,14 +3562,14 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "requires": {
-            "extend": "3.0.1",
-            "glob": "5.0.15",
-            "glob-parent": "3.1.0",
-            "micromatch": "2.3.11",
-            "ordered-read-streams": "0.3.0",
-            "through2": "0.6.5",
-            "to-absolute-glob": "0.1.1",
-            "unique-stream": "2.2.1"
+            "extend": "^3.0.0",
+            "glob": "^5.0.3",
+            "glob-parent": "^3.0.0",
+            "micromatch": "^2.3.7",
+            "ordered-read-streams": "^0.3.0",
+            "through2": "^0.6.0",
+            "to-absolute-glob": "^0.1.1",
+            "unique-stream": "^2.0.2"
           },
           "dependencies": {
             "readable-stream": {
@@ -3577,10 +3577,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "through2": {
@@ -3588,8 +3588,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
               }
             }
           }
@@ -3599,11 +3599,11 @@
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "requires": {
-            "convert-source-map": "1.5.1",
-            "graceful-fs": "4.1.11",
-            "strip-bom": "2.0.0",
-            "through2": "2.0.3",
-            "vinyl": "1.2.0"
+            "convert-source-map": "^1.1.1",
+            "graceful-fs": "^4.1.2",
+            "strip-bom": "^2.0.0",
+            "through2": "^2.0.0",
+            "vinyl": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -3616,7 +3616,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "isarray": {
@@ -3629,8 +3629,8 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "requires": {
-            "is-stream": "1.1.0",
-            "readable-stream": "2.3.3"
+            "is-stream": "^1.0.1",
+            "readable-stream": "^2.0.1"
           }
         },
         "string_decoder": {
@@ -3643,7 +3643,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "unique-stream": {
@@ -3651,8 +3651,8 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
+            "json-stable-stringify": "^1.0.0",
+            "through2-filter": "^2.0.0"
           }
         },
         "vinyl": {
@@ -3660,8 +3660,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -3670,23 +3670,23 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "3.5.3",
-            "glob-stream": "5.3.5",
-            "graceful-fs": "4.1.11",
+            "duplexify": "^3.2.0",
+            "glob-stream": "^5.3.2",
+            "graceful-fs": "^4.0.0",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "0.3.0",
-            "lazystream": "1.0.0",
-            "lodash.isequal": "4.5.0",
-            "merge-stream": "1.0.1",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "readable-stream": "2.3.3",
-            "strip-bom": "2.0.0",
-            "strip-bom-stream": "1.0.0",
-            "through2": "2.0.3",
-            "through2-filter": "2.0.0",
-            "vali-date": "1.0.0",
-            "vinyl": "1.2.0"
+            "is-valid-glob": "^0.3.0",
+            "lazystream": "^1.0.0",
+            "lodash.isequal": "^4.0.0",
+            "merge-stream": "^1.0.0",
+            "mkdirp": "^0.5.0",
+            "object-assign": "^4.0.0",
+            "readable-stream": "^2.0.4",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^1.0.0",
+            "through2": "^2.0.0",
+            "through2-filter": "^2.0.0",
+            "vali-date": "^1.0.0",
+            "vinyl": "^1.0.0"
           }
         }
       }
@@ -3701,7 +3701,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "isarray": {
@@ -3714,10 +3714,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3737,10 +3737,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -3748,7 +3748,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         }
       }
@@ -3758,8 +3758,8 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
       }
     },
     "easy-extender": {
@@ -3767,7 +3767,7 @@
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
       "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -3782,7 +3782,7 @@
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "requires": {
-        "tfunk": "3.1.0"
+        "tfunk": "^3.0.1"
       }
     },
     "ecc-jsbn": {
@@ -3791,7 +3791,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "editorconfig": {
@@ -3799,10 +3799,10 @@
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
       "integrity": "sha1-jleSbZ7mmrbLmZ8CfCFxRnrM6zU=",
       "requires": {
-        "bluebird": "3.5.1",
-        "commander": "2.11.0",
-        "lru-cache": "3.2.0",
-        "sigmund": "1.0.1"
+        "bluebird": "^3.0.5",
+        "commander": "^2.9.0",
+        "lru-cache": "^3.2.0",
+        "sigmund": "^1.0.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -3810,7 +3810,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "requires": {
-            "pseudomap": "1.0.2"
+            "pseudomap": "^1.0.1"
           }
         }
       }
@@ -3830,13 +3830,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.5",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -3854,7 +3854,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.23"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -3862,7 +3862,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "requires": {
-        "once": "1.3.3"
+        "once": "~1.3.0"
       },
       "dependencies": {
         "once": {
@@ -3870,7 +3870,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -3880,12 +3880,12 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
       },
       "dependencies": {
         "debug": {
@@ -3905,14 +3905,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3932,10 +3932,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "1.0.3"
+        "has-binary2": "~1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -3943,10 +3943,10 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "entities": {
@@ -3959,7 +3959,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -3967,7 +3967,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -3975,11 +3975,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3987,9 +3987,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -3997,8 +3997,8 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
       "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -4006,9 +4006,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -4016,12 +4016,12 @@
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -4034,7 +4034,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       },
       "dependencies": {
         "es6-promise": {
@@ -4049,11 +4049,11 @@
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -4061,8 +4061,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -4070,10 +4070,10 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -4091,10 +4091,10 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "esprima": {
@@ -4107,7 +4107,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -4125,22 +4125,22 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       },
       "dependencies": {
         "map-stream": {
@@ -4165,7 +4165,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
-        "original": "1.0.1"
+        "original": ">=0.0.5"
       }
     },
     "evp_bytestokey": {
@@ -4173,8 +4173,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exec-buffer": {
@@ -4183,11 +4183,11 @@
       "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
       "optional": true,
       "requires": {
-        "execa": "0.7.0",
-        "p-finally": "1.0.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2",
-        "tempfile": "2.0.0"
+        "execa": "^0.7.0",
+        "p-finally": "^1.0.0",
+        "pify": "^3.0.0",
+        "rimraf": "^2.5.4",
+        "tempfile": "^2.0.0"
       },
       "dependencies": {
         "tempfile": {
@@ -4196,8 +4196,8 @@
           "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
           "optional": true,
           "requires": {
-            "temp-dir": "1.0.0",
-            "uuid": "3.2.1"
+            "temp-dir": "^1.0.0",
+            "uuid": "^3.0.1"
           }
         }
       }
@@ -4208,8 +4208,8 @@
       "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
       "optional": true,
       "requires": {
-        "async-each-series": "1.1.0",
-        "object-assign": "4.1.1"
+        "async-each-series": "^1.1.0",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "async-each-series": {
@@ -4225,13 +4225,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "execall": {
@@ -4239,7 +4239,7 @@
       "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "requires": {
-        "clone-regexp": "1.0.1"
+        "clone-regexp": "^1.0.0"
       }
     },
     "executable": {
@@ -4248,7 +4248,7 @@
       "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
       "optional": true,
       "requires": {
-        "meow": "3.7.0"
+        "meow": "^3.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -4263,8 +4263,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "optional": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -4273,8 +4273,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "optional": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "get-stdin": {
@@ -4289,7 +4289,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "optional": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -4298,11 +4298,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -4316,16 +4316,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "optional": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "parse-json": {
@@ -4334,7 +4334,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "optional": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -4343,7 +4343,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "optional": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -4352,9 +4352,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -4368,9 +4368,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "optional": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -4379,8 +4379,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "optional": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -4389,8 +4389,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "optional": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -4399,7 +4399,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "optional": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -4408,7 +4408,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "optional": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -4434,7 +4434,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -4442,7 +4442,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-tilde": {
@@ -4450,7 +4450,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "express": {
@@ -4458,36 +4458,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.4",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -4512,7 +4512,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "extglob": {
@@ -4520,7 +4520,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -4544,10 +4544,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -4562,9 +4562,9 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "requires": {
-        "ansi-gray": "0.1.1",
-        "color-support": "1.1.3",
-        "time-stamp": "1.1.0"
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "time-stamp": "^1.0.0"
       }
     },
     "fast-deep-equal": {
@@ -4577,12 +4577,12 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.1.0",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.0",
-        "merge2": "1.2.2",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.0.1",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.1",
+        "micromatch": "^3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -4600,16 +4600,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4617,7 +4617,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -4627,8 +4627,8 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "expand-brackets": {
@@ -4636,13 +4636,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -4650,7 +4650,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -4658,7 +4658,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-descriptor": {
@@ -4666,9 +4666,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -4683,8 +4683,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -4692,7 +4692,7 @@
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -4702,14 +4702,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -4717,7 +4717,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -4725,7 +4725,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -4735,10 +4735,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4746,7 +4746,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -4756,8 +4756,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -4765,7 +4765,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -4775,7 +4775,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4783,7 +4783,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4793,7 +4793,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4801,7 +4801,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4816,7 +4816,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -4824,7 +4824,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4832,7 +4832,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4842,7 +4842,7 @@
           "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
           "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "requires": {
-            "is-number": "4.0.0"
+            "is-number": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -4872,19 +4872,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "nanomatch": {
@@ -4892,18 +4892,18 @@
           "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
           "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-odd": "2.0.0",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "to-regex": {
@@ -4911,10 +4911,10 @@
           "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           },
           "dependencies": {
             "regex-not": {
@@ -4922,8 +4922,8 @@
               "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
               "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
               "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
               }
             }
           }
@@ -4940,7 +4940,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fbjs": {
@@ -4948,13 +4948,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.18"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
       },
       "dependencies": {
         "promise": {
@@ -4962,7 +4962,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "2.0.6"
+            "asap": "~2.0.3"
           }
         }
       }
@@ -4972,7 +4972,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -4981,8 +4981,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "optional": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -4990,8 +4990,8 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-type": {
@@ -5014,9 +5014,9 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "requires": {
-        "filename-reserved-regex": "1.0.0",
-        "strip-outer": "1.0.0",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^1.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "filesize": {
@@ -5029,11 +5029,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "3.0.0",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -5042,12 +5042,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       }
     },
     "find-index": {
@@ -5060,7 +5060,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "find-versions": {
@@ -5069,10 +5069,10 @@
       "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
       "optional": true,
       "requires": {
-        "array-uniq": "1.0.3",
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0",
-        "semver-regex": "1.0.0"
+        "array-uniq": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "meow": "^3.5.0",
+        "semver-regex": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -5087,8 +5087,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "optional": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -5097,8 +5097,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "optional": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "get-stdin": {
@@ -5112,7 +5112,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "optional": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -5121,11 +5121,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -5139,16 +5139,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "optional": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "parse-json": {
@@ -5157,7 +5157,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "optional": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -5166,7 +5166,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "optional": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -5175,9 +5175,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -5191,9 +5191,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "optional": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -5202,8 +5202,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "optional": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -5212,8 +5212,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "optional": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -5222,7 +5222,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "optional": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -5231,7 +5231,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "optional": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -5247,10 +5247,10 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "requires": {
-        "detect-file": "1.0.0",
-        "is-glob": "3.1.0",
-        "micromatch": "3.1.5",
-        "resolve-dir": "1.0.1"
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -5268,17 +5268,17 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
           "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.1"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           }
         },
         "expand-brackets": {
@@ -5286,13 +5286,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -5300,7 +5300,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -5310,14 +5310,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "fill-range": {
@@ -5325,10 +5325,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -5336,7 +5336,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5344,7 +5344,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5354,7 +5354,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5362,7 +5362,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5372,9 +5372,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -5394,7 +5394,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "is-number": {
@@ -5402,7 +5402,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5410,7 +5410,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5430,19 +5430,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
           "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.0",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.7",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.0",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "extglob": "^2.0.2",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.0",
+            "nanomatch": "^1.2.5",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         }
       }
@@ -5452,11 +5452,11 @@
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "is-plain-object": "2.0.4",
-        "object.defaults": "1.1.0",
-        "object.pick": "1.3.0",
-        "parse-filepath": "1.0.2"
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
       }
     },
     "first-chunk-stream": {
@@ -5474,10 +5474,10 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       },
       "dependencies": {
         "del": {
@@ -5485,13 +5485,13 @@
           "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.1",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "globby": {
@@ -5499,12 +5499,12 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -5519,7 +5519,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
       "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5537,7 +5537,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "1.1.3"
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -5550,7 +5550,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -5573,9 +5573,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "formatio": {
@@ -5583,7 +5583,7 @@
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "forwarded": {
@@ -5596,7 +5596,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -5614,11 +5614,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -5632,8 +5632,8 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5655,8 +5655,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -5667,7 +5667,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5721,7 +5721,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -5734,14 +5734,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -5749,12 +5749,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -5767,7 +5767,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -5775,7 +5775,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -5783,8 +5783,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -5800,7 +5800,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -5812,7 +5812,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5823,8 +5823,8 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -5832,7 +5832,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -5852,9 +5852,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5862,16 +5862,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -5879,8 +5879,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -5893,8 +5893,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -5902,10 +5902,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5921,7 +5921,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -5939,8 +5939,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -5958,10 +5958,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5976,13 +5976,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -5990,7 +5990,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -6026,9 +6026,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -6036,14 +6036,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -6056,13 +6056,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -6075,7 +6075,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -6093,10 +6093,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -6109,14 +6109,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "string-width": {
@@ -6124,9 +6124,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -6136,7 +6136,7 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "requires": {
-        "globule": "0.1.0"
+        "globule": "~0.1.0"
       }
     },
     "get-caller-file": {
@@ -6149,7 +6149,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "requires": {
-        "rc": "1.2.8"
+        "rc": "^1.1.2"
       }
     },
     "get-stdin": {
@@ -6172,7 +6172,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gifsicle": {
@@ -6181,9 +6181,9 @@
       "integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
       "optional": true,
       "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "gift": {
@@ -6191,7 +6191,7 @@
       "resolved": "https://registry.npmjs.org/gift/-/gift-0.6.1.tgz",
       "integrity": "sha1-wWmOa2iHFk7ZeKAQlUI8/2W4558=",
       "requires": {
-        "underscore": "1.8.3"
+        "underscore": "1.x.x"
       }
     },
     "glob": {
@@ -6199,12 +6199,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -6212,8 +6212,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -6221,7 +6221,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "glob-stream": {
@@ -6229,12 +6229,12 @@
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "requires": {
-        "glob": "4.5.3",
-        "glob2base": "0.0.12",
-        "minimatch": "2.0.10",
-        "ordered-read-streams": "0.1.0",
-        "through2": "0.6.5",
-        "unique-stream": "1.0.0"
+        "glob": "^4.3.1",
+        "glob2base": "^0.0.12",
+        "minimatch": "^2.0.1",
+        "ordered-read-streams": "^0.1.0",
+        "through2": "^0.6.1",
+        "unique-stream": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -6242,10 +6242,10 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "isarray": {
@@ -6258,18 +6258,18 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "1.1.9"
+            "brace-expansion": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6282,8 +6282,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -6298,7 +6298,7 @@
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "requires": {
-        "gaze": "0.5.2"
+        "gaze": "^0.5.1"
       }
     },
     "glob2base": {
@@ -6306,7 +6306,7 @@
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "requires": {
-        "find-index": "0.1.1"
+        "find-index": "^0.1.1"
       }
     },
     "global": {
@@ -6314,8 +6314,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "global-dirs": {
@@ -6323,7 +6323,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "global-modules": {
@@ -6331,9 +6331,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.1",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -6341,11 +6341,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.1",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globby": {
@@ -6353,11 +6353,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6377,9 +6377,9 @@
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "requires": {
-        "glob": "3.1.21",
-        "lodash": "1.0.2",
-        "minimatch": "0.2.14"
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
       },
       "dependencies": {
         "glob": {
@@ -6387,9 +6387,9 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           }
         },
         "graceful-fs": {
@@ -6412,8 +6412,8 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -6423,7 +6423,7 @@
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "^1.0.0"
       }
     },
     "gonzales-pe": {
@@ -6431,7 +6431,7 @@
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
       "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
       "requires": {
-        "minimist": "1.1.3"
+        "minimist": "1.1.x"
       },
       "dependencies": {
         "minimist": {
@@ -6446,21 +6446,21 @@
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.1",
+        "duplexer2": "^0.1.4",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "node-status-codes": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "parse-json": "^2.1.0",
+        "pinkie-promise": "^2.0.0",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.5",
+        "timed-out": "^3.0.0",
+        "unzip-response": "^1.0.2",
+        "url-parse-lax": "^1.0.0"
       },
       "dependencies": {
         "duplexer2": {
@@ -6468,7 +6468,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.2"
           }
         },
         "parse-json": {
@@ -6476,7 +6476,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         }
       }
@@ -6496,19 +6496,19 @@
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "requires": {
-        "archy": "1.0.0",
-        "chalk": "1.1.3",
-        "deprecated": "0.0.1",
-        "gulp-util": "3.0.8",
-        "interpret": "1.1.0",
-        "liftoff": "2.5.0",
-        "minimist": "1.2.0",
-        "orchestrator": "0.3.8",
-        "pretty-hrtime": "1.0.3",
-        "semver": "4.3.6",
-        "tildify": "1.2.0",
-        "v8flags": "2.1.1",
-        "vinyl-fs": "0.3.14"
+        "archy": "^1.0.0",
+        "chalk": "^1.0.0",
+        "deprecated": "^0.0.1",
+        "gulp-util": "^3.0.0",
+        "interpret": "^1.0.0",
+        "liftoff": "^2.1.0",
+        "minimist": "^1.1.0",
+        "orchestrator": "^0.3.0",
+        "pretty-hrtime": "^1.0.0",
+        "semver": "^4.1.0",
+        "tildify": "^1.0.0",
+        "v8flags": "^2.0.2",
+        "vinyl-fs": "^0.3.0"
       },
       "dependencies": {
         "semver": {
@@ -6523,12 +6523,12 @@
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-5.0.0.tgz",
       "integrity": "sha1-gjfCeKaXdScKHK/n1vEBz81YVUQ=",
       "requires": {
-        "autoprefixer": "8.5.0",
-        "fancy-log": "1.3.2",
-        "plugin-error": "1.0.1",
-        "postcss": "6.0.17",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "autoprefixer": "^8.0.0",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^1.0.1",
+        "postcss": "^6.0.1",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -6541,8 +6541,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -6550,7 +6550,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "plugin-error": {
@@ -6558,10 +6558,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "1.0.1",
-            "arr-diff": "4.0.0",
-            "arr-union": "3.1.0",
-            "extend-shallow": "3.0.2"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         }
       }
@@ -6571,11 +6571,11 @@
       "resolved": "https://registry.npmjs.org/gulp-bump/-/gulp-bump-3.1.1.tgz",
       "integrity": "sha512-4lVWz2L/8G2lYBjYGzql2BiVIa1Mml03YcHQc1pERk8jH/8nZbrdQ8dHABDnAcBNP4rKAh9AVycjNJ4/4AHkwQ==",
       "requires": {
-        "bump-regex": "3.1.1",
-        "plugin-error": "0.1.2",
-        "plugin-log": "0.1.0",
-        "semver": "5.5.0",
-        "through2": "2.0.3"
+        "bump-regex": "^3.1.1",
+        "plugin-error": "^0.1.2",
+        "plugin-log": "^0.1.0",
+        "semver": "^5.3.0",
+        "through2": "^2.0.1"
       }
     },
     "gulp-clean": {
@@ -6583,11 +6583,11 @@
       "resolved": "https://registry.npmjs.org/gulp-clean/-/gulp-clean-0.4.0.tgz",
       "integrity": "sha512-DARK8rNMo4lHOFLGTiHEJdf19GuoBDHqGUaypz+fOhrvOs3iFO7ntdYtdpNxv+AzSJBx/JfypF0yEj9ks1IStQ==",
       "requires": {
-        "fancy-log": "1.3.2",
-        "plugin-error": "0.1.2",
-        "rimraf": "2.6.2",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^0.1.2",
+        "rimraf": "^2.6.2",
+        "through2": "^2.0.3",
+        "vinyl": "^2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -6610,12 +6610,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -6625,9 +6625,9 @@
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "requires": {
-        "concat-with-sourcemaps": "1.1.0",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "concat-with-sourcemaps": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^2.0.0"
       },
       "dependencies": {
         "clone": {
@@ -6650,12 +6650,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -6665,13 +6665,13 @@
       "resolved": "https://registry.npmjs.org/gulp-cssmin/-/gulp-cssmin-0.2.0.tgz",
       "integrity": "sha1-h6s8ad05sg1dljVcZQStakR7HnI=",
       "requires": {
-        "clean-css": "3.4.28",
-        "filesize": "2.0.4",
-        "graceful-fs": "4.1.11",
-        "gulp-rename": "1.1.0",
-        "gulp-util": "2.2.20",
+        "clean-css": "^3.1.9",
+        "filesize": "~2.0.0",
+        "graceful-fs": "~4.1.4",
+        "gulp-rename": "~1.1.0",
+        "gulp-util": "~2.2.0",
         "map-stream": "0.0.4",
-        "temp-write": "0.1.1"
+        "temp-write": "~0.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6689,11 +6689,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "gulp-rename": {
@@ -6701,7 +6701,7 @@
           "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.1.0.tgz",
           "integrity": "sha1-kwkKqvTThsB/IFOKaIjxXvunJ6E=",
           "requires": {
-            "map-stream": "0.0.4"
+            "map-stream": ">=0.0.4"
           }
         },
         "gulp-util": {
@@ -6709,14 +6709,14 @@
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "requires": {
-            "chalk": "0.5.1",
-            "dateformat": "1.0.11",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.template": "2.4.1",
-            "minimist": "0.2.0",
-            "multipipe": "0.1.2",
-            "through2": "0.5.1",
-            "vinyl": "0.2.3"
+            "chalk": "^0.5.0",
+            "dateformat": "^1.0.7-1.2.3",
+            "lodash._reinterpolate": "^2.4.1",
+            "lodash.template": "^2.4.1",
+            "minimist": "^0.2.0",
+            "multipipe": "^0.1.0",
+            "through2": "^0.5.0",
+            "vinyl": "^0.2.1"
           }
         },
         "has-ansi": {
@@ -6724,7 +6724,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "isarray": {
@@ -6742,9 +6742,9 @@
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "requires": {
-            "lodash._escapehtmlchar": "2.4.1",
-            "lodash._reunescapedhtml": "2.4.1",
-            "lodash.keys": "2.4.1"
+            "lodash._escapehtmlchar": "~2.4.1",
+            "lodash._reunescapedhtml": "~2.4.1",
+            "lodash.keys": "~2.4.1"
           }
         },
         "lodash.keys": {
@@ -6752,9 +6752,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         },
         "lodash.template": {
@@ -6762,13 +6762,13 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "requires": {
-            "lodash._escapestringchar": "2.4.1",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.defaults": "2.4.1",
-            "lodash.escape": "2.4.1",
-            "lodash.keys": "2.4.1",
-            "lodash.templatesettings": "2.4.1",
-            "lodash.values": "2.4.1"
+            "lodash._escapestringchar": "~2.4.1",
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.defaults": "~2.4.1",
+            "lodash.escape": "~2.4.1",
+            "lodash.keys": "~2.4.1",
+            "lodash.templatesettings": "~2.4.1",
+            "lodash.values": "~2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -6776,8 +6776,8 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "requires": {
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.escape": "2.4.1"
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.escape": "~2.4.1"
           }
         },
         "minimist": {
@@ -6790,10 +6790,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6806,7 +6806,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -6819,8 +6819,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "3.0.0"
+            "readable-stream": "~1.0.17",
+            "xtend": "~3.0.0"
           }
         },
         "vinyl": {
@@ -6828,7 +6828,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "requires": {
-            "clone-stats": "0.0.1"
+            "clone-stats": "~0.0.1"
           }
         },
         "xtend": {
@@ -6843,10 +6843,10 @@
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "requires": {
-        "archive-type": "3.2.0",
-        "decompress": "3.0.0",
-        "gulp-util": "3.0.8",
-        "readable-stream": "2.3.3"
+        "archive-type": "^3.0.0",
+        "decompress": "^3.0.0",
+        "gulp-util": "^3.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "gulp-filter": {
@@ -6854,9 +6854,9 @@
       "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
       "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
       "requires": {
-        "multimatch": "2.1.0",
-        "plugin-error": "0.1.2",
-        "streamfilter": "1.0.7"
+        "multimatch": "^2.0.0",
+        "plugin-error": "^0.1.2",
+        "streamfilter": "^1.0.5"
       }
     },
     "gulp-gh-pages": {
@@ -6864,12 +6864,12 @@
       "resolved": "https://registry.npmjs.org/gulp-gh-pages/-/gulp-gh-pages-0.5.4.tgz",
       "integrity": "sha1-pnMspHWrm1pTJTwcJHNMQMIbZUY=",
       "requires": {
-        "gift": "0.6.1",
-        "gulp-util": "3.0.8",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.2",
-        "vinyl-fs": "2.4.4",
-        "wrap-promise": "1.0.1"
+        "gift": "^0.6.1",
+        "gulp-util": "^3.0.7",
+        "readable-stream": "^2.0.2",
+        "rimraf": "^2.4.3",
+        "vinyl-fs": "^2.2.1",
+        "wrap-promise": "^1.0.1"
       },
       "dependencies": {
         "glob": {
@@ -6877,11 +6877,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -6889,8 +6889,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           }
         },
         "glob-stream": {
@@ -6898,14 +6898,14 @@
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "requires": {
-            "extend": "3.0.1",
-            "glob": "5.0.15",
-            "glob-parent": "3.1.0",
-            "micromatch": "2.3.11",
-            "ordered-read-streams": "0.3.0",
-            "through2": "0.6.5",
-            "to-absolute-glob": "0.1.1",
-            "unique-stream": "2.2.1"
+            "extend": "^3.0.0",
+            "glob": "^5.0.3",
+            "glob-parent": "^3.0.0",
+            "micromatch": "^2.3.7",
+            "ordered-read-streams": "^0.3.0",
+            "through2": "^0.6.0",
+            "to-absolute-glob": "^0.1.1",
+            "unique-stream": "^2.0.2"
           },
           "dependencies": {
             "readable-stream": {
@@ -6913,10 +6913,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "through2": {
@@ -6924,8 +6924,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
               }
             }
           }
@@ -6935,11 +6935,11 @@
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "requires": {
-            "convert-source-map": "1.5.1",
-            "graceful-fs": "4.1.11",
-            "strip-bom": "2.0.0",
-            "through2": "2.0.3",
-            "vinyl": "1.2.0"
+            "convert-source-map": "^1.1.1",
+            "graceful-fs": "^4.1.2",
+            "strip-bom": "^2.0.0",
+            "through2": "^2.0.0",
+            "vinyl": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -6952,7 +6952,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "isarray": {
@@ -6965,8 +6965,8 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "requires": {
-            "is-stream": "1.1.0",
-            "readable-stream": "2.3.3"
+            "is-stream": "^1.0.1",
+            "readable-stream": "^2.0.1"
           }
         },
         "string_decoder": {
@@ -6979,7 +6979,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "unique-stream": {
@@ -6987,8 +6987,8 @@
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
+            "json-stable-stringify": "^1.0.0",
+            "through2-filter": "^2.0.0"
           }
         },
         "vinyl": {
@@ -6996,8 +6996,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -7006,23 +7006,23 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "3.5.3",
-            "glob-stream": "5.3.5",
-            "graceful-fs": "4.1.11",
+            "duplexify": "^3.2.0",
+            "glob-stream": "^5.3.2",
+            "graceful-fs": "^4.0.0",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "0.3.0",
-            "lazystream": "1.0.0",
-            "lodash.isequal": "4.5.0",
-            "merge-stream": "1.0.1",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "readable-stream": "2.3.3",
-            "strip-bom": "2.0.0",
-            "strip-bom-stream": "1.0.0",
-            "through2": "2.0.3",
-            "through2-filter": "2.0.0",
-            "vali-date": "1.0.0",
-            "vinyl": "1.2.0"
+            "is-valid-glob": "^0.3.0",
+            "lazystream": "^1.0.0",
+            "lodash.isequal": "^4.0.0",
+            "merge-stream": "^1.0.0",
+            "mkdirp": "^0.5.0",
+            "object-assign": "^4.0.0",
+            "readable-stream": "^2.0.4",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^1.0.0",
+            "through2": "^2.0.0",
+            "through2-filter": "^2.0.0",
+            "vali-date": "^1.0.0",
+            "vinyl": "^1.0.0"
           }
         }
       }
@@ -7032,14 +7032,14 @@
       "resolved": "https://registry.npmjs.org/gulp-git/-/gulp-git-2.6.0.tgz",
       "integrity": "sha512-//Nf/1nG03rpDI5M4AxkhNVUUBx5qLboLg5kUSERirtCXviYYvIjnVgoRskgCyP1aljycbksnX0U13o3r1ABYQ==",
       "requires": {
-        "any-shell-escape": "0.1.1",
-        "fancy-log": "1.3.2",
-        "lodash.template": "4.4.0",
-        "plugin-error": "0.1.2",
-        "require-dir": "1.0.0",
-        "strip-bom-stream": "3.0.0",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "any-shell-escape": "^0.1.1",
+        "fancy-log": "^1.3.2",
+        "lodash.template": "^4.4.0",
+        "plugin-error": "^0.1.2",
+        "require-dir": "^1.0.0",
+        "strip-bom-stream": "^3.0.0",
+        "through2": "^2.0.3",
+        "vinyl": "^2.0.1"
       },
       "dependencies": {
         "clone": {
@@ -7057,7 +7057,7 @@
           "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.2"
           }
         },
         "lodash.template": {
@@ -7065,8 +7065,8 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.templatesettings": "4.1.0"
+            "lodash._reinterpolate": "~3.0.0",
+            "lodash.templatesettings": "^4.0.0"
           }
         },
         "lodash.templatesettings": {
@@ -7074,7 +7074,7 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "requires": {
-            "lodash._reinterpolate": "3.0.0"
+            "lodash._reinterpolate": "~3.0.0"
           }
         },
         "replace-ext": {
@@ -7087,8 +7087,8 @@
           "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
           "integrity": "sha1-lWvMXYRDD2klapDtgjdlzYWOFZw=",
           "requires": {
-            "first-chunk-stream": "2.0.0",
-            "strip-bom-buf": "1.0.0"
+            "first-chunk-stream": "^2.0.0",
+            "strip-bom-buf": "^1.0.0"
           }
         },
         "vinyl": {
@@ -7096,12 +7096,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -7111,9 +7111,9 @@
       "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "requires": {
-        "gulp-match": "1.0.3",
-        "ternary-stream": "2.0.1",
-        "through2": "2.0.3"
+        "gulp-match": "^1.0.3",
+        "ternary-stream": "^2.0.1",
+        "through2": "^2.0.1"
       }
     },
     "gulp-imagemin": {
@@ -7121,17 +7121,17 @@
       "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-4.1.0.tgz",
       "integrity": "sha512-6nWkrMNY5ub+34+DwlgQdWg21Z4DWAOARLpnyuZ773pGPJrfiyQrkOzdz9DgQSGBQjU1zuw6gd+9clLi6eicuw==",
       "requires": {
-        "chalk": "2.3.0",
-        "fancy-log": "1.3.2",
-        "imagemin": "5.3.1",
-        "imagemin-gifsicle": "5.2.0",
-        "imagemin-jpegtran": "5.0.2",
-        "imagemin-optipng": "5.2.1",
-        "imagemin-svgo": "6.0.0",
-        "plugin-error": "0.1.2",
-        "plur": "2.1.2",
-        "pretty-bytes": "4.0.2",
-        "through2-concurrent": "1.1.1"
+        "chalk": "^2.1.0",
+        "fancy-log": "^1.3.2",
+        "imagemin": "^5.3.1",
+        "imagemin-gifsicle": "^5.2.0",
+        "imagemin-jpegtran": "^5.0.2",
+        "imagemin-optipng": "^5.2.1",
+        "imagemin-svgo": "^6.0.0",
+        "plugin-error": "^0.1.2",
+        "plur": "^2.1.2",
+        "pretty-bytes": "^4.0.2",
+        "through2-concurrent": "^1.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7139,7 +7139,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -7147,9 +7147,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -7157,7 +7157,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -7167,14 +7167,14 @@
       "resolved": "https://registry.npmjs.org/gulp-lintspaces/-/gulp-lintspaces-1.0.0.tgz",
       "integrity": "sha512-Lt/weXK2PnyqN0C3ncGltJviKgYSlCfzOZI03tdTfQvHFvNd8EM556mdrj5lCdUtuRhRFN79WNFr9lEvRcm+ww==",
       "requires": {
-        "ansi-colors": "1.1.0",
-        "app-root-path": "1.4.0",
-        "colors": "1.1.2",
-        "event-stream": "3.3.4",
-        "lintspaces": "0.5.1",
-        "log-symbols": "1.0.2",
-        "path": "0.11.14",
-        "plugin-error": "1.0.1"
+        "ansi-colors": "^1.1.0",
+        "app-root-path": "^1.0.0",
+        "colors": "^1.0.3",
+        "event-stream": "^3.1.1",
+        "lintspaces": "^0.5.0",
+        "log-symbols": "^1.0.2",
+        "path": "^0.11.14",
+        "plugin-error": "^1.0.1"
       },
       "dependencies": {
         "ansi-colors": {
@@ -7182,7 +7182,7 @@
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
           "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
           "requires": {
-            "ansi-wrap": "0.1.0"
+            "ansi-wrap": "^0.1.0"
           }
         },
         "arr-diff": {
@@ -7195,8 +7195,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -7204,7 +7204,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "plugin-error": {
@@ -7212,10 +7212,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "1.1.0",
-            "arr-diff": "4.0.0",
-            "arr-union": "3.1.0",
-            "extend-shallow": "3.0.2"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         }
       }
@@ -7225,7 +7225,7 @@
       "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.3"
       }
     },
     "gulp-plumber": {
@@ -7234,10 +7234,10 @@
       "integrity": "sha512-L/LJftsbKoHbVj6dN5pvMsyJn9jYI0wT0nMg3G6VZhDac4NesezecYTi8/48rHi+yEic3sUpw6jlSc7qNWh32A==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "fancy-log": "1.3.2",
-        "plugin-error": "0.1.2",
-        "through2": "2.0.3"
+        "chalk": "^1.1.3",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^0.1.2",
+        "through2": "^2.0.3"
       }
     },
     "gulp-postcss": {
@@ -7245,11 +7245,11 @@
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.1.tgz",
       "integrity": "sha1-Pxw22xGXFAw5nCUt3/M5EpY445U=",
       "requires": {
-        "fancy-log": "1.3.2",
-        "plugin-error": "0.1.2",
-        "postcss": "6.0.17",
-        "postcss-load-config": "1.2.0",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^0.1.2",
+        "postcss": "^6.0.0",
+        "postcss-load-config": "^1.2.0",
+        "vinyl-sourcemaps-apply": "^0.2.1"
       }
     },
     "gulp-rename": {
@@ -7262,14 +7262,14 @@
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-4.0.1.tgz",
       "integrity": "sha512-OMQEgWNggpog8Tc5v1MuI6eo+5iiPkVeLL76iBhDoEEScLUPfZlpvzmgTnLkpcqdrNodZxpz5qcv6mS2rulk3g==",
       "requires": {
-        "chalk": "2.4.1",
-        "lodash.clonedeep": "4.5.0",
-        "node-sass": "4.9.2",
-        "plugin-error": "1.0.1",
-        "replace-ext": "1.0.0",
-        "strip-ansi": "4.0.0",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "chalk": "^2.3.0",
+        "lodash.clonedeep": "^4.3.2",
+        "node-sass": "^4.8.3",
+        "plugin-error": "^1.0.1",
+        "replace-ext": "^1.0.0",
+        "strip-ansi": "^4.0.0",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7282,7 +7282,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "arr-diff": {
@@ -7295,9 +7295,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "extend-shallow": {
@@ -7305,8 +7305,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "has-flag": {
@@ -7319,7 +7319,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "plugin-error": {
@@ -7327,10 +7327,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "1.0.1",
-            "arr-diff": "4.0.0",
-            "arr-union": "3.1.0",
-            "extend-shallow": "3.0.2"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         },
         "replace-ext": {
@@ -7343,7 +7343,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -7351,7 +7351,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7362,11 +7362,11 @@
       "integrity": "sha512-5NgvOYE8OrYj3hmxL4Tf79qdxRTJXe2UdAM+L6R/qu4h9ZPvoujtPYk/CmpNReuBJdDXR2DNWeq6t58NFARYUA==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4",
-        "safe-buffer": "5.1.1",
-        "slash": "2.0.0",
-        "through2": "2.0.3"
+        "glob": "^7.1.2",
+        "minimatch": "^3.0.4",
+        "safe-buffer": "^5.1.1",
+        "slash": "^2.0.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "slash": {
@@ -7382,13 +7382,13 @@
       "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.6.5.tgz",
       "integrity": "sha512-f3m1WcS0o2B72/PGj1Jbv9zYR9rynBh/EQJv64n01xQUo7j7anols0eww9GG/WtDTzGVQLrupVDYkifRFnj5Zg==",
       "requires": {
-        "async": "2.6.0",
-        "chalk": "2.3.0",
-        "fancy-log": "1.3.2",
-        "lodash": "4.17.5",
-        "lodash.template": "4.4.0",
-        "plugin-error": "0.1.2",
-        "through2": "2.0.3"
+        "async": "^2.1.5",
+        "chalk": "^2.3.0",
+        "fancy-log": "^1.3.2",
+        "lodash": "^4.17.4",
+        "lodash.template": "^4.4.0",
+        "plugin-error": "^0.1.2",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7396,7 +7396,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "async": {
@@ -7404,7 +7404,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "^4.14.0"
           }
         },
         "chalk": {
@@ -7412,9 +7412,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "lodash.template": {
@@ -7422,8 +7422,8 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.templatesettings": "4.1.0"
+            "lodash._reinterpolate": "~3.0.0",
+            "lodash.templatesettings": "^4.0.0"
           }
         },
         "lodash.templatesettings": {
@@ -7431,7 +7431,7 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "requires": {
-            "lodash._reinterpolate": "3.0.0"
+            "lodash._reinterpolate": "~3.0.0"
           }
         },
         "supports-color": {
@@ -7439,7 +7439,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -7449,17 +7449,17 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz",
       "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
       "requires": {
-        "@gulp-sourcemaps/identity-map": "1.0.1",
-        "@gulp-sourcemaps/map-sources": "1.0.0",
-        "acorn": "5.4.1",
-        "convert-source-map": "1.5.1",
-        "css": "2.2.3",
-        "debug-fabulous": "1.0.0",
-        "detect-newline": "2.1.0",
-        "graceful-fs": "4.1.11",
-        "source-map": "0.6.1",
-        "strip-bom-string": "1.0.0",
-        "through2": "2.0.3"
+        "@gulp-sourcemaps/identity-map": "1.X",
+        "@gulp-sourcemaps/map-sources": "1.X",
+        "acorn": "5.X",
+        "convert-source-map": "1.X",
+        "css": "2.X",
+        "debug-fabulous": "1.X",
+        "detect-newline": "2.X",
+        "graceful-fs": "4.X",
+        "source-map": "~0.6.0",
+        "strip-bom-string": "1.X",
+        "through2": "2.X"
       },
       "dependencies": {
         "source-map": {
@@ -7474,15 +7474,15 @@
       "resolved": "https://registry.npmjs.org/gulp-stylelint/-/gulp-stylelint-7.0.0.tgz",
       "integrity": "sha512-0PI+tNTzaJz5+qO3i9Jyd04ZPSb+NCN7bZ2GaIArvbQpuyJha9p3lpWxPG+XJtrVT42bIiyLeYKPnLe7uW4dQQ==",
       "requires": {
-        "chalk": "2.4.1",
-        "deep-extend": "0.5.1",
-        "fancy-log": "1.3.2",
-        "mkdirp": "0.5.1",
-        "plugin-error": "1.0.1",
-        "promise": "8.0.1",
-        "source-map": "0.5.7",
-        "strip-ansi": "4.0.0",
-        "through2": "2.0.3"
+        "chalk": "^2.3.0",
+        "deep-extend": "^0.5.0",
+        "fancy-log": "^1.3.2",
+        "mkdirp": "^0.5.1",
+        "plugin-error": "^1.0.1",
+        "promise": "^8.0.1",
+        "source-map": "^0.5.6",
+        "strip-ansi": "^4.0.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7495,7 +7495,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "arr-diff": {
@@ -7508,9 +7508,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "deep-extend": {
@@ -7523,8 +7523,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "has-flag": {
@@ -7537,7 +7537,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "plugin-error": {
@@ -7545,10 +7545,10 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "1.0.1",
-            "arr-diff": "4.0.0",
-            "arr-union": "3.1.0",
-            "extend-shallow": "3.0.2"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         },
         "strip-ansi": {
@@ -7556,7 +7556,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -7564,7 +7564,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7575,8 +7575,8 @@
       "integrity": "sha1-pKqeJhXPEQXvVVrqhuhilswg4nM=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "svgo": "0.7.2"
+        "gulp-util": "^3.0.4",
+        "svgo": "^0.7.0"
       },
       "dependencies": {
         "coa": {
@@ -7585,7 +7585,7 @@
           "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
           "dev": true,
           "requires": {
-            "q": "1.5.1"
+            "q": "^1.1.2"
           }
         },
         "csso": {
@@ -7594,8 +7594,8 @@
           "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
           "dev": true,
           "requires": {
-            "clap": "1.2.3",
-            "source-map": "0.5.7"
+            "clap": "^1.0.9",
+            "source-map": "^0.5.3"
           }
         },
         "esprima": {
@@ -7610,8 +7610,8 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         },
         "svgo": {
@@ -7620,13 +7620,13 @@
           "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
           "dev": true,
           "requires": {
-            "coa": "1.0.4",
-            "colors": "1.1.2",
-            "csso": "2.3.2",
-            "js-yaml": "3.7.0",
-            "mkdirp": "0.5.1",
-            "sax": "1.2.4",
-            "whet.extend": "0.9.9"
+            "coa": "~1.0.1",
+            "colors": "~1.1.2",
+            "csso": "~2.3.1",
+            "js-yaml": "~3.7.0",
+            "mkdirp": "~0.5.1",
+            "sax": "~1.2.1",
+            "whet.extend": "~0.9.9"
           }
         }
       }
@@ -7636,10 +7636,10 @@
       "resolved": "https://registry.npmjs.org/gulp-tag-version/-/gulp-tag-version-1.3.1.tgz",
       "integrity": "sha512-bt1LbmGeg6OaiKEdQ+hmi9KeawTXYnunDVCd9cvNoVT89KKXyZEEdR2DCSFR8zk+nunatRnSD3Zaa4R9JGC4Tw==",
       "requires": {
-        "ansi-colors": "1.0.1",
-        "fancy-log": "1.3.2",
-        "gulp-git": "2.6.0",
-        "map-stream": "0.1.0"
+        "ansi-colors": "~1.0.1",
+        "fancy-log": "~1.3.2",
+        "gulp-git": "^2.4.2",
+        "map-stream": "~0.1.0"
       },
       "dependencies": {
         "map-stream": {
@@ -7654,13 +7654,13 @@
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
       "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
       "requires": {
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash": "4.17.5",
-        "make-error-cause": "1.2.2",
-        "through2": "2.0.3",
-        "uglify-js": "3.3.10",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash": "^4.13.1",
+        "make-error-cause": "^1.1.1",
+        "through2": "^2.0.0",
+        "uglify-js": "^3.0.5",
+        "vinyl-sourcemaps-apply": "^0.2.0"
       }
     },
     "gulp-util": {
@@ -7668,24 +7668,24 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "2.2.0",
-        "fancy-log": "1.3.2",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
+        "array-differ": "^1.0.0",
+        "array-uniq": "^1.0.2",
+        "beeper": "^1.0.0",
+        "chalk": "^1.0.0",
+        "dateformat": "^2.0.0",
+        "fancy-log": "^1.1.0",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash._reescape": "^3.0.0",
+        "lodash._reevaluate": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
+        "minimist": "^1.1.0",
+        "multipipe": "^0.1.2",
+        "object-assign": "^3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
+        "through2": "^2.0.0",
+        "vinyl": "^0.5.0"
       },
       "dependencies": {
         "dateformat": {
@@ -7705,7 +7705,7 @@
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "requires": {
-        "glogg": "1.0.1"
+        "glogg": "^1.0.0"
       }
     },
     "handle-thing": {
@@ -7718,23 +7718,23 @@
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.4.0.tgz",
       "integrity": "sha512-ZxzvlGVs0lb7MW4AGxFQ/TM4rOvH6aeR4O0kj47eWy0VjGshlTZFPTighstJQPJy/bKTrlMaThn5ES87fwmGTA==",
       "requires": {
-        "accept": "3.0.2",
-        "ammo": "3.0.1",
-        "boom": "7.2.0",
-        "bounce": "1.2.0",
-        "call": "5.0.1",
-        "catbox": "10.0.2",
-        "catbox-memory": "3.1.2",
-        "heavy": "6.1.0",
-        "hoek": "5.0.3",
-        "joi": "13.3.0",
-        "mimos": "4.0.0",
-        "podium": "3.1.2",
-        "shot": "4.0.5",
-        "statehood": "6.0.6",
-        "subtext": "6.0.7",
-        "teamwork": "3.0.1",
-        "topo": "3.0.0"
+        "accept": "3.x.x",
+        "ammo": "3.x.x",
+        "boom": "7.x.x",
+        "bounce": "1.x.x",
+        "call": "5.x.x",
+        "catbox": "10.x.x",
+        "catbox-memory": "3.x.x",
+        "heavy": "6.x.x",
+        "hoek": "5.x.x",
+        "joi": "13.x.x",
+        "mimos": "4.x.x",
+        "podium": "3.x.x",
+        "shot": "4.x.x",
+        "statehood": "6.x.x",
+        "subtext": "6.x.x",
+        "teamwork": "3.x.x",
+        "topo": "3.x.x"
       },
       "dependencies": {
         "boom": {
@@ -7742,7 +7742,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -7757,8 +7757,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -7766,10 +7766,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "fast-deep-equal": {
@@ -7784,7 +7784,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -7792,7 +7792,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -7825,7 +7825,7 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "^1.0.0"
       }
     },
     "has-own-property-x": {
@@ -7834,9 +7834,9 @@
       "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
       "optional": true,
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
+        "cached-constructors-x": "^1.0.0",
+        "to-object-x": "^1.5.0",
+        "to-property-key-x": "^2.0.2"
       }
     },
     "has-symbol-support-x": {
@@ -7849,7 +7849,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "1.4.1"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -7862,9 +7862,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -7879,8 +7879,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7888,7 +7888,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7896,7 +7896,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -7906,7 +7906,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -7916,8 +7916,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -7925,8 +7925,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hasha": {
@@ -7934,8 +7934,8 @@
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hawk": {
@@ -7943,10 +7943,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -7961,9 +7961,9 @@
       "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.0.tgz",
       "integrity": "sha512-TKS9DC9NOTGulHQI31Lx+bmeWmNOstbJbGMiN3pX6bF+Zc2GKSpbbym4oasNnB6yPGkqJ9TQXXYDGohqNSJRxA==",
       "requires": {
-        "boom": "7.2.0",
-        "hoek": "5.0.3",
-        "joi": "13.3.0"
+        "boom": "7.x.x",
+        "hoek": "5.x.x",
+        "joi": "13.x.x"
       },
       "dependencies": {
         "boom": {
@@ -7971,7 +7971,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -7981,9 +7981,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.5",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -8001,7 +8001,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -8014,10 +8014,10 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.3"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       }
     },
     "html-comment-regex": {
@@ -8041,12 +8041,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-deceiver": {
@@ -8059,10 +8059,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-parser-js": {
@@ -8075,9 +8075,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.1",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -8085,10 +8085,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
-        "http-proxy": "1.17.0",
-        "is-glob": "3.1.0",
-        "lodash": "4.17.5",
-        "micromatch": "2.3.11"
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -8101,7 +8101,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -8111,9 +8111,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -8126,8 +8126,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "4.2.1",
-        "debug": "3.1.0"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -8145,7 +8145,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -8163,12 +8163,12 @@
       "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
       "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
       "requires": {
-        "file-type": "4.4.0",
-        "globby": "6.1.0",
-        "make-dir": "1.1.0",
-        "p-pipe": "1.2.0",
-        "pify": "2.3.0",
-        "replace-ext": "1.0.0"
+        "file-type": "^4.1.0",
+        "globby": "^6.1.0",
+        "make-dir": "^1.0.0",
+        "p-pipe": "^1.1.0",
+        "pify": "^2.3.0",
+        "replace-ext": "^1.0.0"
       },
       "dependencies": {
         "file-type": {
@@ -8194,9 +8194,9 @@
       "integrity": "sha512-K01m5QuPK+0en8oVhiOOAicF7KjrHlCZxS++mfLI2mV/Ksfq/Y9nCXCWDz6jRv13wwlqe5T7hXT+ji2DnLc2yQ==",
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "gifsicle": "3.0.4",
-        "is-gif": "1.0.0"
+        "exec-buffer": "^3.0.0",
+        "gifsicle": "^3.0.0",
+        "is-gif": "^1.0.0"
       }
     },
     "imagemin-jpegtran": {
@@ -8205,9 +8205,9 @@
       "integrity": "sha1-5ogiY7j3kW/duABkDPddLpcNKtY=",
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "is-jpg": "1.0.0",
-        "jpegtran-bin": "3.2.0"
+        "exec-buffer": "^3.0.0",
+        "is-jpg": "^1.0.0",
+        "jpegtran-bin": "^3.0.0"
       }
     },
     "imagemin-optipng": {
@@ -8216,9 +8216,9 @@
       "integrity": "sha1-0i2kEsCfX/AKQzmWC5ioix2+hpU=",
       "optional": true,
       "requires": {
-        "exec-buffer": "3.2.0",
-        "is-png": "1.1.0",
-        "optipng-bin": "3.1.4"
+        "exec-buffer": "^3.0.0",
+        "is-png": "^1.0.0",
+        "optipng-bin": "^3.0.0"
       }
     },
     "imagemin-svgo": {
@@ -8227,9 +8227,9 @@
       "integrity": "sha512-xwjBZQKpbkklHtJYnCOwRJjTRJA/nR0hQzKMh+CUZRvm/L0QwKKPJQ9tkPWQHrg+cydPu2i1vLgHuy2E0hKEkg==",
       "optional": true,
       "requires": {
-        "buffer-from": "0.1.1",
-        "is-svg": "2.1.0",
-        "svgo": "1.0.4"
+        "buffer-from": "^0.1.1",
+        "is-svg": "^2.0.0",
+        "svgo": "^1.0.0"
       }
     },
     "immutable": {
@@ -8247,8 +8247,8 @@
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -8287,8 +8287,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -8306,7 +8306,7 @@
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
       "requires": {
-        "meow": "3.7.0"
+        "meow": "^3.3.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8319,8 +8319,8 @@
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -8328,8 +8328,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "get-stdin": {
@@ -8342,7 +8342,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -8350,11 +8350,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -8367,16 +8367,16 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "parse-json": {
@@ -8384,7 +8384,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -8392,7 +8392,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -8400,9 +8400,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -8415,9 +8415,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -8425,8 +8425,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -8434,8 +8434,8 @@
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -8443,7 +8443,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -8451,7 +8451,7 @@
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -8471,7 +8471,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -8499,9 +8499,9 @@
       "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
       "integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
       "requires": {
-        "boom": "7.2.0",
-        "cryptiles": "4.1.1",
-        "hoek": "5.0.3"
+        "boom": "7.x.x",
+        "cryptiles": "4.x.x",
+        "hoek": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -8509,7 +8509,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         },
         "cryptiles": {
@@ -8517,7 +8517,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
           "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
           "requires": {
-            "boom": "7.2.0"
+            "boom": "7.x.x"
           }
         }
       }
@@ -8532,8 +8532,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "requires": {
-        "is-relative": "1.0.0",
-        "is-windows": "1.0.1"
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
       }
     },
     "is-accessor-descriptor": {
@@ -8541,7 +8541,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -8566,8 +8566,8 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "1.0.2",
-        "is-decimal": "1.0.2"
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       }
     },
     "is-array-buffer-x": {
@@ -8576,11 +8576,11 @@
       "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
       "optional": true,
       "requires": {
-        "attempt-x": "1.1.1",
-        "has-to-string-tag-x": "1.4.1",
-        "is-object-like-x": "1.6.0",
-        "object-get-own-property-descriptor-x": "3.2.0",
-        "to-string-tag-x": "1.4.2"
+        "attempt-x": "^1.1.0",
+        "has-to-string-tag-x": "^1.4.1",
+        "is-object-like-x": "^1.5.1",
+        "object-get-own-property-descriptor-x": "^3.2.0",
+        "to-string-tag-x": "^1.4.1"
       }
     },
     "is-arrayish": {
@@ -8593,7 +8593,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -8606,7 +8606,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-bzip2": {
@@ -8624,7 +8624,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "requires": {
-        "ci-info": "1.1.3"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -8632,7 +8632,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -8657,9 +8657,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8684,7 +8684,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -8702,7 +8702,7 @@
       "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
       "integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
       "requires": {
-        "to-boolean-x": "1.0.1"
+        "to-boolean-x": "^1.0.1"
       }
     },
     "is-finite": {
@@ -8710,7 +8710,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-finite-x": {
@@ -8719,8 +8719,8 @@
       "integrity": "sha512-HyFrxJZsgmP5RtR1PVlVvHSP4VslZOqr4uoq4x3rDrSOFaYp4R9tfmiWtAzQxPzixXhac3cYEno3NuVn0OHk2Q==",
       "optional": true,
       "requires": {
-        "infinity-x": "1.0.0",
-        "is-nan-x": "1.0.1"
+        "infinity-x": "^1.0.0",
+        "is-nan-x": "^1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -8728,7 +8728,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -8741,14 +8741,14 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
       "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
       "requires": {
-        "attempt-x": "1.1.1",
-        "has-to-string-tag-x": "1.4.1",
-        "is-falsey-x": "1.0.1",
-        "is-primitive": "2.0.0",
-        "normalize-space-x": "3.0.0",
-        "replace-comments-x": "2.0.0",
-        "to-boolean-x": "1.0.1",
-        "to-string-tag-x": "1.4.2"
+        "attempt-x": "^1.1.1",
+        "has-to-string-tag-x": "^1.4.1",
+        "is-falsey-x": "^1.0.1",
+        "is-primitive": "^2.0.0",
+        "normalize-space-x": "^3.0.0",
+        "replace-comments-x": "^2.0.0",
+        "to-boolean-x": "^1.0.1",
+        "to-string-tag-x": "^1.4.2"
       }
     },
     "is-gif": {
@@ -8762,7 +8762,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-gzip": {
@@ -8781,11 +8781,11 @@
       "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
       "optional": true,
       "requires": {
-        "math-clamp-x": "1.2.0",
-        "max-safe-integer": "1.0.1",
-        "to-integer-x": "3.0.0",
-        "to-number-x": "2.0.0",
-        "to-string-symbols-supported-x": "1.0.0"
+        "math-clamp-x": "^1.2.0",
+        "max-safe-integer": "^1.0.1",
+        "to-integer-x": "^3.0.0",
+        "to-number-x": "^2.0.0",
+        "to-string-symbols-supported-x": "^1.0.0"
       }
     },
     "is-installed-globally": {
@@ -8793,8 +8793,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-jpg": {
@@ -8818,8 +8818,8 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz",
       "integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
       "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
+        "lodash.isnull": "^3.0.0",
+        "validate.io-undefined": "^1.0.3"
       }
     },
     "is-npm": {
@@ -8832,7 +8832,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-number-like": {
@@ -8840,7 +8840,7 @@
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "requires": {
-        "lodash.isfinite": "3.3.2"
+        "lodash.isfinite": "^3.3.2"
       }
     },
     "is-obj": {
@@ -8854,8 +8854,8 @@
       "integrity": "sha512-mc3dBMv1jEOdk0f1i2RkJFsZDux0MuHqGwHOoRo770ShUOf4VE6tWThAW8dAZARr9a5RN+iNX1yzMDA5ad1clQ==",
       "optional": true,
       "requires": {
-        "is-function-x": "3.3.0",
-        "is-primitive": "2.0.0"
+        "is-function-x": "^3.3.0",
+        "is-primitive": "^2.0.0"
       }
     },
     "is-odd": {
@@ -8863,7 +8863,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
       "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "^3.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8871,7 +8871,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -8886,7 +8886,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -8894,7 +8894,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -8907,7 +8907,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8948,7 +8948,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-regexp": {
@@ -8961,7 +8961,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "requires": {
-        "is-unc-path": "1.0.0"
+        "is-unc-path": "^1.0.0"
       }
     },
     "is-retry-allowed": {
@@ -8991,7 +8991,7 @@
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "optional": true,
       "requires": {
-        "html-comment-regex": "1.1.1"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -9014,7 +9014,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.2"
       }
     },
     "is-url": {
@@ -9067,7 +9067,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
       "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "2.x.x"
       },
       "dependencies": {
         "punycode": {
@@ -9095,8 +9095,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -9109,22 +9109,22 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
       "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "requires": {
-        "bignumber.js": "2.4.0",
+        "bignumber.js": "^2.1.0",
         "bmp-js": "0.0.3",
-        "es6-promise": "3.3.1",
-        "exif-parser": "0.1.12",
-        "file-type": "3.9.0",
-        "jpeg-js": "0.2.0",
-        "load-bmfont": "1.3.0",
-        "mime": "1.6.0",
+        "es6-promise": "^3.0.2",
+        "exif-parser": "^0.1.9",
+        "file-type": "^3.1.0",
+        "jpeg-js": "^0.2.0",
+        "load-bmfont": "^1.2.3",
+        "mime": "^1.3.4",
         "mkdirp": "0.5.1",
-        "pixelmatch": "4.0.2",
-        "pngjs": "3.3.3",
-        "read-chunk": "1.0.1",
-        "request": "2.85.0",
-        "stream-to-buffer": "0.1.0",
-        "tinycolor2": "1.4.1",
-        "url-regex": "3.2.0"
+        "pixelmatch": "^4.0.0",
+        "pngjs": "^3.0.0",
+        "read-chunk": "^1.0.1",
+        "request": "^2.65.0",
+        "stream-to-buffer": "^0.1.0",
+        "tinycolor2": "^1.1.2",
+        "url-regex": "^3.0.0"
       }
     },
     "joi": {
@@ -9132,9 +9132,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.3.0.tgz",
       "integrity": "sha512-iF6jEYVfBIoYXztYymia1JfuoVbxBNuOcwdbsdoGin9/jjhBLhonKmfTQOvePss8r8v4tU4JOcNmYPHZzKEFag==",
       "requires": {
-        "hoek": "5.0.3",
-        "isemail": "3.1.2",
-        "topo": "3.0.0"
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
       }
     },
     "jpeg-js": {
@@ -9148,9 +9148,9 @@
       "integrity": "sha1-9g7PSumZwL2tLp+83ytvCYHnops=",
       "optional": true,
       "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "js-base64": {
@@ -9168,8 +9168,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -9203,7 +9203,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -9226,7 +9226,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -9284,7 +9284,7 @@
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
           "integrity": "sha1-+Rb20Q1F3BcbG+Lm5nP7bgzDXQo=",
           "requires": {
-            "lodash": "3.5.0"
+            "lodash": "~3.5.0"
           }
         }
       }
@@ -9304,7 +9304,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -9312,7 +9312,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "known-css-properties": {
@@ -9325,7 +9325,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lazy-cache": {
@@ -9333,7 +9333,7 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "lazy-req": {
@@ -9347,7 +9347,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "lcid": {
@@ -9355,7 +9355,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "liftoff": {
@@ -9363,14 +9363,14 @@
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "requires": {
-        "extend": "3.0.1",
-        "findup-sync": "2.0.0",
-        "fined": "1.1.0",
-        "flagged-respawn": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "object.map": "1.0.1",
-        "rechoir": "0.6.2",
-        "resolve": "1.5.0"
+        "extend": "^3.0.0",
+        "findup-sync": "^2.0.0",
+        "fined": "^1.0.1",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
+        "rechoir": "^0.6.2",
+        "resolve": "^1.1.7"
       }
     },
     "lighthouse-logger": {
@@ -9378,7 +9378,7 @@
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.0.1.tgz",
       "integrity": "sha1-8HPYP3rLyWcpvxAKEhyPAGmRrmE=",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.6.8"
       }
     },
     "limiter": {
@@ -9401,10 +9401,10 @@
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "1.0.4"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~1.0.4"
           }
         },
         "strip-json-comments": {
@@ -9420,12 +9420,12 @@
       "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "mime": "1.6.0",
-        "parse-bmfont-ascii": "1.0.6",
-        "parse-bmfont-binary": "1.0.6",
-        "parse-bmfont-xml": "1.1.3",
-        "xhr": "2.5.0",
-        "xtend": "4.0.1"
+        "mime": "^1.3.4",
+        "parse-bmfont-ascii": "^1.0.3",
+        "parse-bmfont-binary": "^1.0.5",
+        "parse-bmfont-xml": "^1.1.0",
+        "xhr": "^2.0.1",
+        "xtend": "^4.0.0"
       }
     },
     "load-json-file": {
@@ -9433,10 +9433,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "loader-runner": {
@@ -9449,9 +9449,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "localtunnel": {
@@ -9475,9 +9475,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "debug": {
@@ -9493,8 +9493,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -9502,11 +9502,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -9514,7 +9514,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "parse-json": {
@@ -9522,7 +9522,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -9530,7 +9530,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -9538,9 +9538,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -9553,9 +9553,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -9563,8 +9563,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "string-width": {
@@ -9572,9 +9572,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -9582,7 +9582,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
@@ -9595,19 +9595,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           }
         },
         "yargs-parser": {
@@ -9615,7 +9615,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -9625,8 +9625,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -9659,7 +9659,7 @@
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "requires": {
-        "lodash._htmlescapes": "2.4.1"
+        "lodash._htmlescapes": "~2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -9712,8 +9712,8 @@
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "requires": {
-        "lodash._htmlescapes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._htmlescapes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9721,9 +9721,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -9738,7 +9738,7 @@
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.assign": {
@@ -9761,8 +9761,8 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "requires": {
-        "lodash._objecttypes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9770,9 +9770,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -9782,7 +9782,7 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -9815,7 +9815,7 @@
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.keys": {
@@ -9823,9 +9823,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.mergewith": {
@@ -9843,15 +9843,15 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
+        "lodash._basecopy": "^3.0.0",
+        "lodash._basetostring": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.restparam": "^3.0.0",
+        "lodash.templatesettings": "^3.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -9859,8 +9859,8 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0"
       }
     },
     "lodash.values": {
@@ -9868,7 +9868,7 @@
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "requires": {
-        "lodash.keys": "2.4.1"
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9876,9 +9876,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -9888,7 +9888,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "logalot": {
@@ -9897,8 +9897,8 @@
       "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
       "optional": true,
       "requires": {
-        "figures": "1.7.0",
-        "squeak": "1.3.0"
+        "figures": "^1.3.5",
+        "squeak": "^1.0.0"
       }
     },
     "loglevel": {
@@ -9926,7 +9926,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -9934,8 +9934,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -9949,10 +9949,10 @@
       "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
       "optional": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "indent-string": "2.1.0",
-        "longest": "1.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "indent-string": "^2.1.0",
+        "longest": "^1.0.0",
+        "meow": "^3.3.0"
       },
       "dependencies": {
         "camelcase": {
@@ -9967,8 +9967,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "optional": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -9977,8 +9977,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "optional": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "get-stdin": {
@@ -9991,7 +9991,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -10000,11 +10000,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -10018,16 +10018,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "optional": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "parse-json": {
@@ -10036,7 +10036,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "optional": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -10045,7 +10045,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "optional": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -10054,9 +10054,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -10070,9 +10070,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "optional": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -10081,8 +10081,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "optional": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -10091,8 +10091,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "optional": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -10101,7 +10101,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "optional": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -10110,7 +10110,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "optional": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -10131,7 +10131,7 @@
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "~0.10.2"
       }
     },
     "make-dir": {
@@ -10139,7 +10139,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "make-error": {
@@ -10152,7 +10152,7 @@
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "requires": {
-        "make-error": "1.3.3"
+        "make-error": "^1.2.0"
       }
     },
     "make-iterator": {
@@ -10160,7 +10160,7 @@
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.1.0"
       }
     },
     "map-cache": {
@@ -10183,7 +10183,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "markdown-escapes": {
@@ -10202,7 +10202,7 @@
       "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
       "optional": true,
       "requires": {
-        "to-number-x": "2.0.0"
+        "to-number-x": "^2.0.0"
       }
     },
     "math-random": {
@@ -10216,8 +10216,8 @@
       "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
       "optional": true,
       "requires": {
-        "is-nan-x": "1.0.1",
-        "to-number-x": "2.0.0"
+        "is-nan-x": "^1.0.1",
+        "to-number-x": "^2.0.0"
       }
     },
     "mathml-tag-names": {
@@ -10236,8 +10236,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mdast-util-compact": {
@@ -10245,8 +10245,8 @@
       "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
       "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
       "requires": {
-        "unist-util-modify-children": "1.1.2",
-        "unist-util-visit": "1.3.1"
+        "unist-util-modify-children": "^1.0.0",
+        "unist-util-visit": "^1.1.0"
       }
     },
     "mdn-data": {
@@ -10264,7 +10264,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memoizee": {
@@ -10272,14 +10272,14 @@
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.11.tgz",
       "integrity": "sha1-vemBdmPJ5A/bKk6hw2cpYIeujI8=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-weak-map": "2.0.2",
-        "event-emitter": "0.3.5",
-        "is-promise": "2.1.0",
-        "lru-queue": "0.1.0",
-        "next-tick": "1.0.0",
-        "timers-ext": "0.1.2"
+        "d": "1",
+        "es5-ext": "^0.10.30",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.2"
       }
     },
     "memory-fs": {
@@ -10287,8 +10287,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -10296,15 +10296,15 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
       "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
       "requires": {
-        "camelcase-keys": "4.2.0",
-        "decamelize-keys": "1.1.0",
-        "loud-rejection": "1.6.0",
-        "minimist": "1.2.0",
-        "minimist-options": "3.0.2",
-        "normalize-package-data": "2.4.0",
-        "read-pkg-up": "3.0.0",
-        "redent": "2.0.0",
-        "trim-newlines": "2.0.0"
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist": "^1.1.3",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0"
       }
     },
     "merge": {
@@ -10322,7 +10322,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "merge2": {
@@ -10340,19 +10340,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -10360,8 +10360,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -10379,7 +10379,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -10392,8 +10392,8 @@
       "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.0.tgz",
       "integrity": "sha512-JvlvRLqGIlk+AYypWrbrDmhsM+6JVx/xBM5S3AMwTBz1trPCEoPN/swO2L4Wu653fL7oJdgk8DMQyG/Gq3JkZg==",
       "requires": {
-        "hoek": "5.0.3",
-        "mime-db": "1.33.0"
+        "hoek": "5.x.x",
+        "mime-db": "1.x.x"
       }
     },
     "min-document": {
@@ -10401,7 +10401,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -10419,12 +10419,12 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.9"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -10432,8 +10432,8 @@
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "mixin-deep": {
@@ -10441,8 +10441,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -10450,14 +10450,14 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -10465,7 +10465,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -10480,8 +10480,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "requires": {
-        "dns-packet": "1.3.1",
-        "thunky": "1.0.2"
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -10494,10 +10494,10 @@
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "multipipe": {
@@ -10523,17 +10523,17 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
       "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^1.0.0",
+        "kind-of": "^5.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -10578,8 +10578,8 @@
       "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.1.tgz",
       "integrity": "sha512-kCVtUG9JyD//tsYrZY+/Y+2gUrANVSba8y23QkM5Znx0FOxlnl9Z4OVPBODmstKWTOvigfTO+Va1VPOu3eWSOQ==",
       "requires": {
-        "hoek": "5.0.3",
-        "vise": "3.0.0"
+        "hoek": "5.x.x",
+        "vise": "3.x.x"
       }
     },
     "node-fetch": {
@@ -10587,8 +10587,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -10601,19 +10601,19 @@
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.5",
-        "request": "2.85.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.0"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -10628,28 +10628,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.10",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.4",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -10658,9 +10658,9 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.12",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "process": {
@@ -10676,7 +10676,7 @@
       "integrity": "sha1-ijbGZ4ph5dhFX+xYAJsbAnGxkJo=",
       "requires": {
         "jpeg-js": "0.2.0",
-        "pngjs": "2.2.0"
+        "pngjs": "~2.2.0"
       },
       "dependencies": {
         "pngjs": {
@@ -10691,25 +10691,25 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
       "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.3",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.1",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.10.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.10.0",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
         "request": "2.87.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0",
-        "true-case-path": "1.0.2"
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "camelcase": {
@@ -10722,8 +10722,8 @@
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "cross-spawn": {
@@ -10731,8 +10731,8 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "requires": {
-            "lru-cache": "4.1.3",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "find-up": {
@@ -10740,8 +10740,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "gaze": {
@@ -10749,7 +10749,7 @@
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
           "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
           "requires": {
-            "globule": "1.2.1"
+            "globule": "^1.0.0"
           }
         },
         "get-stdin": {
@@ -10762,9 +10762,9 @@
           "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
           "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
           "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.10",
-            "minimatch": "3.0.4"
+            "glob": "~7.1.1",
+            "lodash": "~4.17.10",
+            "minimatch": "~3.0.2"
           }
         },
         "indent-string": {
@@ -10772,7 +10772,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -10780,11 +10780,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "lodash": {
@@ -10797,8 +10797,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "map-obj": {
@@ -10811,16 +10811,16 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "parse-json": {
@@ -10828,7 +10828,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -10836,7 +10836,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -10844,9 +10844,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -10859,9 +10859,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -10869,8 +10869,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -10878,8 +10878,8 @@
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "request": {
@@ -10887,26 +10887,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.7.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.1",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "strip-bom": {
@@ -10914,7 +10914,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -10922,7 +10922,7 @@
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -10942,7 +10942,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -10950,10 +10950,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -10961,7 +10961,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -10979,9 +10979,9 @@
       "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
       "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "trim-x": "3.0.0",
-        "white-space-x": "3.0.0"
+        "cached-constructors-x": "^1.0.0",
+        "trim-x": "^3.0.0",
+        "white-space-x": "^3.0.0"
       }
     },
     "npm-run-path": {
@@ -10989,7 +10989,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -10997,10 +10997,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -11009,7 +11009,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "optional": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -11042,9 +11042,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -11052,7 +11052,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -11060,7 +11060,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-data-descriptor": {
@@ -11068,7 +11068,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-descriptor": {
@@ -11076,9 +11076,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -11096,16 +11096,16 @@
       "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
       "optional": true,
       "requires": {
-        "attempt-x": "1.1.1",
-        "has-own-property-x": "3.2.0",
-        "has-symbol-support-x": "1.4.1",
-        "is-falsey-x": "1.0.1",
-        "is-index-x": "1.1.0",
-        "is-primitive": "2.0.0",
-        "is-string": "1.0.4",
-        "property-is-enumerable-x": "1.1.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
+        "attempt-x": "^1.1.0",
+        "has-own-property-x": "^3.1.1",
+        "has-symbol-support-x": "^1.4.1",
+        "is-falsey-x": "^1.0.0",
+        "is-index-x": "^1.0.0",
+        "is-primitive": "^2.0.0",
+        "is-string": "^1.0.4",
+        "property-is-enumerable-x": "^1.1.0",
+        "to-object-x": "^1.4.1",
+        "to-property-key-x": "^2.0.1"
       }
     },
     "object-hash": {
@@ -11123,7 +11123,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -11138,10 +11138,10 @@
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "requires": {
-        "array-each": "1.0.1",
-        "array-slice": "1.1.0",
-        "for-own": "1.0.0",
-        "isobject": "3.0.1"
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "for-own": {
@@ -11149,7 +11149,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "isobject": {
@@ -11165,8 +11165,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "optional": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.map": {
@@ -11174,8 +11174,8 @@
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "requires": {
-        "for-own": "1.0.0",
-        "make-iterator": "1.0.0"
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
       },
       "dependencies": {
         "for-own": {
@@ -11183,7 +11183,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         }
       }
@@ -11193,8 +11193,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -11202,7 +11202,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -11218,10 +11218,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "optional": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "obuf": {
@@ -11247,12 +11247,12 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "openurl": {
@@ -11265,7 +11265,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optipng-bin": {
@@ -11274,9 +11274,9 @@
       "integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
       "optional": true,
       "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
       }
     },
     "orchestrator": {
@@ -11284,9 +11284,9 @@
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "requires": {
-        "end-of-stream": "0.1.5",
-        "sequencify": "0.0.7",
-        "stream-consume": "0.1.0"
+        "end-of-stream": "~0.1.5",
+        "sequencify": "~0.0.7",
+        "stream-consume": "~0.1.0"
       }
     },
     "ordered-read-streams": {
@@ -11299,7 +11299,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
       "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
       "requires": {
-        "url-parse": "1.4.3"
+        "url-parse": "~1.4.0"
       }
     },
     "os": {
@@ -11328,9 +11328,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -11343,8 +11343,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-finally": {
@@ -11357,7 +11357,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -11365,7 +11365,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -11393,10 +11393,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       },
       "dependencies": {
         "got": {
@@ -11404,17 +11404,17 @@
           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           }
         },
         "timed-out": {
@@ -11439,11 +11439,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-bmfont-ascii": {
@@ -11461,8 +11461,8 @@
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
       "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
       "requires": {
-        "xml-parse-from-string": "1.0.1",
-        "xml2js": "0.4.19"
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.4.5"
       }
     },
     "parse-entities": {
@@ -11470,12 +11470,12 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "1.2.2",
-        "character-entities-legacy": "1.1.2",
-        "character-reference-invalid": "1.1.2",
-        "is-alphanumerical": "1.0.2",
-        "is-decimal": "1.0.2",
-        "is-hexadecimal": "1.0.2"
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-filepath": {
@@ -11483,9 +11483,9 @@
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "requires": {
-        "is-absolute": "1.0.0",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-glob": {
@@ -11493,10 +11493,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-headers": {
@@ -11504,7 +11504,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "0.3.3",
+        "for-each": "^0.3.2",
         "trim": "0.0.1"
       }
     },
@@ -11513,10 +11513,10 @@
       "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
       "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "nan-x": "1.0.0",
-        "to-string-x": "1.4.2",
-        "trim-left-x": "3.0.0"
+        "cached-constructors-x": "^1.0.0",
+        "nan-x": "^1.0.0",
+        "to-string-x": "^1.4.2",
+        "trim-left-x": "^3.0.0"
       }
     },
     "parse-json": {
@@ -11524,8 +11524,8 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.1"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse-passwd": {
@@ -11538,7 +11538,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -11546,7 +11546,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -11564,14 +11564,14 @@
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-5.1.1.tgz",
       "integrity": "sha512-bO+vfFGgTVTtv89kXWGEMIPnrYhhhMtbOnJKStfIhNWUxperVjlI++1ixksi0YPCMPGuFy9W3zsKHxIITV2r2A==",
       "requires": {
-        "chalk": "1.1.3",
-        "cross-spawn": "5.1.0",
-        "fs-extra": "4.0.3",
-        "minimist": "1.2.0",
-        "rimraf": "2.6.2",
-        "slash": "1.0.0",
-        "tmp": "0.0.31",
-        "update-notifier": "2.5.0"
+        "chalk": "^1.1.3",
+        "cross-spawn": "^5.1.0",
+        "fs-extra": "^4.0.1",
+        "minimist": "^1.2.0",
+        "rimraf": "^2.6.1",
+        "slash": "^1.0.0",
+        "tmp": "^0.0.31",
+        "update-notifier": "^2.2.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -11579,9 +11579,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "jsonfile": {
@@ -11589,7 +11589,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -11639,7 +11639,7 @@
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "requires": {
-        "path-root-regex": "0.1.2"
+        "path-root-regex": "^0.1.0"
       }
     },
     "path-root-regex": {
@@ -11657,7 +11657,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "pause-stream": {
@@ -11665,7 +11665,7 @@
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -11673,11 +11673,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pend": {
@@ -11695,11 +11695,11 @@
       "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.2.tgz",
       "integrity": "sha512-HuPxmGxHsEFPWhdkwBs2gIrHhFqktIxMtudISTFN95RQ85ZZAOl8Ki6u3nnN/X8OUaGlIGldk/l8p2IR4/i76w==",
       "requires": {
-        "b64": "4.0.0",
-        "boom": "7.2.0",
-        "content": "4.0.5",
-        "hoek": "5.0.3",
-        "nigel": "3.0.1"
+        "b64": "4.x.x",
+        "boom": "7.x.x",
+        "content": "4.x.x",
+        "hoek": "5.x.x",
+        "nigel": "3.x.x"
       },
       "dependencies": {
         "boom": {
@@ -11707,7 +11707,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -11717,15 +11717,15 @@
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "requires": {
-        "es6-promise": "4.2.4",
-        "extract-zip": "1.6.7",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.85.0",
-        "request-progress": "2.0.1",
-        "which": "1.3.0"
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
       },
       "dependencies": {
         "es6-promise": {
@@ -11738,9 +11738,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         }
       }
@@ -11760,7 +11760,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pixelmatch": {
@@ -11768,7 +11768,7 @@
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "requires": {
-        "pngjs": "3.3.3"
+        "pngjs": "^3.0.0"
       }
     },
     "pkg-dir": {
@@ -11776,7 +11776,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "plugin-error": {
@@ -11784,11 +11784,11 @@
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "requires": {
-        "ansi-cyan": "0.1.1",
-        "ansi-red": "0.1.1",
-        "arr-diff": "1.1.0",
-        "arr-union": "2.1.0",
-        "extend-shallow": "1.1.4"
+        "ansi-cyan": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "arr-diff": "^1.0.1",
+        "arr-union": "^2.0.1",
+        "extend-shallow": "^1.1.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -11796,8 +11796,8 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
           }
         },
         "arr-union": {
@@ -11815,7 +11815,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -11830,8 +11830,8 @@
       "resolved": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
       "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
       "requires": {
-        "chalk": "1.1.3",
-        "dateformat": "1.0.11"
+        "chalk": "^1.1.1",
+        "dateformat": "^1.0.11"
       }
     },
     "plur": {
@@ -11839,7 +11839,7 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "requires": {
-        "irregular-plurals": "1.4.0"
+        "irregular-plurals": "^1.0.0"
       }
     },
     "pngjs": {
@@ -11852,8 +11852,8 @@
       "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.2.tgz",
       "integrity": "sha512-18VrjJAduIdPv7d9zWsfmKxTj3cQTYC5Pv5gtKxcWujYBpGbV+mhNSPYhlHW5xeWoazYyKfB9FEsPT12r5rY1A==",
       "requires": {
-        "hoek": "5.0.3",
-        "joi": "13.3.0"
+        "hoek": "5.x.x",
+        "joi": "13.x.x"
       }
     },
     "portfinder": {
@@ -11861,9 +11861,9 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "async": {
@@ -11879,7 +11879,7 @@
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
       "requires": {
         "async": "1.5.2",
-        "is-number-like": "1.0.8"
+        "is-number-like": "^1.0.3"
       },
       "dependencies": {
         "async": {
@@ -11899,9 +11899,9 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
       "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
       "requires": {
-        "chalk": "2.3.0",
-        "source-map": "0.6.1",
-        "supports-color": "5.1.0"
+        "chalk": "^2.3.0",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11909,7 +11909,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -11917,9 +11917,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11927,7 +11927,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
               "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
               }
             }
           }
@@ -11942,7 +11942,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -11952,7 +11952,7 @@
       "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.28.0.tgz",
       "integrity": "sha512-H+ucbGVR+lsZySspOApeQU9yC6Q3t75lwJYa3Im93fKAUt5DScKOSErShC0aC7USdn2jsT1LxubcC5vYu/VJYw==",
       "requires": {
-        "htmlparser2": "3.9.2"
+        "htmlparser2": "^3.9.2"
       }
     },
     "postcss-less": {
@@ -11960,7 +11960,7 @@
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-2.0.0.tgz",
       "integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.2.16"
       },
       "dependencies": {
         "has-flag": {
@@ -11973,10 +11973,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -11984,7 +11984,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -11994,10 +11994,10 @@
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "postcss-load-options": "^1.2.0",
+        "postcss-load-plugins": "^2.3.0"
       }
     },
     "postcss-load-options": {
@@ -12005,8 +12005,8 @@
       "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-load-plugins": {
@@ -12014,8 +12014,8 @@
       "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.1",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-markdown": {
@@ -12023,8 +12023,8 @@
       "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.28.0.tgz",
       "integrity": "sha512-F0Vc8eHKDKTmensntXpd35LSAoXXtykhPY+IRfn4AnN4m+irav3QawmtSWLhsmbElKna8l1/HObYnbiM/Wok9Q==",
       "requires": {
-        "remark": "9.0.0",
-        "unist-util-find-all-after": "1.0.2"
+        "remark": "^9.0.0",
+        "unist-util-find-all-after": "^1.0.2"
       }
     },
     "postcss-media-query-parser": {
@@ -12037,10 +12037,10 @@
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
       "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
       "requires": {
-        "chalk": "2.3.0",
-        "lodash": "4.17.5",
-        "log-symbols": "2.2.0",
-        "postcss": "6.0.17"
+        "chalk": "^2.0.1",
+        "lodash": "^4.17.4",
+        "log-symbols": "^2.0.0",
+        "postcss": "^6.0.8"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12048,7 +12048,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -12056,9 +12056,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "log-symbols": {
@@ -12066,7 +12066,7 @@
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "requires": {
-            "chalk": "2.3.0"
+            "chalk": "^2.0.1"
           }
         },
         "supports-color": {
@@ -12074,7 +12074,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -12089,7 +12089,7 @@
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
       "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "^6.0.6"
       }
     },
     "postcss-sass": {
@@ -12106,7 +12106,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -12114,9 +12114,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -12129,9 +12129,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.4.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         },
         "source-map": {
@@ -12144,7 +12144,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -12154,7 +12154,7 @@
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.5.tgz",
       "integrity": "sha512-gJB1tKYMkBy0MU+COt6WXA4ZiRctAKoWLa6qD7a6bbEbBMqrpa/BhfQdN80eYMV+JkKddZVEpZlOggnGShpvyg==",
       "requires": {
-        "postcss": "6.0.22"
+        "postcss": "^6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12162,7 +12162,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -12170,9 +12170,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -12185,9 +12185,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.4.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         },
         "source-map": {
@@ -12200,7 +12200,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -12210,9 +12210,9 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
       "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
       "requires": {
-        "dot-prop": "4.2.0",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "dot-prop": "^4.1.1",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-syntax": {
@@ -12265,7 +12265,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
       "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -12273,8 +12273,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "property-is-enumerable-x": {
@@ -12283,8 +12283,8 @@
       "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
       "optional": true,
       "requires": {
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
+        "to-object-x": "^1.4.1",
+        "to-property-key-x": "^2.0.1"
       }
     },
     "proxy-addr": {
@@ -12292,7 +12292,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -12316,11 +12316,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -12333,14 +12333,14 @@
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.6.1.tgz",
       "integrity": "sha512-qz6DLwK+PhlBMjJZOMOsgVCnweYLtmiqnmJYUDPT++ElMz+cQgbsCNKPw4YDVpg3RTbsRX/pqQqr20zrp0cuKw==",
       "requires": {
-        "debug": "3.1.0",
-        "extract-zip": "1.6.7",
-        "https-proxy-agent": "2.2.1",
-        "mime": "2.3.1",
-        "progress": "2.0.0",
-        "proxy-from-env": "1.0.0",
-        "rimraf": "2.6.2",
-        "ws": "5.2.2"
+        "debug": "^3.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.0",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^5.1.1"
       },
       "dependencies": {
         "debug": {
@@ -12366,7 +12366,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -12406,7 +12406,7 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "randomatic": {
@@ -12414,9 +12414,9 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -12436,7 +12436,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -12444,8 +12444,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -12477,7 +12477,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "iconv-lite": {
@@ -12497,10 +12497,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "deep-extend": {
@@ -12515,11 +12515,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "15.6.3",
-        "fbjs": "0.8.17",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
+        "create-react-class": "^15.6.0",
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       }
     },
     "react-lifecycles-compat": {
@@ -12532,10 +12532,10 @@
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
       "integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
       "requires": {
-        "exenv": "1.2.2",
-        "prop-types": "15.6.2",
-        "react-lifecycles-compat": "3.0.4",
-        "warning": "3.0.0"
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^3.0.0"
       }
     },
     "react-motion": {
@@ -12543,9 +12543,9 @@
       "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
       "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
       "requires": {
-        "performance-now": "0.2.0",
-        "prop-types": "15.6.2",
-        "raf": "3.4.0"
+        "performance-now": "^0.2.0",
+        "prop-types": "^15.5.8",
+        "raf": "^3.1.0"
       },
       "dependencies": {
         "performance-now": {
@@ -12560,12 +12560,12 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
       "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
       "requires": {
-        "hoist-non-react-statics": "2.5.5",
-        "invariant": "2.2.4",
-        "lodash": "4.17.5",
-        "lodash-es": "4.17.10",
-        "loose-envify": "1.4.0",
-        "prop-types": "15.6.2"
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
       }
     },
     "react-sticky": {
@@ -12573,8 +12573,8 @@
       "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.3.tgz",
       "integrity": "sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==",
       "requires": {
-        "prop-types": "15.6.2",
-        "raf": "3.4.0"
+        "prop-types": "^15.5.8",
+        "raf": "^3.3.0"
       }
     },
     "react-toggle-button": {
@@ -12582,8 +12582,8 @@
       "resolved": "https://registry.npmjs.org/react-toggle-button/-/react-toggle-button-2.2.0.tgz",
       "integrity": "sha1-obkhQ6oN9BRkL8sUHwh59UW8Wok=",
       "requires": {
-        "prop-types": "15.6.2",
-        "react-motion": "0.5.2"
+        "prop-types": "^15.6.0",
+        "react-motion": "^0.5.2"
       }
     },
     "read-all-stream": {
@@ -12591,8 +12591,8 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "read-chunk": {
@@ -12605,9 +12605,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "load-json-file": "4.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "3.0.0"
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
       }
     },
     "read-pkg-up": {
@@ -12615,8 +12615,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
       "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "3.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -12624,13 +12624,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -12638,10 +12638,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "rechoir": {
@@ -12649,7 +12649,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -12657,8 +12657,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "redux": {
@@ -12666,10 +12666,10 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "4.17.5",
-        "lodash-es": "4.17.10",
-        "loose-envify": "1.4.0",
-        "symbol-observable": "1.2.0"
+        "lodash": "^4.2.1",
+        "lodash-es": "^4.2.1",
+        "loose-envify": "^1.1.0",
+        "symbol-observable": "^1.0.3"
       }
     },
     "regenerator-runtime": {
@@ -12682,7 +12682,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -12690,7 +12690,7 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
       "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "registry-auth-token": {
@@ -12698,8 +12698,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -12707,7 +12707,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.8"
+        "rc": "^1.0.1"
       }
     },
     "remark": {
@@ -12715,9 +12715,9 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
       "integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
       "requires": {
-        "remark-parse": "5.0.0",
-        "remark-stringify": "5.0.0",
-        "unified": "6.2.0"
+        "remark-parse": "^5.0.0",
+        "remark-stringify": "^5.0.0",
+        "unified": "^6.0.0"
       }
     },
     "remark-parse": {
@@ -12725,21 +12725,21 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
       "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
       "requires": {
-        "collapse-white-space": "1.0.4",
-        "is-alphabetical": "1.0.2",
-        "is-decimal": "1.0.2",
-        "is-whitespace-character": "1.0.2",
-        "is-word-character": "1.0.2",
-        "markdown-escapes": "1.0.2",
-        "parse-entities": "1.1.2",
-        "repeat-string": "1.6.1",
-        "state-toggle": "1.0.1",
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
         "trim": "0.0.1",
-        "trim-trailing-lines": "1.1.1",
-        "unherit": "1.1.1",
-        "unist-util-remove-position": "1.1.2",
-        "vfile-location": "2.0.3",
-        "xtend": "4.0.1"
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "remark-stringify": {
@@ -12747,20 +12747,20 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
       "integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
       "requires": {
-        "ccount": "1.0.3",
-        "is-alphanumeric": "1.0.0",
-        "is-decimal": "1.0.2",
-        "is-whitespace-character": "1.0.2",
-        "longest-streak": "2.0.2",
-        "markdown-escapes": "1.0.2",
-        "markdown-table": "1.1.2",
-        "mdast-util-compact": "1.0.1",
-        "parse-entities": "1.1.2",
-        "repeat-string": "1.6.1",
-        "state-toggle": "1.0.1",
-        "stringify-entities": "1.3.2",
-        "unherit": "1.1.1",
-        "xtend": "4.0.1"
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^1.1.0",
+        "mdast-util-compact": "^1.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^1.0.1",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -12783,7 +12783,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-comments-x": {
@@ -12791,8 +12791,8 @@
       "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
       "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
       "requires": {
-        "require-coercible-to-string-x": "1.0.0",
-        "to-string-x": "1.4.2"
+        "require-coercible-to-string-x": "^1.0.0",
+        "to-string-x": "^1.4.2"
       }
     },
     "replace-ext": {
@@ -12805,28 +12805,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.6",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-progress": {
@@ -12834,7 +12834,7 @@
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "require-coercible-to-string-x": {
@@ -12842,8 +12842,8 @@
       "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
       "integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
       "requires": {
-        "require-object-coercible-x": "1.4.1",
-        "to-string-x": "1.4.2"
+        "require-object-coercible-x": "^1.4.1",
+        "to-string-x": "^1.4.2"
       }
     },
     "require-dir": {
@@ -12871,7 +12871,7 @@
       "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
       "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
       "requires": {
-        "is-nil-x": "1.4.1"
+        "is-nil-x": "^1.4.1"
       }
     },
     "requires-port": {
@@ -12884,7 +12884,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-cwd": {
@@ -12892,7 +12892,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-dir": {
@@ -12900,8 +12900,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -12919,8 +12919,8 @@
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "requires": {
-        "debug": "2.6.9",
-        "minimatch": "3.0.4"
+        "debug": "^2.2.0",
+        "minimatch": "^3.0.2"
       }
     },
     "ret": {
@@ -12933,7 +12933,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -12941,7 +12941,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -12949,8 +12949,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "run-sequence": {
@@ -12959,9 +12959,9 @@
       "integrity": "sha512-qkzZnQWMZjcKbh3CNly2srtrkaO/2H/SI5f2eliMCapdRD3UhMrwjfOAZJAnZ2H8Ju4aBzFZkBGXUqFs9V0yxw==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "fancy-log": "1.3.2",
-        "plugin-error": "0.1.2"
+        "chalk": "^1.1.3",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^0.1.2"
       }
     },
     "rx": {
@@ -12979,7 +12979,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -12997,7 +12997,7 @@
       "resolved": "https://registry.npmjs.org/sass-breakpoints/-/sass-breakpoints-1.0.0.tgz",
       "integrity": "sha1-LNOUbr86an+WG5XobuWiJHGgopk=",
       "requires": {
-        "sass-ems": "1.0.3"
+        "sass-ems": "^1.0.3"
       }
     },
     "sass-ems": {
@@ -13010,10 +13010,10 @@
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -13026,9 +13026,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "find-up": {
@@ -13036,8 +13036,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -13045,11 +13045,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -13057,7 +13057,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "parse-json": {
@@ -13065,7 +13065,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -13073,7 +13073,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -13081,9 +13081,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -13096,9 +13096,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -13106,8 +13106,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "string-width": {
@@ -13115,9 +13115,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -13125,7 +13125,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
@@ -13138,19 +13138,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
@@ -13158,7 +13158,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -13168,7 +13168,7 @@
       "resolved": "https://registry.npmjs.org/sass-grid/-/sass-grid-3.0.0.tgz",
       "integrity": "sha1-iFXIcPcgyaTIR2oxbbxx+as4WQE=",
       "requires": {
-        "sass-breakpoints": "1.0.0"
+        "sass-breakpoints": "^1.0.0"
       }
     },
     "sax": {
@@ -13181,8 +13181,8 @@
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "requires": {
-        "js-base64": "2.4.3",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -13190,7 +13190,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -13200,7 +13200,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -13208,7 +13208,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         }
       }
@@ -13236,7 +13236,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.0.3"
       }
     },
     "semver-regex": {
@@ -13251,7 +13251,7 @@
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "optional": true,
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.3.0"
       }
     },
     "send": {
@@ -13260,18 +13260,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -13291,13 +13291,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.18",
-        "parseurl": "1.3.2"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       }
     },
     "serve-static": {
@@ -13305,9 +13305,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -13326,7 +13326,7 @@
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -13339,10 +13339,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       }
     },
     "setimmediate": {
@@ -13360,8 +13360,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -13369,7 +13369,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -13382,8 +13382,8 @@
       "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.5.tgz",
       "integrity": "sha1-x+dFXRHWD2ts08Q+FaO0McF+VWY=",
       "requires": {
-        "hoek": "5.0.3",
-        "joi": "13.3.0"
+        "hoek": "5.x.x",
+        "joi": "13.x.x"
       }
     },
     "sigmund": {
@@ -13404,7 +13404,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.10.4"
+        "util": ">=0.10.3 <1"
       }
     },
     "slash": {
@@ -13417,7 +13417,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -13432,14 +13432,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -13447,7 +13447,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -13455,7 +13455,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13463,7 +13463,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -13473,7 +13473,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13481,7 +13481,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -13491,9 +13491,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -13508,9 +13508,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -13525,7 +13525,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "sntp": {
@@ -13533,7 +13533,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -13548,12 +13548,12 @@
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "requires": {
-        "debug": "3.1.0",
-        "engine.io": "3.2.0",
-        "has-binary2": "1.0.3",
-        "socket.io-adapter": "1.1.1",
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "3.2.0"
+        "socket.io-parser": "~3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -13571,14 +13571,14 @@
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
-            "debug": "3.1.0",
-            "engine.io-parser": "2.1.2",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.1",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "ws": "3.3.3",
-            "xmlhttprequest-ssl": "1.5.5",
+            "ws": "~3.3.1",
+            "xmlhttprequest-ssl": "~1.5.4",
             "yeast": "0.1.2"
           }
         },
@@ -13596,15 +13596,15 @@
             "base64-arraybuffer": "0.1.5",
             "component-bind": "1.0.0",
             "component-emitter": "1.2.1",
-            "debug": "3.1.0",
-            "engine.io-client": "3.2.1",
-            "has-binary2": "1.0.3",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.2.0",
+            "has-binary2": "~1.0.2",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "socket.io-parser": "3.2.0",
+            "socket.io-parser": "~3.2.0",
             "to-array": "0.1.4"
           }
         },
@@ -13614,7 +13614,7 @@
           "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
           "requires": {
             "component-emitter": "1.2.1",
-            "debug": "3.1.0",
+            "debug": "~3.1.0",
             "isarray": "2.0.1"
           }
         }
@@ -13634,14 +13634,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "engine.io-client": "3.1.6",
+        "debug": "~2.6.4",
+        "engine.io-client": "~3.1.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.3",
+        "socket.io-parser": "~3.1.1",
         "to-array": "0.1.4"
       }
     },
@@ -13651,8 +13651,8 @@
       "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "has-binary2": "1.0.3",
+        "debug": "~3.1.0",
+        "has-binary2": "~1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -13676,8 +13676,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "3.2.1"
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
       }
     },
     "sockjs-client": {
@@ -13685,12 +13685,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "requires": {
-        "debug": "2.6.9",
+        "debug": "^2.6.6",
         "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.4.3"
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
       },
       "dependencies": {
         "faye-websocket": {
@@ -13698,7 +13698,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
           "requires": {
-            "websocket-driver": "0.7.0"
+            "websocket-driver": ">=0.5.1"
           }
         }
       }
@@ -13718,11 +13718,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.0.0",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -13740,7 +13740,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -13758,12 +13758,12 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
-        "debug": "2.6.9",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.1.0"
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
       }
     },
     "spdy-transport": {
@@ -13771,13 +13771,13 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
       "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "requires": {
-        "debug": "2.6.9",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.3"
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
       }
     },
     "specificity": {
@@ -13790,7 +13790,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -13798,7 +13798,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -13806,8 +13806,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -13815,7 +13815,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -13831,9 +13831,9 @@
       "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
       "optional": true,
       "requires": {
-        "chalk": "1.1.3",
-        "console-stream": "0.1.1",
-        "lpad-align": "1.1.2"
+        "chalk": "^1.0.0",
+        "console-stream": "^0.1.1",
+        "lpad-align": "^1.0.1"
       }
     },
     "sshpk": {
@@ -13841,14 +13841,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stable": {
@@ -13872,12 +13872,12 @@
       "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.6.tgz",
       "integrity": "sha512-jR45n5ZMAkasw0xoE9j9TuLmJv4Sa3AkXe+6yIFT6a07kXYHgSbuD2OVGECdZGFxTmvNqLwL1iRIgvq6O6rq+A==",
       "requires": {
-        "boom": "7.2.0",
-        "bounce": "1.2.0",
-        "cryptiles": "4.1.1",
-        "hoek": "5.0.3",
-        "iron": "5.0.4",
-        "joi": "13.3.0"
+        "boom": "7.x.x",
+        "bounce": "1.x.x",
+        "cryptiles": "4.x.x",
+        "hoek": "5.x.x",
+        "iron": "5.x.x",
+        "joi": "13.x.x"
       },
       "dependencies": {
         "boom": {
@@ -13885,7 +13885,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         },
         "cryptiles": {
@@ -13893,7 +13893,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
           "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
           "requires": {
-            "boom": "7.2.0"
+            "boom": "7.x.x"
           }
         }
       }
@@ -13903,8 +13903,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13912,7 +13912,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -13920,7 +13920,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13928,7 +13928,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -13938,7 +13938,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13946,7 +13946,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -13956,9 +13956,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -13978,7 +13978,7 @@
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "stream-browserify": {
@@ -13986,8 +13986,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner": {
@@ -13995,7 +13995,7 @@
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-combiner2": {
@@ -14003,8 +14003,8 @@
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.3"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "duplexer2": {
@@ -14012,7 +14012,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.2"
           }
         }
       }
@@ -14027,11 +14027,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -14044,13 +14044,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -14058,7 +14058,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -14073,8 +14073,8 @@
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "requires": {
-        "commander": "2.11.0",
-        "limiter": "1.1.3"
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
       }
     },
     "stream-to": {
@@ -14087,7 +14087,7 @@
       "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
       "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
       "requires": {
-        "stream-to": "0.2.2"
+        "stream-to": "~0.2.0"
       }
     },
     "streamfilter": {
@@ -14095,7 +14095,7 @@
       "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
       "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.2"
       }
     },
     "string-width": {
@@ -14103,8 +14103,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14122,7 +14122,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -14132,7 +14132,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-entities": {
@@ -14140,10 +14140,10 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "1.1.2",
-        "character-entities-legacy": "1.1.2",
-        "is-alphanumerical": "1.0.2",
-        "is-hexadecimal": "1.0.2"
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "stringstream": {
@@ -14156,7 +14156,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -14169,7 +14169,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -14177,8 +14177,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "requires": {
-        "first-chunk-stream": "1.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -14186,7 +14186,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -14201,12 +14201,12 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "requires": {
-        "chalk": "1.1.3",
-        "get-stdin": "4.0.1",
-        "is-absolute": "0.1.7",
-        "is-natural-number": "2.1.1",
-        "minimist": "1.2.0",
-        "sum-up": "1.0.3"
+        "chalk": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "is-absolute": "^0.1.5",
+        "is-natural-number": "^2.0.0",
+        "minimist": "^1.1.0",
+        "sum-up": "^1.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -14219,7 +14219,7 @@
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
           "requires": {
-            "is-relative": "0.1.3"
+            "is-relative": "^0.1.0"
           }
         },
         "is-relative": {
@@ -14249,7 +14249,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
       "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "style-search": {
@@ -14262,14 +14262,14 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.4.1.tgz",
       "integrity": "sha1-ZjvQSF1LarRvlGIQ3APSOY0a3nQ=",
       "requires": {
-        "buffer": "5.2.0",
-        "css-to-react-native": "2.2.1",
-        "fbjs": "0.8.17",
-        "hoist-non-react-statics": "1.2.0",
-        "is-plain-object": "2.0.4",
-        "prop-types": "15.6.2",
-        "stylis": "3.5.3",
-        "supports-color": "3.2.3"
+        "buffer": "^5.0.3",
+        "css-to-react-native": "^2.0.3",
+        "fbjs": "^0.8.9",
+        "hoist-non-react-statics": "^1.2.0",
+        "is-plain-object": "^2.0.1",
+        "prop-types": "^15.5.4",
+        "stylis": "^3.4.0",
+        "supports-color": "^3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -14287,7 +14287,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14297,49 +14297,49 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.3.0.tgz",
       "integrity": "sha512-u59pWTlrdwjqriJtTvO1a0wRK1mfbQQp7jLt27SX4zl2HmtVHOM/I1wd43xHTvUJZDKp1PTOpqRAamU3gFvmOA==",
       "requires": {
-        "autoprefixer": "8.5.0",
-        "balanced-match": "1.0.0",
-        "chalk": "2.4.1",
-        "cosmiconfig": "5.0.5",
-        "debug": "3.1.0",
-        "execall": "1.0.0",
-        "file-entry-cache": "2.0.0",
-        "get-stdin": "6.0.0",
-        "globby": "8.0.1",
-        "globjoin": "0.1.4",
-        "html-tags": "2.0.0",
-        "ignore": "3.3.10",
-        "import-lazy": "3.1.0",
-        "imurmurhash": "0.1.4",
-        "known-css-properties": "0.6.1",
-        "lodash": "4.17.5",
-        "log-symbols": "2.2.0",
-        "mathml-tag-names": "2.1.0",
-        "meow": "5.0.0",
-        "micromatch": "2.3.11",
-        "normalize-selector": "0.2.0",
-        "pify": "3.0.0",
-        "postcss": "6.0.17",
-        "postcss-html": "0.28.0",
-        "postcss-less": "2.0.0",
-        "postcss-markdown": "0.28.0",
-        "postcss-media-query-parser": "0.2.3",
-        "postcss-reporter": "5.0.0",
-        "postcss-resolve-nested-selector": "0.1.1",
-        "postcss-safe-parser": "3.0.1",
-        "postcss-sass": "0.3.2",
-        "postcss-scss": "1.0.5",
-        "postcss-selector-parser": "3.1.1",
-        "postcss-syntax": "0.28.0",
-        "postcss-value-parser": "3.3.0",
-        "resolve-from": "4.0.0",
-        "signal-exit": "3.0.2",
-        "specificity": "0.3.2",
-        "string-width": "2.1.1",
-        "style-search": "0.1.0",
-        "sugarss": "1.0.1",
-        "svg-tags": "1.0.0",
-        "table": "4.0.3"
+        "autoprefixer": "^8.0.0",
+        "balanced-match": "^1.0.0",
+        "chalk": "^2.4.1",
+        "cosmiconfig": "^5.0.0",
+        "debug": "^3.0.0",
+        "execall": "^1.0.0",
+        "file-entry-cache": "^2.0.0",
+        "get-stdin": "^6.0.0",
+        "globby": "^8.0.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^2.0.0",
+        "ignore": "^3.3.3",
+        "import-lazy": "^3.1.0",
+        "imurmurhash": "^0.1.4",
+        "known-css-properties": "^0.6.0",
+        "lodash": "^4.17.4",
+        "log-symbols": "^2.0.0",
+        "mathml-tag-names": "^2.0.1",
+        "meow": "^5.0.0",
+        "micromatch": "^2.3.11",
+        "normalize-selector": "^0.2.0",
+        "pify": "^3.0.0",
+        "postcss": "^6.0.16",
+        "postcss-html": "^0.28.0",
+        "postcss-less": "^2.0.0",
+        "postcss-markdown": "^0.28.0",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-reporter": "^5.0.0",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^3.0.1",
+        "postcss-sass": "^0.3.0",
+        "postcss-scss": "^1.0.2",
+        "postcss-selector-parser": "^3.1.0",
+        "postcss-syntax": "^0.28.0",
+        "postcss-value-parser": "^3.3.0",
+        "resolve-from": "^4.0.0",
+        "signal-exit": "^3.0.2",
+        "specificity": "^0.3.1",
+        "string-width": "^2.1.0",
+        "style-search": "^0.1.0",
+        "sugarss": "^1.0.0",
+        "svg-tags": "^1.0.0",
+        "table": "^4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14347,7 +14347,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -14355,9 +14355,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cosmiconfig": {
@@ -14365,9 +14365,9 @@
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
           "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.10.0",
-            "parse-json": "4.0.0"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0"
           }
         },
         "debug": {
@@ -14388,13 +14388,13 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "fast-glob": "2.2.2",
-            "glob": "7.1.2",
-            "ignore": "3.3.10",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
           }
         },
         "has-flag": {
@@ -14412,7 +14412,7 @@
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "requires": {
-            "chalk": "2.4.1"
+            "chalk": "^2.0.1"
           }
         },
         "meow": {
@@ -14420,15 +14420,15 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
           "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0",
-            "yargs-parser": "10.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
           }
         },
         "resolve-from": {
@@ -14441,7 +14441,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "yargs-parser": {
@@ -14449,7 +14449,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
           "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -14464,11 +14464,11 @@
       "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.7.tgz",
       "integrity": "sha512-IcJUvRjeR+NB437Iq+LORFNJW4L6Knqkj3oQrBrkdhIaS2VKJvx/9aYEq7vi+PEx5/OuehOL/40SkSZotLi/MA==",
       "requires": {
-        "boom": "7.2.0",
-        "content": "4.0.5",
-        "hoek": "5.0.3",
-        "pez": "4.0.2",
-        "wreck": "14.0.2"
+        "boom": "7.x.x",
+        "content": "4.x.x",
+        "hoek": "5.x.x",
+        "pez": "4.x.x",
+        "wreck": "14.x.x"
       },
       "dependencies": {
         "boom": {
@@ -14476,7 +14476,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -14486,7 +14486,7 @@
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
       "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "^6.0.14"
       }
     },
     "sum-up": {
@@ -14494,7 +14494,7 @@
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "supports-color": {
@@ -14513,20 +14513,20 @@
       "integrity": "sha512-DR9ieoaBoeySY4pnIJMM3Hez6kcVj+Uzj8AUJkr3435qstozP9i+mZ9yzcbq64A44i9YKh3I1Laex+mAyc69Rg==",
       "optional": true,
       "requires": {
-        "coa": "2.0.1",
-        "colors": "1.1.2",
-        "css-select": "1.3.0-rc0",
-        "css-select-base-adapter": "0.1.0",
+        "coa": "~2.0.1",
+        "colors": "~1.1.2",
+        "css-select": "~1.3.0-rc0",
+        "css-select-base-adapter": "~0.1.0",
         "css-tree": "1.0.0-alpha25",
-        "css-url-regex": "1.1.0",
-        "csso": "3.5.0",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "object.values": "1.0.4",
-        "sax": "1.2.4",
-        "stable": "0.1.6",
-        "unquote": "1.1.1",
-        "util.promisify": "1.0.0"
+        "css-url-regex": "^1.1.0",
+        "csso": "^3.5.0",
+        "js-yaml": "~3.10.0",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.0.4",
+        "sax": "~1.2.4",
+        "stable": "~0.1.6",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
       }
     },
     "symbol-observable": {
@@ -14539,12 +14539,12 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "requires": {
-        "ajv": "6.5.0",
-        "ajv-keywords": "3.2.0",
-        "chalk": "2.4.1",
-        "lodash": "4.17.5",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14552,7 +14552,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -14560,9 +14560,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -14575,7 +14575,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -14590,9 +14590,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-stream": {
@@ -14600,10 +14600,10 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -14611,7 +14611,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         }
       }
@@ -14626,8 +14626,8 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
       },
       "dependencies": {
         "rimraf": {
@@ -14648,8 +14648,8 @@
       "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-0.1.1.tgz",
       "integrity": "sha1-C2Rng43Xf79/YqDJPah5cy/9qTI=",
       "requires": {
-        "graceful-fs": "2.0.3",
-        "tempfile": "0.1.3"
+        "graceful-fs": "~2.0.0",
+        "tempfile": "~0.1.2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -14664,7 +14664,7 @@
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
       "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
       "requires": {
-        "uuid": "1.4.2"
+        "uuid": "~1.4.0"
       },
       "dependencies": {
         "uuid": {
@@ -14679,7 +14679,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "ternary-stream": {
@@ -14687,10 +14687,10 @@
       "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "requires": {
-        "duplexify": "3.5.3",
-        "fork-stream": "0.0.4",
-        "merge-stream": "1.0.1",
-        "through2": "2.0.3"
+        "duplexify": "^3.5.0",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^1.0.0",
+        "through2": "^2.0.1"
       }
     },
     "tfunk": {
@@ -14698,8 +14698,8 @@
       "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "requires": {
-        "chalk": "1.1.3",
-        "object-path": "0.9.2"
+        "chalk": "^1.1.1",
+        "object-path": "^0.9.0"
       }
     },
     "throttleit": {
@@ -14717,8 +14717,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "through2-concurrent": {
@@ -14726,7 +14726,7 @@
       "resolved": "https://registry.npmjs.org/through2-concurrent/-/through2-concurrent-1.1.1.tgz",
       "integrity": "sha1-EctOpMnjG8puTB5tukjRxyjDUks=",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.0"
       }
     },
     "through2-filter": {
@@ -14734,8 +14734,8 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "thunky": {
@@ -14748,7 +14748,7 @@
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "time-stamp": {
@@ -14766,7 +14766,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "timers-ext": {
@@ -14774,8 +14774,8 @@
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "requires": {
-        "es5-ext": "0.10.38",
-        "next-tick": "1.0.0"
+        "es5-ext": "~0.10.14",
+        "next-tick": "1"
       }
     },
     "tinycolor2": {
@@ -14788,7 +14788,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "to-absolute-glob": {
@@ -14796,7 +14796,7 @@
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "to-array": {
@@ -14820,10 +14820,10 @@
       "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
       "optional": true,
       "requires": {
-        "is-finite-x": "3.0.2",
-        "is-nan-x": "1.0.1",
-        "math-sign-x": "3.0.0",
-        "to-number-x": "2.0.0"
+        "is-finite-x": "^3.0.2",
+        "is-nan-x": "^1.0.1",
+        "math-sign-x": "^3.0.0",
+        "to-number-x": "^2.0.0"
       }
     },
     "to-number-x": {
@@ -14831,11 +14831,11 @@
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
       "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "nan-x": "1.0.0",
-        "parse-int-x": "2.0.0",
-        "to-primitive-x": "1.1.0",
-        "trim-x": "3.0.0"
+        "cached-constructors-x": "^1.0.0",
+        "nan-x": "^1.0.0",
+        "parse-int-x": "^2.0.0",
+        "to-primitive-x": "^1.1.0",
+        "trim-x": "^3.0.0"
       }
     },
     "to-object-path": {
@@ -14843,7 +14843,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-object-x": {
@@ -14851,8 +14851,8 @@
       "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
       "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-object-coercible-x": "1.4.1"
+        "cached-constructors-x": "^1.0.0",
+        "require-object-coercible-x": "^1.4.1"
       }
     },
     "to-primitive-x": {
@@ -14860,14 +14860,14 @@
       "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
       "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
       "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "is-date-object": "1.0.1",
-        "is-function-x": "3.3.0",
-        "is-nil-x": "1.4.1",
-        "is-primitive": "2.0.0",
-        "is-symbol": "1.0.1",
-        "require-object-coercible-x": "1.4.1",
-        "validate.io-undefined": "1.0.3"
+        "has-symbol-support-x": "^1.4.1",
+        "is-date-object": "^1.0.1",
+        "is-function-x": "^3.2.0",
+        "is-nil-x": "^1.4.1",
+        "is-primitive": "^2.0.0",
+        "is-symbol": "^1.0.1",
+        "require-object-coercible-x": "^1.4.1",
+        "validate.io-undefined": "^1.0.3"
       }
     },
     "to-property-key-x": {
@@ -14875,9 +14875,9 @@
       "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
       "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
       "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "to-primitive-x": "1.1.0",
-        "to-string-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1",
+        "to-primitive-x": "^1.1.0",
+        "to-string-x": "^1.4.2"
       }
     },
     "to-regex": {
@@ -14885,9 +14885,9 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
       "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^1.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -14895,7 +14895,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -14903,7 +14903,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14911,7 +14911,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -14921,7 +14921,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14929,7 +14929,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -14939,9 +14939,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -14956,8 +14956,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -14965,7 +14965,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -14976,9 +14976,9 @@
       "integrity": "sha512-HbVH673pybrUmhzESGHUm17BBJvqb7BU8HciOvuEYm9ipuDyjmddhvkVqpVW6sM/C5/zhJo17n7O7I/24loJIQ==",
       "optional": true,
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "has-symbol-support-x": "1.4.1",
-        "is-symbol": "1.0.1"
+        "cached-constructors-x": "^1.0.0",
+        "has-symbol-support-x": "^1.4.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "to-string-tag-x": {
@@ -14986,8 +14986,8 @@
       "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
       "integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
       "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
+        "lodash.isnull": "^3.0.0",
+        "validate.io-undefined": "^1.0.3"
       }
     },
     "to-string-x": {
@@ -14995,7 +14995,7 @@
       "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.2.tgz",
       "integrity": "sha512-/WP5arlwtCpAAexCCHiQBW0eXwse84osWyP1Qtaz71nsYSuUpOkT6tBm8nQ4IIUfSh5hji0hDupUCD2xbbOL6A==",
       "requires": {
-        "is-symbol": "1.0.1"
+        "is-symbol": "^1.0.1"
       }
     },
     "topo": {
@@ -15003,7 +15003,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
       "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
       "requires": {
-        "hoek": "5.0.3"
+        "hoek": "5.x.x"
       }
     },
     "tough-cookie": {
@@ -15011,7 +15011,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim": {
@@ -15024,9 +15024,9 @@
       "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
       "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "3.0.0"
+        "cached-constructors-x": "^1.0.0",
+        "require-coercible-to-string-x": "^1.0.0",
+        "white-space-x": "^3.0.0"
       }
     },
     "trim-newlines": {
@@ -15039,7 +15039,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-right-x": {
@@ -15047,9 +15047,9 @@
       "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
       "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
       "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "3.0.0"
+        "cached-constructors-x": "^1.0.0",
+        "require-coercible-to-string-x": "^1.0.0",
+        "white-space-x": "^3.0.0"
       }
     },
     "trim-trailing-lines": {
@@ -15062,8 +15062,8 @@
       "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
       "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
       "requires": {
-        "trim-left-x": "3.0.0",
-        "trim-right-x": "3.0.0"
+        "trim-left-x": "^3.0.0",
+        "trim-right-x": "^3.0.0"
       }
     },
     "trough": {
@@ -15076,7 +15076,7 @@
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "requires": {
-        "glob": "6.0.4"
+        "glob": "^6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -15084,11 +15084,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -15103,7 +15103,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -15118,7 +15118,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -15136,8 +15136,8 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.10.tgz",
       "integrity": "sha512-dNib7aUDNZFJNTXFyq0CDmLRVOsnY1F+IQgt2FAOdZFx2+LvKVLbbIb/fL+BYKCv3YH3bPCE/6M/JaxChtQLHQ==",
       "requires": {
-        "commander": "2.14.1",
-        "source-map": "0.6.1"
+        "commander": "~2.14.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -15163,9 +15163,9 @@
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.1.0"
+        "source-map": "^0.5.6",
+        "uglify-js": "^2.8.29",
+        "webpack-sources": "^1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -15178,9 +15178,9 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           }
         },
         "yargs": {
@@ -15188,9 +15188,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -15216,8 +15216,8 @@
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "2.0.3",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
       }
     },
     "unified": {
@@ -15225,12 +15225,12 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
       "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "requires": {
-        "bail": "1.0.3",
-        "extend": "3.0.1",
-        "is-plain-obj": "1.1.0",
-        "trough": "1.0.2",
-        "vfile": "2.3.0",
-        "x-is-string": "0.1.0"
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^2.0.0",
+        "x-is-string": "^0.1.0"
       }
     },
     "union-value": {
@@ -15238,10 +15238,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -15249,10 +15249,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -15272,7 +15272,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unist-util-find-all-after": {
@@ -15280,7 +15280,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
       "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
       "requires": {
-        "unist-util-is": "2.1.2"
+        "unist-util-is": "^2.0.0"
       }
     },
     "unist-util-is": {
@@ -15293,7 +15293,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
       "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
       "requires": {
-        "array-iterate": "1.1.2"
+        "array-iterate": "^1.0.0"
       }
     },
     "unist-util-remove-position": {
@@ -15301,7 +15301,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
       "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "requires": {
-        "unist-util-visit": "1.3.1"
+        "unist-util-visit": "^1.1.0"
       }
     },
     "unist-util-stringify-position": {
@@ -15314,7 +15314,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
       "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
       "requires": {
-        "unist-util-is": "2.1.2"
+        "unist-util-is": "^2.1.1"
       }
     },
     "universalify": {
@@ -15338,8 +15338,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -15347,9 +15347,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -15389,16 +15389,16 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.4.1",
-        "configstore": "3.1.2",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15406,7 +15406,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -15414,9 +15414,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -15429,7 +15429,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -15439,7 +15439,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
       "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -15475,8 +15475,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
-        "querystringify": "2.0.0",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {
@@ -15484,7 +15484,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-regex": {
@@ -15492,7 +15492,7 @@
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "requires": {
-        "ip-regex": "1.0.3"
+        "ip-regex": "^1.0.1"
       }
     },
     "use": {
@@ -15500,9 +15500,9 @@
       "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -15510,7 +15510,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -15518,7 +15518,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15526,7 +15526,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -15536,7 +15536,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15544,7 +15544,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -15554,9 +15554,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "isobject": {
@@ -15595,8 +15595,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "optional": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "utils-merge": {
@@ -15614,7 +15614,7 @@
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "^1.1.1"
       }
     },
     "vali-date": {
@@ -15627,8 +15627,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "validate.io-undefined": {
@@ -15646,9 +15646,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vfile": {
@@ -15656,10 +15656,10 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
-        "is-buffer": "1.1.6",
+        "is-buffer": "^1.1.4",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "1.1.2",
-        "vfile-message": "1.0.1"
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
       },
       "dependencies": {
         "replace-ext": {
@@ -15679,7 +15679,7 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
       "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
       "requires": {
-        "unist-util-stringify-position": "1.1.2"
+        "unist-util-stringify-position": "^1.1.1"
       }
     },
     "vinyl": {
@@ -15687,8 +15687,8 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -15697,8 +15697,8 @@
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "requires": {
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.3"
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "vinyl-fs": {
@@ -15706,14 +15706,14 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "requires": {
-        "defaults": "1.0.3",
-        "glob-stream": "3.1.18",
-        "glob-watcher": "0.0.6",
-        "graceful-fs": "3.0.11",
-        "mkdirp": "0.5.1",
-        "strip-bom": "1.0.0",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "defaults": "^1.0.0",
+        "glob-stream": "^3.1.5",
+        "glob-watcher": "^0.0.6",
+        "graceful-fs": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "strip-bom": "^1.0.0",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.0"
       },
       "dependencies": {
         "clone": {
@@ -15726,7 +15726,7 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "requires": {
-            "natives": "1.1.1"
+            "natives": "^1.1.0"
           }
         },
         "isarray": {
@@ -15736,13 +15736,13 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -15755,8 +15755,8 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
           "requires": {
-            "first-chunk-stream": "1.0.0",
-            "is-utf8": "0.2.1"
+            "first-chunk-stream": "^1.0.0",
+            "is-utf8": "^0.2.0"
           }
         },
         "through2": {
@@ -15764,8 +15764,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "vinyl": {
@@ -15773,8 +15773,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -15784,7 +15784,7 @@
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.1"
       }
     },
     "vise": {
@@ -15792,7 +15792,7 @@
       "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.0.tgz",
       "integrity": "sha512-kBFZLmiL1Vm3rHXphkhvvAcsjgeQXRrOFCbJb0I50YZZP4HGRNH+xGzK3matIMcpbsfr3I02u9odj4oCD0TWgA==",
       "requires": {
-        "hoek": "5.0.3"
+        "hoek": "5.x.x"
       }
     },
     "vm-browserify": {
@@ -15808,7 +15808,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "0.1.5"
+        "wrap-fn": "^0.1.0"
       }
     },
     "warning": {
@@ -15816,7 +15816,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -15824,9 +15824,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "requires": {
-        "chokidar": "2.0.4",
-        "graceful-fs": "4.1.11",
-        "neo-async": "2.5.1"
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
       }
     },
     "wbuf": {
@@ -15834,7 +15834,7 @@
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
-        "minimalistic-assert": "1.0.1"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "webpack": {
@@ -15842,28 +15842,28 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
       "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
       "requires": {
-        "acorn": "5.4.1",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.5.0",
-        "ajv-keywords": "3.2.0",
-        "async": "2.6.1",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.6.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
+        "acorn": "^5.0.0",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.4.0",
+        "escope": "^3.6.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "json5": "^0.5.1",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^4.2.1",
+        "tapable": "^0.2.7",
+        "uglifyjs-webpack-plugin": "^0.4.6",
+        "watchpack": "^1.4.0",
+        "webpack-sources": "^1.0.1",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "supports-color": {
@@ -15871,7 +15871,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -15881,11 +15881,11 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.6.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.1"
+        "memory-fs": "~0.4.1",
+        "mime": "^1.5.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
       },
       "dependencies": {
         "time-stamp": {
@@ -15901,30 +15901,30 @@
       "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
       "requires": {
         "ansi-html": "0.0.7",
-        "array-includes": "3.0.3",
-        "bonjour": "3.5.0",
-        "chokidar": "2.0.4",
-        "compression": "1.7.3",
-        "connect-history-api-fallback": "1.5.0",
-        "debug": "3.1.0",
-        "del": "3.0.0",
-        "express": "4.16.3",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.17.4",
-        "import-local": "1.0.0",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
         "internal-ip": "1.2.0",
-        "ip": "1.1.5",
-        "killable": "1.0.0",
-        "loglevel": "1.6.1",
-        "opn": "5.3.0",
-        "portfinder": "1.0.13",
-        "selfsigned": "1.10.3",
-        "serve-index": "1.9.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
         "sockjs": "0.3.19",
         "sockjs-client": "1.1.4",
-        "spdy": "3.4.7",
-        "strip-ansi": "3.0.1",
-        "supports-color": "5.4.0",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
         "webpack-dev-middleware": "1.12.2",
         "yargs": "6.6.0"
       },
@@ -15939,9 +15939,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "debug": {
@@ -15957,8 +15957,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "has-flag": {
@@ -15971,11 +15971,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -15983,7 +15983,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "parse-json": {
@@ -15991,7 +15991,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -15999,7 +15999,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -16007,9 +16007,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -16022,9 +16022,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -16032,8 +16032,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "string-width": {
@@ -16041,9 +16041,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -16051,7 +16051,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "supports-color": {
@@ -16059,7 +16059,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "which-module": {
@@ -16072,19 +16072,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           }
         },
         "yargs-parser": {
@@ -16092,7 +16092,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -16102,8 +16102,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -16118,8 +16118,8 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": "0.4.13",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -16143,7 +16143,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -16161,7 +16161,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       },
       "dependencies": {
         "string-width": {
@@ -16169,9 +16169,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -16181,7 +16181,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       }
     },
     "window-size": {
@@ -16199,8 +16199,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -16208,9 +16208,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -16235,7 +16235,7 @@
       "resolved": "https://registry.npmjs.org/wrap-promise/-/wrap-promise-1.0.1.tgz",
       "integrity": "sha1-sBn0I2zL8ftWCSG0tIcLe9ovUlU=",
       "requires": {
-        "es6-promise": "2.3.0"
+        "es6-promise": "^2.3.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -16255,8 +16255,8 @@
       "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
       "integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
       "requires": {
-        "boom": "7.2.0",
-        "hoek": "5.0.3"
+        "boom": "7.x.x",
+        "hoek": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -16264,7 +16264,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -16274,7 +16274,7 @@
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -16282,9 +16282,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -16292,9 +16292,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "x-is-string": {
@@ -16312,10 +16312,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
       "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "xml-parse-from-string": {
@@ -16328,8 +16328,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -16362,19 +16362,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       },
       "dependencies": {
         "cliui": {
@@ -16382,9 +16382,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -16392,9 +16392,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -16404,10 +16404,10 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -16415,7 +16415,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-type": {
@@ -16423,7 +16423,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "pify": {
@@ -16436,9 +16436,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -16446,8 +16446,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         }
       }
@@ -16457,7 +16457,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {
@@ -16465,7 +16465,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "yeast": {

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -1,6 +1,5 @@
 {
   "name": "ama-style-guide",
-<<<<<<< HEAD
   "version": "2.27.0",
   "description": "A living style guide for the American Medical Association",
   "repository": "https://github.com/AmericanMedicalAssociation/ama-style-guide-2/releases",

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ama-style-guide",
-  "version": "2.26.5",
+  "version": "2.27.0",
   "description": "A living style guide for the American Medical Association",
   "repository": "https://github.com/AmericanMedicalAssociation/ama-style-guide-2/releases",
   "main": "gulpfile.js",


### PR DESCRIPTION
## Description
Updates package-lock file in preparation for style guide release.

Please note that the lock file updated some dependencies to have `^` in front of version numbers. We have experienced this in the past and determined that it was not an issue.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
