### PR TITLE
EWL-6544: Resource page - Eliminate divider lines in between items on Download tab

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tool.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tool.scss
@@ -1,6 +1,7 @@
 .ama__tool {
   @include gutter($padding-top-half...);
   @include gutter($padding-bottom-half...);
+  @include ama-rules(1px, "", $gray-64, solid);
   @extend %ama__link--no-underline;
   $c: &; //Sets the parent selector as a variable to be used later
   display: flex;
@@ -51,4 +52,8 @@
       }
     }
   }
+}
+
+#downloads .ama__tool {
+  border-top: none;
 }

--- a/styleguide/source/assets/scss/02-molecules/_tool.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tool.scss
@@ -1,7 +1,6 @@
 .ama__tool {
   @include gutter($padding-top-half...);
   @include gutter($padding-bottom-half...);
-  @include ama-rules(1px, "", $gray-64, solid);
   @extend %ama__link--no-underline;
   $c: &; //Sets the parent selector as a variable to be used later
   display: flex;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6544: Resource page - Eliminate divider lines in between items on Download tab](https://issues.ama-assn.org/browse/EWL-6544)

## Description
Removed the border at the top of `.ama__tool` in the resource page downloads tab. See screenshot below for correct appearance.


## To Test
- [ ] Open the resource page in SG2
- [ ] Check that the only borders are the ones in-between download items. The ones between the title and download link should be gone.
- [ ] Check that tools list remains unaffected ;)
- [ ] Did you test in IE 11?

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6544-remove-divider-lines-downloads-tab/html_report/index.html).

## Relevant Screenshots/GIFs
<img width="597" alt="screen shot 2018-11-06 at 11 27 14 am" src="https://user-images.githubusercontent.com/1919263/48090346-46129100-e1cc-11e8-8e86-dcf51ffc6835.png">



## Remaining Tasks
N/A


## Additional Notes
If there's a better place to put the `#downloads .ama__tool` don't hesitate to say so.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
