### PR TITLE
EWL-6549 Fix category navigation padding and margins

### DIFF
--- a/styleguide/source/_patterns/03-organisms/subcategory-exploration.twig
+++ b/styleguide/source/_patterns/03-organisms/subcategory-exploration.twig
@@ -11,11 +11,11 @@
     </ul>
   </div>
 
-  <a href="#" class="ama__subcategory-exploration__show-more">View all subcategories
+  <a href="#" class="ama__link--purple ama__subcategory-exploration__show-more">View all subcategories
     <span class="ama__subcategory-exploration__show-more--open">
       <i class="icon--opendropdown"></i>
     </span>
-    <span class="ama__subcategory-exploration__show-more--close">
+    <span class="ama__link--purple ama__subcategory-exploration__show-more--close">
       <i class="icon--closedropdown"></i>
     </span>
   </a>

--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -19,7 +19,6 @@
 
       // If the unordered list outerHeight is greater than the parent container then show the show more link
       if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
-
         $subcategoryListExpander.show();
       }
 

--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -17,8 +17,9 @@
       var $subcategoryListContainerHeight = $subcategoryListContainer.outerHeight();
       var $subcategoryListLinkText = $('.ama__subcategory-exploration__text');
 
-      // If the unordered list height is greater than the parent container then show the show more link
-      if ($subcategoryList.height() > $subcategoryListContainerHeight) {
+      // If the unordered list outerHeight is greater than the parent container then show the show more link
+      if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
+
         $subcategoryListExpander.show();
       }
 
@@ -27,8 +28,8 @@
         e.stopPropagation();
         e.preventDefault();
 
-        // Checks to see if the container has been expand or not by comparing initial height to current height
-        if($subcategoryListContainer.height() > $subcategoryListContainerHeight) {
+        // Checks to see if the container has been expand or not by comparing initial outerHeight to current outerHeight
+        if($subcategoryListContainer.outerHeight() > $subcategoryListContainerHeight) {
           $subcategoryListContainer.removeClass('ama__subcategory-exploration__list--expanded');
           $(this).removeClass('ama__subcategory-exploration__show-more--expanded');
           $subcategoryListLinkText.text('View all subcategories');

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -69,7 +69,7 @@
   }
 }
 
-.ama__subcategory-exploration__show-more {
+&__show-more {
   @include font-size($h2-font-sizes);
   width: 100%;
   display: none;

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -7,7 +7,7 @@
     padding: $gutter/2 0;
   }
 
-  .ama__subcategory-exploration__list {
+  &__list {
     overflow: hidden;
     height: 65px;
 

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -12,7 +12,7 @@
     height: 60px;
 
     @include breakpoint($bp-small) {
-      height: 80px;
+      height: 95px;
     }
 
     &--expanded {

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -9,7 +9,7 @@
 
   &__list {
     overflow: hidden;
-    height: 65px;
+    height: 60px;
 
     @include breakpoint($bp-small) {
       height: 80px;

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -1,18 +1,18 @@
 .ama__subcategory-exploration {
   border-bottom: solid 1px $gray-50;
-  padding-bottom: $gutter / 2;
   overflow: hidden;
+  padding: 0 0 $gutter/4 0;
+
   @include breakpoint($bp-small) {
-    padding-bottom: $gutter;
+    padding: $gutter/2 0;
   }
 
   .ama__subcategory-exploration__list {
     overflow: hidden;
-    height: 108px;
+    height: 65px;
 
-    @include breakpoint($bp-small max-width) {
-      margin-left: -2px - $gutter / 4;
-      height: 1.1em;
+    @include breakpoint($bp-small) {
+      height: 80px;
     }
 
     &--expanded {
@@ -23,35 +23,47 @@
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      margin-left: -2px - $gutter / 2;
     }
 
     li {
-      @include breakpoint($bp-small max-width) {
-        margin: 0 ($gutter / 4) ($gutter / 4) 0;
-        padding: 0 0 0 ($gutter / 4);
-      }
-
       list-style-type: none;
-      border-left: solid 2px;
-      margin: 0 ($gutter / 2) ($gutter / 2) 0;
-      padding: 0 0 0 ($gutter / 2);
-    }
+      margin: 0;
 
-    a {
-      text-decoration: none;
-
-      &:hover h2,
-      &:hover {
-        text-decoration: underline;
+      &:last-child a {
+        &:after {
+          content: "";
+          padding: 0;
+        }
       }
-    }
 
-    h2 {
-      font-weight: 600;
+      a {
+        text-decoration: none;
+        padding: 0;
+        font-weight: 600;
+        font-size: 14px;
 
-      @include breakpoint($bp-small max-width) {
-        font-size: 16px;
+        @include breakpoint($bp-small) {
+          font-weight: 900;
+          font-size: 26px;
+        }
+
+        &:after {
+          content: "|";
+          padding: 0 $gutter / 5;
+        }
+
+        &:hover h2,
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+
+      h2 {
+        line-height: 14px;
+
+        @include breakpoint($bp-small) {
+          line-height: 36px;
+        }
       }
     }
   }
@@ -60,26 +72,22 @@
 .ama__subcategory-exploration__show-more {
   @include font-size($h2-font-sizes);
   width: 100%;
+  display: none;
 
    @include breakpoint($bp-small max-width) {
      font-size: 16px;
    }
 
    @include breakpoint($bp-small) {
-     display: inline-block;
      margin-top: $gutter / 2;
    }
-
-  @include breakpoint($bp-large) {
-    display: none;
-  }
 
   .ama__subcategory-exploration__show-more--close {
     display: none;
 
     i {
       background-size: 14px 8px;
-      background-position: 0 0;
+      background-position: 0 6px;
       min-height: 14px;
       min-width: 14px;
       max-height: 14px;

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -23,100 +23,105 @@
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
+      margin-bottom: 0;
     }
 
     li {
       list-style-type: none;
       margin: 0;
 
-      &:last-child a {
-        &:after {
+      &:last-child a:after {
           content: "";
           padding: 0;
         }
       }
 
-      a {
-        text-decoration: none;
-        padding: 0;
+    a,
+    h2 {
+      text-decoration: none;
+      padding: 0;
+      font-weight: 600;
+      font-size: 14px;
+      display: inline;
+
+      @include breakpoint($bp-small) {
         font-weight: 600;
-        font-size: 14px;
-
-        @include breakpoint($bp-small) {
-          font-weight: 900;
-          font-size: 26px;
-        }
-
-        &:after {
-          content: "|";
-          padding: 0 $gutter / 5;
-        }
-
-        &:hover h2,
-        &:hover {
-          text-decoration: underline;
-        }
+        font-size: 26px;
       }
 
-      h2 {
-        line-height: 14px;
+      &:hover h2,
+      &:hover {
+        text-decoration: underline;
+      }
+    }
 
-        @include breakpoint($bp-small) {
-          line-height: 36px;
-        }
+
+    a:after {
+      content: "|";
+      padding: 0 $gutter / 5;
+    }
+
+
+    h2 {
+      line-height: 14px;
+
+      @include breakpoint($bp-small) {
+        line-height: 32px;
       }
     }
   }
-}
 
-&__show-more {
-  @include font-size($h2-font-sizes);
-  width: 100%;
-  display: none;
-
-   @include breakpoint($bp-small max-width) {
-     font-size: 16px;
-   }
-
-   @include breakpoint($bp-small) {
-     margin-top: $gutter / 2;
-   }
-
-  &__show-more--close {
+  &__show-more {
+    @include font-size($h3-font-sizes);
+    width: 100%;
     display: none;
 
-    i {
-      background-size: 14px 8px;
-      background-position: 0 6px;
-      min-height: 14px;
-      min-width: 14px;
-      max-height: 14px;
-      max-width: 14px;
+    @include breakpoint($bp-small max-width) {
+      font-size: 16px;
     }
-  }
 
-  .ama__subcategory-exploration__show-more--open {
-    display: inline-block;
-
-    i {
-      background-size: 14px 8px;
-      background-position: 0 0;
-      min-height: 14px;
-      min-width: 14px;
-      max-height: 14px;
-      max-width: 14px;
+    @include breakpoint($bp-small) {
+      margin-top: $gutter / 2;
+      line-height: 42px;
     }
-  }
 
-
-  &--expanded {
-    .ama__subcategory-exploration__show-more--open {
+    &--close {
       display: none;
+
+      i {
+        background-size: 14px 8px;
+        background-position: 0 6px;
+        min-height: 14px;
+        min-width: 14px;
+        max-height: 14px;
+        max-width: 14px;
+      }
     }
 
-    .ama__subcategory-exploration__show-more--close {
+    &--open {
       display: inline-block;
+
+      i {
+        background-size: 14px 8px;
+        background-position: 0 0;
+        min-height: 14px;
+        min-width: 14px;
+        max-height: 14px;
+        max-width: 14px;
+      }
+    }
+
+    &--expanded {
+      .ama__subcategory-exploration__show-more--open {
+        display: none;
+      }
+
+      .ama__subcategory-exploration__show-more--close {
+        display: inline-block;
+      }
     }
   }
 }
+
+
 

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -82,7 +82,7 @@
      margin-top: $gutter / 2;
    }
 
-  .ama__subcategory-exploration__show-more--close {
+  &__show-more--close {
     display: none;
 
     i {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-6549: Category mobile - navigation extending beyond page](https://issues.ama-assn.org/browse/EWL-6549)

## Description
Category MOBILE – Subcategory   Navigation is extending beyond page margins on the left

## To Test
- [ ] switch your branch to `bugfix/EWL-6549-sub-cat-nav`
- [ ] `gulp serve`
- [ ] enable local SG2 testing in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/advocacy
- [ ] test the category navigation in various viewports and observe the margins and padding
- [ ] observe that the category navigation on mobile is not cut off
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="492" alt="screen shot 2018-11-07 at 10 57 00 am" src="https://user-images.githubusercontent.com/2271747/48146984-deb41a00-e27b-11e8-866b-ef31ea3eca97.png">


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
