### PR TITLE
EWL-6148: Add special formatting for related article news teasers.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -184,3 +184,15 @@
     }
   }
 }
+
+.ama__page--news__teasers {
+  .ama__h5--purple {
+    font-size: 12px;
+    font-weight: normal;
+  }
+
+  .ama__article-stub__title {
+    font-size: 12px;
+    font-weight: normal;
+  }
+}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6148: Text on related articles is too big](https://issues.ama-assn.org/browse/EWL-6148)

## Description

Should be tested with https://github.com/AmericanMedicalAssociation/ama-d8/pull/1042.

Adds specific styles for unique display of the related articles when used on the bottom of a news article.

## To Test
- View an example link, http://ama-one.local/house-delegates/ama-elections/physicians-elect-ama-trustees-council-members
- Confirm that the text in the related articles is smaller (12px) and normal weight.

![current](https://user-images.githubusercontent.com/397902/48372740-1f999d80-e685-11e8-9d69-8b2e7fdeff7e.jpg)

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6148-related-article-text-size/html_report/index.html).

## Relevant Screenshots/GIFs
See testing steps

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
