### PR TITLE
EWL-6481 Fixes buttons overlapping names when there are no photos

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_people-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_people-listing.scss
@@ -3,6 +3,9 @@
   width: 100%;
   margin: 1% 0;
   position: relative;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr auto;
 
   @include breakpoint($bp-small) {
     width: 48.08%;
@@ -14,10 +17,11 @@
 
   .ama__image {
     width: 100%;
+    grid-row: 1;
   }
 
   &__bio {
-    height: calc(100%  - 360px);
+    grid-row: 2;
 
     a {
       @include gutter($padding-bottom-half...);
@@ -44,6 +48,9 @@
 
   &__button-container {
     @include gutter-all($padding-all-half...);
+    display: flex;
+    align-items: flex-end;
+    grid-row: 3;
 
     .ama__button--secondary {
       width: 100%;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6481: Bios were not designed to function without images - modifications required](https://issues.ama-assn.org/browse/EWL-6481)

## Description
When no bio profile photos were missing the CTA button overlapped the card description

## To Test
- [ ] switch your branch to `bugfix/EWL-6481-bios-without-images`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8 instance
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/wire-authors/author-profiles/news-authors
- [ ] observe the CTA buttons of the profiles without photos no longer overlap the descritpion
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs

<img width="526" alt="screen shot 2018-11-06 at 12 37 56 pm" src="https://user-images.githubusercontent.com/2271747/48085758-ccc17100-e1c0-11e8-86f8-5c703601ff3e.png">

## Remaining Tasks
n/a

## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
