### PR TITLE
EWL-6538: News Article - numbered list options not displaying on frontend

### DIFF
--- a/styleguide/source/_patterns/05-pages/news/news.json
+++ b/styleguide/source/_patterns/05-pages/news/news.json
@@ -1187,6 +1187,48 @@
     "text": "The JAMA Network will launch a new online general medical journal, JAMA Network Open, in early 2018. The new journal will publish peer-reviewed, fully open-access clinical research across all medical disciplines. \u201COpen access\u201D is free, immediate, online availability of research articles that permits others to access, read and reuse the content.<\/p><p>The weekly journal will be the 13th journal in The JAMA Network, which includes JAMA and 11 other specialty journals. The newest journal follows the launch of JAMA Oncology in 2015 and JAMA Cardiology in 2016, which are hybrid journals offering open access for research articles.<img class='ama__image ama__image--right' alt='placeholder image' src='https://ipsumimage.appspot.com/400x300x186?l=3:2|400x300&amp;s=36' height='300' width='400'\/><\/p><p>The founding editor-in-chief of <a href=\"https:sites.jamanetwork.com\/jamanetworkopen\/m\">JAMA Network<\/a> Open will be Frederick P. Rivara, MD, MPH, now editor-in-chief of JAMA Pediatrics. Dr. Rivara is Seattle Children\u2019s Guild Endowed Chair in Pediatrics, professor of pediatrics and adjunct professor of epidemiology at the University of Washington.<\/p><p>\"Our editorial goal is to publish the very best clinical research across all disciplines, serving the worldwide community of investigators and clinicians and meeting the evolving needs and requirements of authors and funders\", Dr. Rivara and his co-authors wrote in an editorial published in JAMA. The editorial was co-written by JAMA Network Editor-in-Chief Howard Bauchner, MD, JAMA Network Publisher Thomas J. Easley, and Annette Flanagin, the executive managing editor of JAMA and JAMA Network.",
     "class": ""
   },
+  "unorderedList": [
+    {
+      "text": "This is a list item in an unordered list"
+    },
+    {
+      "text": "An unordered list is a list in which the sequence of items is not important."
+    },
+    {
+      "text": "Lists can be nested inside of each other",
+      "sublist" : [
+        {
+          "text":"This is a nested list item"
+        },{
+          "text":"This is another nested list item in an unordered list"
+        }
+      ]
+    },
+    {
+      "text": "This is the last list item"
+    }
+  ],
+  "orderedList": [
+    {
+      "text": "This is a list item in an ordered list"
+    },
+    {
+      "text": "An ordered list is a list in which the sequence of items is important."
+    },
+    {
+      "text": "Lists can be nested inside of each other",
+      "sublist" : [
+        {
+          "text":"This is a nested list item"
+        },{
+          "text":"This is another nested list item in an ordered list"
+        }
+      ]
+    },
+    {
+      "text": "This is the last list item"
+    }
+  ],
   "learnMore": {
     "heading": {
       "class": "ama__h5"

--- a/styleguide/source/_patterns/05-pages/news/news.twig
+++ b/styleguide/source/_patterns/05-pages/news/news.twig
@@ -1,4 +1,5 @@
 {% extends '@templates/two-column-right.twig' %}
+{% set pageContentClass = 'ama__layout--two-column--right__page-content ama__news' %}
 
 {% block contentTop %}
   {% include '@organisms/masthead/masthead.twig' %}
@@ -9,6 +10,7 @@
 
 {% block pageContent %}
   {% include '@atoms/paragraph.twig' %}
+  {% include '@atoms/ordered-list.twig' %}
   {% include '@molecules/article-stub/article-stub-as-inline.twig' %}
   {% set heading = heading|merge({
     "level": "1",
@@ -16,6 +18,7 @@
   }) %}
   {% include '@atoms/heading/heading.twig' %}
   {% set promo = promoAsInline %}
+  {% include '@atoms/unordered-list.twig' %}
   {% include '@molecules/promo/promo.twig' %}
   {% include '@atoms/paragraph.twig' %}
   <section class="ama__page--news__teasers">

--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -1,0 +1,6 @@
+.ama__news {
+  ol {
+    list-style: decimal;
+    padding-left: 1em;
+  }
+}


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6538: News Article - numbered list options not displaying on frontend](https://issues.ama-assn.org/browse/EWL-6538)

## Description
Adds ordered list to news article template, styles `<ol>` specifically for News Article page template.


## To Test
- [ ] View the News -> News page and verify that the `<ol>` looks like a numbered list instead of unstyled text.
- [ ] Did you test in IE 11?

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A

## Additional Notes
[Related D8 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/1028)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
