### PR TITLE
EWL-6532 Fix menu and ribbon styling

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_menu-icon.scss
+++ b/styleguide/source/assets/scss/01-atoms/_menu-icon.scss
@@ -31,6 +31,7 @@
       border: 0;
       outline: none;
       box-shadow: none;
+      margin: 0;
 
       &:after,
       &:before,
@@ -96,6 +97,8 @@
       @include font-size($small-font-sizes--homepage);
       display: block;
       color: $white;
+      font-weight: 900;
+      text-transform: uppercase;
       width: 40px;
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -26,6 +26,7 @@
 
     &__article-container {
       flex-direction: row;
+      max-width: 654px;
     }
   }
 
@@ -69,10 +70,6 @@
         border-top: 6px solid transparent;
         border-bottom: 6px solid transparent;
         transition: all 0.21s ease-out;
-      }
-
-      @include breakpoint($bp-small) {
-
       }
 
       &.highlighted .sub-arrow {
@@ -136,7 +133,7 @@
 
     @include breakpoint($bp-med) {
       left: 0 !important;
-      width: 900px !important;
+      width: 940px !important;
       max-width: none !important;
     }
   }
@@ -201,12 +198,16 @@
         &:hover {
           background-color: transparent;
         }
+
+        p {
+          font-weight: 400;
+        }
       }
 
       @include breakpoint($bp-med) {
         @include gutter($margin-left-full...);
 
-        &:nth-child(1):nth-last-child(2) {
+        &:nth-child(1) {
           margin-right: 12px;
           width: 50%;
         }
@@ -230,7 +231,7 @@
 
     @include breakpoint($bp-med) {
       flex-direction: row;
-      width: 650px;
+      width: 690px;
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_product-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_product-nav.scss
@@ -10,7 +10,6 @@
     display: inline-block;
 
     a {
-      font-weight: 600;
       margin: 0 ($gutter / 2);
     }
   }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6532: Menu - text style modification required](https://issues.ama-assn.org/browse/EWL-6532)
- [EWL-6535: Flyout nav images too large on IE](https://issues.ama-assn.org/browse/EWL-6535)
- [EWL-6533: Global Nav – Flyout text style is inconsistent](https://issues.ama-assn.org/browse/EWL-6533)
- [EWL-6534: X menu item on navigation](https://issues.ama-assn.org/browse/EWL-6534)
- [EWL-6536: Global Nav - Product Nav Styling Bug](https://issues.ama-assn.org/browse/EWL-6536)

## Description
- EWL-6532: Menu - text style modification required
Global Nav - Menu text style is incorrect
Text style should be Myriad Pro, bold, caps, size 14 
Zeplin: zpl.io/agGM7NM

- EWL-6535: Flyout nav images too large on IE
Homepage – Flyout is displaying highlighted articles component extremely large in IE11

- EWL-6533: Global Nav
Global Nav – Flyout text style is inconsistent
Both article descriptions should be in the styling of the furthest right article 
Zeplin: zpl.io/bLOyGYG

- EWL-6534 X menu item on navigation
The word menu is not centered to the X

- EWL-6536: Global Nav - Product Nav Styling 
Homepage – Product nav text style should be regular weight, not bold and should be aligned absolute left

## To Test
- refer to PR https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/507 for testing instructions

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="1949" alt="screen shot 2018-11-06 at 10 35 06 am" src="https://user-images.githubusercontent.com/2271747/48078757-a6470a00-e1af-11e8-8a62-1794cfca30ab.png">


## Remaining Tasks
n/a

## Additional Notes
This has a dependency in D8
Pr 

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)