### PR TITLE
EWL-6548 Fix table alternating colors for mobile

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -68,25 +68,35 @@ tbody {
 
     @include breakpoint($bp-small) {
       display: table-row;
-    }
 
-    &.odd,
-    &:nth-child(odd)  {
-      background: $gray-7;
+      &.odd,
+      &:nth-child(odd)  {
+        background: $gray-7;
+      }
     }
 
     td {
       border: 1px solid $gray-7;
       display: block;
-      padding: 2px 2px 2px 50%;
+      padding: 2px;
       position: relative;
       hyphens: auto;
+
+      &.odd,
+      &:nth-child(odd)  {
+        background: $gray-7;
+      }
 
       @include breakpoint($bp-small) {
         display: table-cell;
         vertical-align: top;
         padding: 2px;
         border: 1px solid $gray-50;
+
+        &.odd,
+        &:nth-child(odd)  {
+          background: transparent;
+        }
       }
 
       &:before {

--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -78,7 +78,7 @@ tbody {
     td {
       border: 1px solid $gray-7;
       display: block;
-      padding: 2px;
+      padding: 2px 2px 2px 50%;
       position: relative;
       hyphens: auto;
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6548: Resource page - mobile. Tables grey/white not displaying correctly](https://issues.ama-assn.org/browse/EWL-6548)

## Description
The mobile version of the resource tables tab alternating row colors is not correct. They are not alternating

## To Test
- [ ] switch your branch to `bugfix/EWL-6548-resource-tables`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/member-groups-sections/international-medical-graduates/imgs-meeting-agenda-important-dates#schedules
- [ ] change your viewport to mobile
- [ ] click on the tables tab on the right
- [ ] observe the table alternating row colors go from grey to white consistently

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
**Prod**
<img width="481" alt="screen shot 2018-11-07 at 3 25 58 pm" src="https://user-images.githubusercontent.com/2271747/48161963-76782f00-e2a1-11e8-8f9d-f421d82f6976.png">


**In PR**
<img width="479" alt="screen shot 2018-11-07 at 3 26 06 pm" src="https://user-images.githubusercontent.com/2271747/48161970-7a0bb600-e2a1-11e8-8724-88f1d29e7015.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
