### PR TITLE
[Hotfix] Resource page split layout

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_split.scss
+++ b/styleguide/source/assets/scss/04-templates/_split.scss
@@ -22,6 +22,7 @@
 
 .ama__layout--split__left {
   grid-column: 1 / 3;
+  grid-row: 2;
   @include breakpoint($bp-small) {
     grid-column: 1 / 2;
     padding-right: $gutter / 2;
@@ -30,9 +31,9 @@
 
 .ama__layout--split__right {
   grid-column: 1 / 3;
-  grid-row: 2;
+  grid-row: 3;
   @include breakpoint($bp-small) {
-    grid-row: 1;
+    grid-row: 2;
     grid-column: 2 / 3;
     border-left: solid 1px $gray-50;
   }


### PR DESCRIPTION
## Description
Corrects split column layout by adding missing grid row.


## To Test
- Pull `hotfix/split-column-styles` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work fixes a bug apparent in D8 and thus should be tested against it. Update ama-d8 local provision vars accordingly. 
- Ensure you have prod content before testing further.
- Go to any resource page such as [IPPS meeting documents](http://ama-one.local/member-groups-sections/integrated-physician-practices/ipps-meeting-documents) and confirm that left content is side by side with right side content.
- Check other pages/components which may use a split layout and confirm that it still works as it did before.
- Test this in IE 11, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/hotfix/split-column-styles/html_report/index.html).


## Relevant Screenshots/GIFs
Bug Screenshot
![image](https://user-images.githubusercontent.com/4438120/48377537-b705ed00-e693-11e8-8630-80534b0085a8.png)



## Remaining Tasks
N/A


## Additional Notes
N/A
