### PR TITLE
EWL-6563 Hub hero should match the sizing on D7

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -33,8 +33,11 @@
 
   &__image {
     margin: 0;
+    display: flex;
+    height: 100%;
     
     .ama__image {
+      min-height: 400px;
       height: auto;
       width: 100%;
     }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6563: Hub pages - hub hero image](https://issues.ama-assn.org/browse/EWL-6563)

## Description
Hub hero should match the sizing on D7

## To Test
- [ ] switch your branch to `bugfix/hub-page-image-match-d7`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8 instance
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/node/24436
- [ ] compare the hub hero image size to prod https://www.ama-assn.org/ama-member-spotlight
- [ ] observe the images have the same height
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="1172" alt="screen shot 2018-11-06 at 2 47 11 pm" src="https://user-images.githubusercontent.com/2271747/48092644-dbb11f00-e1d2-11e8-8f25-9b758511873b.png">



## Remaining Tasks
n/a

## Additional Notes

n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
