### PR TITLE
Fix email subscription button getting cut off in tablet view

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -16,7 +16,6 @@
       margin: 0 auto;
       padding: $gutter / 2.2;
       border: 0;
-      height: 49px;
 
       &:hover {
         background: $hoverPurple;

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -16,6 +16,7 @@
       margin: 0 auto;
       padding: $gutter / 2.2;
       border: 0;
+      height: 49px;
 
       &:hover {
         background: $hoverPurple;
@@ -79,7 +80,6 @@
 
       @include breakpoint($bp-med min-width) {
         flex-direction: row;
-        height: 49px;
 
         .ama__form-group input {
           margin-bottom: 0;


### PR DESCRIPTION
## Ticket(s)


## Description
The email subscription button is getting cut in tablet view.
<img width="1034" alt="pattern_lab_-_pages-homepage" src="https://user-images.githubusercontent.com/2271747/48227227-5ad75c00-e367-11e8-8979-3d026a6ada08.png">



## To Test
- [ ] switch branch to
- [ ] `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-homepage
- [ ] press the pattern lab menu L button
<img width="430" alt="screen shot 2018-11-08 at 3 04 02 pm" src="https://user-images.githubusercontent.com/2271747/48227314-8ce8be00-e367-11e8-9646-8251f4dd78c9.png">
- [ ] keep resizing your viewport at all different sizes to see if the email promo button gets cut in half
- [ ] observe the email subscription button no longer is cut in half
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
<img width="1035" alt="screen shot 2018-11-08 at 3 06 44 pm" src="https://user-images.githubusercontent.com/2271747/48227468-0bddf680-e368-11e8-8a0e-83b36676317d.png">


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
