### PR TITLE
EWL-6568 Fix images getting stretched on hub cards

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -37,7 +37,7 @@
     height: 100%;
     
     .ama__image {
-      min-height: 400px;
+      object-fit: cover;
       height: auto;
       width: 100%;
     }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6568: Hub page - images distorted](https://issues.ama-assn.org/browse/EWL-6568)

## Description
Images are getting stretched on hub cards

## To Test
- [ ] switch your branch to `bugfix/EWL-6568-hub-images`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/node/24851
- [ ] observe the hub card images are no longer stretched

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
**Prod**
<img width="1337" alt="screen shot 2018-11-07 at 2 35 34 pm" src="https://user-images.githubusercontent.com/2271747/48159293-6d379400-e29a-11e8-8240-5b594e554bf8.png">

**In PR**
<img width="1268" alt="screen shot 2018-11-07 at 2 36 03 pm" src="https://user-images.githubusercontent.com/2271747/48159320-788abf80-e29a-11e8-942f-a8c85355e83f.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
