### PR TITLE
EWL-6484 Fix magnifying glass and search input to match zeplin

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -68,7 +68,7 @@
   }
 
   &--in-body {
-    align-items: unset;
+    align-items: stretch;
 
     input[type="text"] {
       border: 1px solid $purple;
@@ -88,8 +88,8 @@
     }
 
     .subcategory_listing {
-      min-height: 34px;
-      max-height: 34px;
+      min-height: 35px;
+      max-height: 35px;
 
       svg {
         height: 24px;

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -70,6 +70,11 @@
   &--in-body {
     align-items: unset;
 
+    input[type="text"] {
+      border: 1px solid $purple;
+    }
+
+
     .ama__search__field__input[type="text"],
     .ama__search__field__input[type="text"]:focus,
     .ama__search__field__input[type="text"]:active {
@@ -77,9 +82,19 @@
     }
 
     .ama__search__field__button {
-      background: $purple;
+      background-color: $purple;
       margin: 0;
       padding: 5px 5px 0;
+    }
+
+    .subcategory_listing {
+      min-height: 34px;
+      max-height: 34px;
+
+      svg {
+        height: 24px;
+        width: 26px;
+      }
     }
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6484: A1 | Fix magnifying glass on category pages](https://issues.ama-assn.org/browse/EWL-6484)

## Description
Fix magnifying glass icon and search input to match zeplin mockup

## To Test
- [ ] switch your branch to `bugfix/EWL-6549-sub-cat-nav`
- [ ] `gulp serve`
- [ ] enable local SG2 testing in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/advocacy/physician-advocacy
- [ ] test the search icon and input match zeplin https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5b0449d1b0161ad12b61abaf
- [ ] observe that the search input is no longer blue and the icon is lined up with the input field
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="1244" alt="screen shot 2018-11-07 at 11 23 00 am" src="https://user-images.githubusercontent.com/2271747/48148508-8121cc80-e27f-11e8-89b9-5685f3c84742.png">


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
