### PR TITLE
EWL6546 Fix padding of category page mobile between hero article

### DIFF
--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -24,6 +24,8 @@
           hideShow();
         }
       });
+
+
     }
   };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -15,9 +15,9 @@
     padding: 0 $gutter / 4;
 
     .ama__tools {
-      @include gutter($margin-top-full...);
+      @include gutter($margin-top-half...);
       @include gutter($padding-top-half...);
-      border-top: 1px solid $black;
+      border-top: 1px solid $gray-64;
     }
 
     @include breakpoint($bp-small) {

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -17,7 +17,7 @@
     .ama__tools {
       @include gutter($margin-top-half...);
       @include gutter($padding-top-half...);
-      border-top: 1px solid $gray-64;
+      border-top: solid 2px $gray-50;
     }
 
     @include breakpoint($bp-small) {

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -15,8 +15,8 @@
     padding: 0 $gutter / 4;
 
     .ama__tools {
-      @include gutter($margin-top-half...);
-      @include gutter($padding-top-half...);
+      @include gutter($margin-top-full...);
+      @include gutter($padding-top-full...);
       border-top: solid 2px $gray-50;
     }
 

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -1,5 +1,37 @@
 .ama__category {
 
+  .ama__layout--two-col-right--75-25__left {
+    margin: 0;
+    padding: 0;
+
+    @include breakpoint($bp-small) {
+      margin-right: 10px;
+      padding: initial;
+    }
+  }
+
+  .ama__layout--two-col-right--75-25__right {
+    margin: 0;
+    padding: 0 $gutter / 4;
+
+    .ama__tools {
+      @include gutter($margin-top-full...);
+      @include gutter($padding-top-half...);
+      border-top: 1px solid $black;
+    }
+
+    @include breakpoint($bp-small) {
+      margin-right: 10px;
+      padding: initial;
+
+      .ama__tools {
+        margin: 0;
+        padding: 0;
+        border-top: 0;
+      }
+    }
+  }
+
   &__row {
     padding: $gutter 0;
     border-top: solid 2px $gray-50;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6546: Category mobile designs - padding modifications](https://issues.ama-assn.org/browse/EWL-6546)

## Description
Category MOBILE – Padding between bottom of Category Hero Article and top of Essential Tools and Resources needs to be increased and a divider line needs to be added in between.

## To Test
- [ ] switch your branch to `bugfix/EWL-6546-category-padding`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8 instance
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/advocacy
- [ ] change your viewport to mobile
- [ ] scroll down to the essential tools section
- [ ] observe there is a line above it and more padding around it separating it from the hero article
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs

<img width="526" alt="screen shot 2018-11-06 at 12 37 56 pm" src="https://user-images.githubusercontent.com/2271747/48085758-ccc17100-e1c0-11e8-86f8-5c703601ff3e.png">

## Remaining Tasks
n/a

## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
