### PR TITLE
EWL-6566 adds margin on top of resource nav tabs

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -1,4 +1,5 @@
 .ama__resource-tabs {
+  @include gutter($margin-top-half...);
   height: 100%;
 }
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6566: Resources - Resource Tab Display Issue](https://issues.ama-assn.org/browse/EWL-6566)

## Description
Global nav and the resource tab nav is running into each other. Add margin to separate the two

## To Test
- [ ] switch your branch to `bugfix/EWL-6568-hub-images`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/test/resource_page_1
- [ ] observe the resource nav has a margin on top separating the global nav from it

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
**Prod**
<img width="1251" alt="screen shot 2018-11-07 at 3 09 05 pm" src="https://user-images.githubusercontent.com/2271747/48161021-213b1e00-e29f-11e8-948b-9c9fcb4db600.png">


**In PR**
<img width="1223" alt="screen shot 2018-11-07 at 3 09 12 pm" src="https://user-images.githubusercontent.com/2271747/48161011-1a141000-e29f-11e8-829b-f34353dcf484.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
