### PR TITLE
EWL-6174: Tools list header uses h3.

### DIFF
--- a/styleguide/source/_patterns/03-organisms/tools.json
+++ b/styleguide/source/_patterns/03-organisms/tools.json
@@ -1,9 +1,9 @@
 {
   "tools": {
     "heading": {
-      "class": "ama__h5",
+      "class": "ama__h3",
       "text": "Topics, Tools and Resources",
-      "level": "5"
+      "level": "3"
     },
     "list": [
       {

--- a/styleguide/source/_patterns/05-pages/category.json
+++ b/styleguide/source/_patterns/05-pages/category.json
@@ -1074,9 +1074,9 @@
     },
     "tools": {
       "heading": {
-        "class": "ama__h5",
+        "class": "ama__h3",
         "text": "Topics, Tools and Resources",
-        "level": "5"
+        "level": "3"
       },
       "list": [
         {

--- a/styleguide/source/_patterns/05-pages/event.json
+++ b/styleguide/source/_patterns/05-pages/event.json
@@ -1461,9 +1461,9 @@
   },
   "tools": {
     "heading": {
-      "class": "ama__h4",
+      "class": "ama__h3",
       "text": "Event Resources",
-      "level": "4"
+      "level": "3"
     },
     "list": [
       {

--- a/styleguide/source/_patterns/05-pages/news/news-as-gated.json
+++ b/styleguide/source/_patterns/05-pages/news/news-as-gated.json
@@ -1058,9 +1058,9 @@
   },
   "tools": {
     "heading": {
-      "class": "ama__h4",
+      "class": "ama__h3",
       "text": "Topics, Tools and Resources",
-      "level": "4"
+      "level": "3"
     },
     "list": [
       {

--- a/styleguide/source/_patterns/05-pages/news/news-with-jama-examples.json
+++ b/styleguide/source/_patterns/05-pages/news/news-with-jama-examples.json
@@ -1058,9 +1058,9 @@
   },
   "tools": {
     "heading": {
-      "class": "ama__h4",
+      "class": "ama__h3",
       "text": "Topics, Tools and Resources",
-      "level": "4"
+      "level": "3"
     },
     "list": [
       {

--- a/styleguide/source/_patterns/05-pages/news/news.json
+++ b/styleguide/source/_patterns/05-pages/news/news.json
@@ -1058,9 +1058,9 @@
   },
   "tools": {
     "heading": {
-      "class": "ama__h4",
+      "class": "ama__h3",
       "text": "Topics, Tools and Resources",
-      "level": "4"
+      "level": "3"
     },
     "list": [
       {

--- a/styleguide/source/_patterns/05-pages/people-bio.json
+++ b/styleguide/source/_patterns/05-pages/people-bio.json
@@ -1230,9 +1230,9 @@
     ],
     "tools": {
       "heading": {
-        "class": "ama__h5",
+        "class": "ama__h3",
         "text": "Category Resources",
-        "level": "5"
+        "level": "3"
       },
       "list": [
         {

--- a/styleguide/source/_patterns/05-pages/press-release.json
+++ b/styleguide/source/_patterns/05-pages/press-release.json
@@ -996,9 +996,9 @@
   },
   "tools": {
     "heading": {
-      "class": "ama__h4",
+      "class": "ama__h3",
       "text": "Topics, Tools and Resources",
-      "level": "4"
+      "level": "3"
     },
     "list": [
       {

--- a/styleguide/source/_patterns/05-pages/topic.json
+++ b/styleguide/source/_patterns/05-pages/topic.json
@@ -1093,9 +1093,9 @@
   },
   "tools": {
     "heading": {
-      "class": "ama__h5",
+      "class": "ama__h3",
       "text": "Topics, Tools and Resources",
-      "level": "5"
+      "level": "3"
     },
     "list": [
       {

--- a/styleguide/source/assets/scss/03-organisms/_tools.scss
+++ b/styleguide/source/assets/scss/03-organisms/_tools.scss
@@ -6,7 +6,7 @@
     padding: 0;
   }
 
-  h5 {
+  h3 {
     @include gutter($padding-bottom-quarter...);
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6174: News Article - tools](https://issues.ama-assn.org/browse/EWL-6174)

## Description
Makes the header in the tools list larger.

Update all of the example data files to use h3.
Update the SCSS rule to use h3.

## To Test

Visit these pages to confirm the tools blocks use h3's

http://localhost:3000/?p=pages-news
http://localhost:3000/?p=pages-category
http://localhost:3000/?p=pages-event
http://localhost:3000/?p=pages-people-bio
http://localhost:3000/?p=pages-press-release
http://localhost:3000/?p=pages-topic

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6174-tools-and-resources-header/html_report/index.html).

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A

## Additional Notes
The story asked to make sure wrapping works. It works.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
