### PR TITLE
EWL-6537 Fix people listing cards last row getting split

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_people-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_people-listing.scss
@@ -1,7 +1,16 @@
 .ama__people-listing-card {
   background-color: $gray-7;
   width: 100%;
+  margin: 1% 0;
   position: relative;
+
+  @include breakpoint($bp-small) {
+    width: 48.08%;
+  }
+
+  @include breakpoint($bp-med) {
+    width: 22.08%;
+  }
 
   .ama__image {
     width: 100%;

--- a/styleguide/source/assets/scss/05-pages/_people-listing.scss
+++ b/styleguide/source/assets/scss/05-pages/_people-listing.scss
@@ -4,21 +4,18 @@
   }
 
   &__card-container {
-    @include grid_column_layout(4, 2, 0, 0);
     @include gutter($padding-top-full...);
     @include gutter($padding-bottom-full...);
     display: flex;
     flex-wrap: wrap;
     height: 100%;
     min-height: 100%;
+    justify-content: space-between;
 
-
-    @include breakpoint($bp-small){
-      @include grid_column_layout(4, 2, $gutter/2, $gutter/2);
-    }
-
-    @include breakpoint($bp-med){
-      @include grid_column_layout(4, 2, $gutter, $gutter);
+    &::after {
+      content:"";
+      display: block;
+      margin-left: 48.38%;
     }
   }
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6537: People listing -stacking issue](https://issues.ama-assn.org/browse/EWL-6537)

## Description
The last row of the people listing cards were getting split

## To Test
- [ ] switch your branch to `bugfix/EWL-6537-people-listing`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8 instance
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/member-groups-sections/residents-fellows/resident-fellow-section-rfs-sectional-delegates
- [ ] scroll to the bottom of the people cards
- [ ] observe the last row is no longer split
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="1404" alt="screen shot 2018-11-06 at 11 56 57 am" src="https://user-images.githubusercontent.com/2271747/48083555-127b3b00-e1bb-11e8-97de-da6ee506ec94.png">


## Remaining Tasks
n/a

## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
