### PR TITLE
BUGFIX: Fix search placeholder in Safari

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -30,7 +30,7 @@
     max-height: 40px;
     min-height: 40px;
     min-width: 250px;
-    line-height: 0;
+    line-height: normal;
 
     @include breakpoint($bp-small) {
       padding: 0 $gutter/4;

--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -30,7 +30,6 @@
     max-height: 40px;
     min-height: 40px;
     min-width: 250px;
-    line-height: normal;
 
     @include breakpoint($bp-small) {
       padding: 0 $gutter/4;

--- a/styleguide/source/assets/scss/02-molecules/_search-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-header.scss
@@ -128,7 +128,6 @@
         color: $purple;
         font-style: normal;
         font-weight: 600;
-        line-height: 0;
 
         &:focus {
           border: none;


### PR DESCRIPTION
Visit `http://ama-one.local` in Safari and verify Placeholder text looks correct.

![screen shot 2018-11-06 at 10 35 03 am](https://user-images.githubusercontent.com/231467/48074755-a5ae7380-e1af-11e8-986c-d296cf5bb544.png)
