### PR TITLE
EWL-6513: Homepage - mobile view all products

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -66,6 +66,7 @@
   &__view-all-link {
     @include font-size($small-font-sizes);
     @include gutter($margin-top-half...);
+    margin-bottom: 10px;
     float: right;
 
     @include breakpoint($bp-small) {

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -66,7 +66,7 @@
   &__view-all-link {
     @include font-size($small-font-sizes);
     @include gutter($margin-top-half...);
-    margin-bottom: 10px;
+    margin-bottom: $gutter-mobile;
     float: right;
 
     @include breakpoint($bp-small) {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-6513: Homepage - mobile view all products](https://issues.ama-assn.org/browse/EWL-6513)

## Description
Fixes bottom margin of "View all Products" link on the homepage. See the issue below: 
![screen shot 2018-11-06 at 9 39 19 am](https://user-images.githubusercontent.com/541745/48071440-531d8900-e1a8-11e8-93cf-f6c7ef4e2aca.png)


## To Test
- [ ] switch SG2 branch to bugfix/EWL-6513-mobile-view-product-link
- [ ] Run `gulp serve`
- [ ] Enable local SG2 in D8: `provisioning/vars/local.yml`
- [ ] In another terminal window run `scripts/build`
- [ ] In vagrant run `drush @one.local cr`
- [ ] visit http://ama-one.local/ or a homepage content type
- [ ] Change your viewport to mobile
- [ ] Check to see if "View all Product" is smushed above the purple footer region or any components directly below the "View all Product" link
- [ ] Did you test in IE 11?

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
- You should be able to see some additional margin below the view all link. 

![screen shot 2018-11-06 at 9 41 24 am](https://user-images.githubusercontent.com/541745/48071401-3aad6e80-e1a8-11e8-8a49-84d9a32a2265.png)



## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
