### PR TITLE
EWL-6567: Update select pattern and add jump menu JS.

### DIFF
--- a/styleguide/source/_patterns/01-atoms/forms/select-menu.twig
+++ b/styleguide/source/_patterns/01-atoms/forms/select-menu.twig
@@ -3,7 +3,8 @@
   <select
     name="{{selectMenu.id}}"
     id="{{selectMenu.id}}"
-    class="ama__select-menu__select js-dropdown-select {{ selectMenu.required ? 'js-required' : '' }}">
+    class="ama__select-menu__select ama__jump_menu {{ selectMenu.required ? 'js-required' : '' }}">
+    {# The `ama__jump_menu` class and the `data-url` options should only be included if this is a jump menu. #}
     <option value="" selected disabled hidden>Select an option</option>
     {% for option in selectMenu.options %}
       <option data-url="{{option.value}}" value="{{option.value}}">{{ option.text }}</option>

--- a/styleguide/source/assets/js/jump-menu.js
+++ b/styleguide/source/assets/js/jump-menu.js
@@ -1,0 +1,9 @@
+(function ($, Drupal) {
+  Drupal.behaviors.jumpMenu = {
+    attach: function (context, settings) {
+      $('.ama__jump_menu').on('selectmenuchange', function () {
+        window.location = $(this).find(':selected').data('url');
+      });
+    }
+  };
+})(jQuery, Drupal);


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6567: Hub page - podcast URL's not functioning as expected](https://issues.ama-assn.org/browse/EWL-6567)

## Description

Works with, but should not require, https://github.com/AmericanMedicalAssociation/ama-d8/pull/1031.

Added jump menu functionality to the hub card with multi cta links.

The existing pattern seems to be used as a stand in for multiple different select boxes. There should probably be multiple patterns, but I'm not sure right now what they are and what would be affected.

I've changed `js-dropdown-select` to `ama__jump_menu` in order to match the existing pattern with the use of the `data-url` attributes. This is the jump menu pattern. The `js-dropdown-select` is also used for exposed filters and other select boxes. The comment is intended to help a bit there.

The jump menu JS is largely taken from the previous rivendale theme code, but the selector is changed to `ama__jump_menu` and the event `selectmenuchange` was used instead of `change` since I had more success with that.

## To Test
- Load the style guide with `gulp serve`
- Go to /ama-style-guide-2/?p=pages-hub
- Select one of the links in the multi cta card
- The link will open and say it cannot connect to google. That is a success.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6567-hub-jump-menu/html_report/index.html).

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
