### PR TITLE
EWL-6096: hover purple color

### DIFF
--- a/styleguide/source/assets/scss/00-base/_colors.scss
+++ b/styleguide/source/assets/scss/00-base/_colors.scss
@@ -6,7 +6,7 @@ $purple: #46166B;
 //Hover Colors
 $hoverBlue: #3597C9;
 $hoverOrange: #F1A233;
-$hoverPurple: #9073A6;
+$hoverPurple: #DAD0E1;
 $hoverBlack: #333333;
 $hoverRed: #d81735; // JAMA red
 

--- a/styleguide/source/assets/scss/00-base/_colors.scss
+++ b/styleguide/source/assets/scss/00-base/_colors.scss
@@ -6,7 +6,8 @@ $purple: #46166B;
 //Hover Colors
 $hoverBlue: #3597C9;
 $hoverOrange: #F1A233;
-$hoverPurple: #DAD0E1;
+$hoverPurple: #9073A6;
+$bodyTextHoverPurple: #DAD0E1;
 $hoverBlack: #333333;
 $hoverRed: #d81735; // JAMA red
 

--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -10,7 +10,7 @@ a {
  a {
    &:hover,
    &:focus {
-     background-color: $hoverPurple;
+     background-color: $bodyTextHoverPurple;
    }
  }
 }

--- a/styleguide/source/assets/scss/05-pages/_resource.scss
+++ b/styleguide/source/assets/scss/05-pages/_resource.scss
@@ -1,5 +1,5 @@
 .ama__page--resource__resource-link {
-  background: $hoverPurple;
+  background: $bodyTextHoverPurple;
   text-decoration: none;
 
   &:hover {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6096: in body link color](https://issues.ama-assn.org/browse/EWL-6096)

## Description
Explain the technical implementation of the work done.


## To Test
- run `gulp serve`
- View the news article page, http://localhost:3000/?p=pages-news
- Hover over a text link
- View the resource page, http://localhost:3000/?p=pages-resource
- View the inline resource links
- The the inline resource link always has the new color as a background, hover or not

Previous

![previous](https://user-images.githubusercontent.com/397902/48366080-629e4580-e672-11e8-9ae8-a630df1856d2.jpg)

New

![new](https://user-images.githubusercontent.com/397902/48366123-819cd780-e672-11e8-9ee2-2933fa1df95e.jpg)


## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6096-hover-purple-color/html_report/index.html).

## Relevant Screenshots/GIFs
See testing steps

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
