### PR TITLE
EWL-6555 Fixes subcat images superimposing themselves in IE11

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -103,22 +103,22 @@
         @include gutter($margin-top-full...);
         display: grid;
         grid-template-columns: 1fr 1fr 1fr;
+        -ms-grid-columns: 1fr $gutter 1fr $gutter 1fr;
+        grid-gap: $gutter;
         grid-template-rows: auto auto;
 
         .ama__article-stub {
-          @include gutter($padding-right-full...);
-          width: 100%;
 
-          &:nth-child(2) {
-            -ms-grid-column: 2;
+          &:nth-child(1) {
+            -ms-grid-column: 1;
           }
 
-          &:nth-child(3) {
+          &:nth-child(2) {
             -ms-grid-column: 3;
           }
 
-          &:last-child {
-            padding-right: 0;
+          &:nth-child(3) {
+            -ms-grid-column: 5;
           }
 
           h3 {

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -104,12 +104,34 @@
         display: grid;
         grid-template-columns: 1fr 1fr 1fr;
         grid-template-rows: auto auto;
-        grid-column-gap: $gutter;
-        grid-row-gap: $gutter;
 
         .ama__article-stub {
+          @include gutter($padding-right-full...);
           width: 100%;
+
+          &:nth-child(2) {
+            -ms-grid-column: 2;
+          }
+
+          &:nth-child(3) {
+            -ms-grid-column: 3;
+          }
+
+          &:last-child {
+            padding-right: 0;
+          }
+
+          h3 {
+            padding: 0;
+          }
+
+          .ama__image {
+            margin-bottom: 0;
+          }
+
         }
+
+
       }
     }
   }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6555: IE Homepage - Category Nav Menu Subcategory pages have distorted Image and Text](https://issues.ama-assn.org/browse/EWL-6555)

## Description
The images on subcat pages are superimposing themselves in IE11


## To Test
- [ ] switch your branch to `bugfix/EWL-6555-subcat-pages-images`
- [ ] `gulp serve`
- [ ] switch your D8 branch to `bugfix/EWL-6555-subcat-pages-images`
- [ ] enable local SG2 in your local.yml
- [ ] `drush @one.local cr`
- [ ] open IE11 browserstack with local testing
- [ ] visit http://ama-one.local/member-groups-sections/advisory-committee-lgbtq-issues 
- [ ] observe the images are no longer stacked

## Visual Regressions
n/a

## Relevant Screenshots/GIFs
<img width="1686" alt="screen shot 2018-11-07 at 2 17 42 pm" src="https://user-images.githubusercontent.com/2271747/48158343-eaadd500-e297-11e8-9a3d-6f32a0305a85.png">

## Remaining Tasks
n/a

## Additional Notes
There is D8 dependency
https://github.com/AmericanMedicalAssociation/ama-d8/compare/bugfix%2FEWL-6555-subcat-pages-images?expand=1

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
