### PR TITLE
[EWL-6154] Resource page downloads tab updates

### DIFF
--- a/styleguide/source/_patterns/02-molecules/download-link.json
+++ b/styleguide/source/_patterns/02-molecules/download-link.json
@@ -1,0 +1,9 @@
+{
+  "downloadLink": {
+    "icon": "icon--audio",
+    "text": "Test Tool Audio",
+    "type": ".AAC",
+    "size": "12.5 MB",
+    "link": "https://www.ama-assn.org"
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/download-link.json
+++ b/styleguide/source/_patterns/02-molecules/download-link.json
@@ -2,7 +2,7 @@
   "downloadLink": {
     "icon": "icon--audio",
     "text": "Test Tool Audio",
-    "type": ".AAC",
+    "type": "AAC",
     "size": "12.5 MB",
     "link": "https://www.ama-assn.org"
   }

--- a/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -4,6 +4,6 @@
 
 <a class="ama__download-link" href={{ link }}>
   <icon class="ama__download-link__icon {{ icon }}"></icon>
-  <div class="ama__download-link__text">{{ text }}</div>
-  <div class="ama__download-link__details">{{ type }}, {{ size }}<icon class="icon--download"></icon></div>
+  <span class="ama__download-link__text"><span class="ama__download-link__title"{{ text }}</span><span class="ama__download-link__details">{{ type }}, {{ size }}<icon class="icon--download"></icon></span></div>
+
 </a>

--- a/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -1,0 +1,9 @@
+{% set icon, text, type, size, link =
+  downloadLink.icon, downloadLink.text, downloadLink.type, downloadLink.size, downloadLink.link
+%}
+
+<a class="ama__download-link" href={{ link }}>
+  <icon class="ama__download-link__icon {{ icon }}"></icon>
+  <div class="ama__download-link__text">{{ text }}</div>
+  <div class="ama__download-link__details">{{ type }}, {{ size }}<icon class="icon--download"></icon></div>
+</a>

--- a/styleguide/source/_patterns/02-molecules/download-link.twig
+++ b/styleguide/source/_patterns/02-molecules/download-link.twig
@@ -4,6 +4,8 @@
 
 <a class="ama__download-link" href={{ link }}>
   <icon class="ama__download-link__icon {{ icon }}"></icon>
-  <span class="ama__download-link__text"><span class="ama__download-link__title"{{ text }}</span><span class="ama__download-link__details">{{ type }}, {{ size }}<icon class="icon--download"></icon></span></div>
-
+  <div class="ama__download-link__text">
+    <span class="ama__download-link__title">{{ text }}</span>
+    <span class="ama__download-link__details">{{ type }}, {{ size }}<icon class="icon--download"></icon></span>
+  </div>
 </a>

--- a/styleguide/source/_patterns/03-organisms/resource-tabs.json
+++ b/styleguide/source/_patterns/03-organisms/resource-tabs.json
@@ -86,83 +86,83 @@
       "tabId": "media",
       "tabClasses": "js--tab-start--tablet",
       "tabContent": {
-          "media": [
-            {
-              "heading": {
-                "text": "Media 1",
-                "level": "3",
-                "class": "ama__h3"
-              },
-              "link": {
-                "href": "yahoo.biz",
-                "title": "a link to a thing",
-                "text": "Lorem ipsum audio.mp4",
-                "target": "_self",
-                "class": "ama__link--icon ama__link--no-underline",
-                "iconLeft": "@atoms/media/icons/svg/icon-audio.twig"
-              }
+        "media": [
+          {
+            "heading": {
+              "text": "Media 1",
+              "level": "3",
+              "class": "ama__h3"
             },
-            {
-              "heading": {
-                "text": "Media 2",
-                "level": "3",
-                "class": "ama__h3"
-              },
-              "link": {
-                "href": "aol.gov",
-                "title": "a link to a thing two",
-                "text": "Link to this video",
-                "class": "ama__link--icon ama__link--no-underline",
-                "iconLeft": "@atoms/media/icons/svg/icon-video.twig"
-              },
-              "video": {
-                "src": "https://player.vimeo.com/video/60673761"
-              },
-              "subtext": {
-                "text": "This is example subtext for a media type.",
-                "class": "ama__type--small"
-              }
-            },
-            {
-              "heading": {
-                "text": "Media 3",
-                "level": "3",
-                "class": "ama__h3"
-              },
-              "link": {
-                "href": "#",
-                "title": "a link to a thing three",
-                "text": "Link to this image",
-                "class": "ama__link--icon ama__link--no-underline",
-                "iconLeft": "@atoms/media/icons/svg/icon-image-gold.twig"
-              },
-              "image": {
-                "alt": "alt text",
-                "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
-                "height": "600",
-                "width": "800"
-              },
-              "subtext": {
-                "text": "This is example subtext for a media type.",
-                "class": "ama__type--small"
-              }
-            },
-            {
-              "heading": {
-                "text": "Media 4",
-                "level": "3",
-                "class": "ama__h3"
-              },
-              "link": {
-                "href": "askjeeves.org",
-                "title": "a link to a thing four",
-                "text": "The Best Podcast Ever",
-                "target": "_self",
-                "class": "ama__link--icon ama__link--no-underline",
-                "iconLeft": "@atoms/media/icons/svg/icon-podcast.twig"
-              }
+            "link": {
+              "href": "yahoo.biz",
+              "title": "a link to a thing",
+              "text": "Lorem ipsum audio.mp4",
+              "target": "_self",
+              "class": "ama__link--icon ama__link--no-underline",
+              "iconLeft": "@atoms/media/icons/svg/icon-audio.twig"
             }
-          ],
+          },
+          {
+            "heading": {
+              "text": "Media 2",
+              "level": "3",
+              "class": "ama__h3"
+            },
+            "link": {
+              "href": "aol.gov",
+              "title": "a link to a thing two",
+              "text": "Link to this video",
+              "class": "ama__link--icon ama__link--no-underline",
+              "iconLeft": "@atoms/media/icons/svg/icon-video.twig"
+            },
+            "video": {
+              "src": "https://player.vimeo.com/video/60673761"
+            },
+            "subtext": {
+              "text": "This is example subtext for a media type.",
+              "class": "ama__type--small"
+            }
+          },
+          {
+            "heading": {
+              "text": "Media 3",
+              "level": "3",
+              "class": "ama__h3"
+            },
+            "link": {
+              "href": "#",
+              "title": "a link to a thing three",
+              "text": "Link to this image",
+              "class": "ama__link--icon ama__link--no-underline",
+              "iconLeft": "@atoms/media/icons/svg/icon-image-gold.twig"
+            },
+            "image": {
+              "alt": "alt text",
+              "src": "https://ipsumimage.appspot.com/800x600x186?l=3:2|800x600&s=36",
+              "height": "600",
+              "width": "800"
+            },
+            "subtext": {
+              "text": "This is example subtext for a media type.",
+              "class": "ama__type--small"
+            }
+          },
+          {
+            "heading": {
+              "text": "Media 4",
+              "level": "3",
+              "class": "ama__h3"
+            },
+            "link": {
+              "href": "askjeeves.org",
+              "title": "a link to a thing four",
+              "text": "The Best Podcast Ever",
+              "target": "_self",
+              "class": "ama__link--icon ama__link--no-underline",
+              "iconLeft": "@atoms/media/icons/svg/icon-podcast.twig"
+            }
+          }
+        ],
         "membership": {
           "heading": {
             "text": "Title for Membership Block"
@@ -175,7 +175,7 @@
             "text": "This is CTA text."
           }
         }
-        }
+      }
     },
     {
       "tabTitle": "Downloads",
@@ -193,11 +193,9 @@
               "level": "5",
               "class": "ama__h5"
             },
-            "tool": {
+            "resourceDownloadLink": {
               "icon": "icon--audio",
-              "paragraph": {
-                "text": "Test Tool Audio"
-              },
+              "text": "Test Tool Audio",
               "type": ".AAC",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
@@ -210,11 +208,9 @@
               "level": "3",
               "class": "ama__h3"
             },
-            "tool": {
+            "resourceDownloadLink": {
               "icon": "icon--pdf",
-              "paragraph": {
-                "text": "Test Tool PDF"
-              },
+              "text": "Test Tool PDF",
               "type": ".PDF",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
@@ -226,11 +222,9 @@
               "level": "3",
               "class": "ama__h3"
             },
-            "tool": {
+            "resourceDownloadLink": {
               "icon": "icon--pdf",
-              "paragraph": {
-                "text": "Test Tool PDF"
-              },
+              "text": "Test Tool PDF",
               "type": ".PDF",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
@@ -303,13 +297,12 @@
       "tabTitle": "Schedules",
       "tabId": "schedules",
       "tabContent": {
-        "schedules":[
+        "schedules": [
           {
             "heading": {
               "level": "3",
               "class": "ama__h3",
               "text": "Schedule 1"
-
             },
             "subheading": {
               "level": "5",

--- a/styleguide/source/_patterns/03-organisms/resource-tabs.twig
+++ b/styleguide/source/_patterns/03-organisms/resource-tabs.twig
@@ -69,8 +69,8 @@
           {% include '@atoms/heading/heading.twig' %}
         {% endif %}
 
-        {% set tool = download.tool %}
-        {% include '@molecules/tool/tool.twig' %}
+        {% set downloadLink = download.resourceDownloadLink %}
+        {% include '@molecules/download-link.twig' %}
 
         {% if download.subtext %}
           <p class="ama__type--small">{{ link.subtext }}</p>

--- a/styleguide/source/_patterns/05-pages/resource.json
+++ b/styleguide/source/_patterns/05-pages/resource.json
@@ -1148,7 +1148,7 @@
             "resourceDownloadLink": {
               "icon": "icon--audio",
               "text": "Test Tool Audio",
-              "type": ".AAC",
+              "type": "AAC",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
             },
@@ -1163,7 +1163,7 @@
             "resourceDownloadLink": {
               "icon": "icon--pdf",
               "text": "Test Tool PDF",
-              "type": ".PDF",
+              "type": "PDF",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
             }
@@ -1177,7 +1177,7 @@
             "resourceDownloadLink": {
               "icon": "icon--pdf",
               "text": "Test Tool PDF",
-              "type": ".PDF",
+              "type": "PDF",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
             }

--- a/styleguide/source/_patterns/05-pages/resource.json
+++ b/styleguide/source/_patterns/05-pages/resource.json
@@ -1145,11 +1145,9 @@
               "level": "5",
               "class": "ama__h5"
             },
-            "tool": {
+            "resourceDownloadLink": {
               "icon": "icon--audio",
-              "paragraph": {
-                "text": "Test Tool Audio"
-              },
+              "text": "Test Tool Audio",
               "type": ".AAC",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
@@ -1162,11 +1160,9 @@
               "level": "3",
               "class": "ama__h3"
             },
-            "tool": {
+            "resourceDownloadLink": {
               "icon": "icon--pdf",
-              "paragraph": {
-                "text": "Test Tool PDF"
-              },
+              "text": "Test Tool PDF",
               "type": ".PDF",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"
@@ -1178,11 +1174,9 @@
               "level": "3",
               "class": "ama__h3"
             },
-            "tool": {
+            "resourceDownloadLink": {
               "icon": "icon--pdf",
-              "paragraph": {
-                "text": "Test Tool PDF"
-              },
+              "text": "Test Tool PDF",
               "type": ".PDF",
               "size": "12.5 MB",
               "link": "https://www.ama-assn.org"

--- a/styleguide/source/assets/scss/02-molecules/_download-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_download-link.scss
@@ -1,7 +1,7 @@
 .ama__download-link {
   display: flex;
   align-items: flex-start;
-  margin-bottom: $gutter/2;
+  margin-bottom: $gutter/4;
 
   & > * {
     display: inline-block;

--- a/styleguide/source/assets/scss/02-molecules/_download-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_download-link.scss
@@ -17,6 +17,7 @@
 
   &__title {
     margin-right: $gutter/2;
+    text-decoration: underline;
   }
   // Mimic current icon styles on a smaller scale
   .icon--download {

--- a/styleguide/source/assets/scss/02-molecules/_download-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_download-link.scss
@@ -1,18 +1,22 @@
 .ama__download-link {
-  display: inline-flex;
-  align-items: flex-end;
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: $gutter/2;
 
   & > * {
     display: inline-block;
-    flex: 0 0 auto;
+  }
+  &__icon {
+    flex: 0 1 20%;
   }
 
   &__text {
-    margin-right: 14px;
+    flex: 0 1 80%;
+    margin-top: 20px;
   }
 
-  &__details {
-    text-decoration: none;
+  &__title {
+    margin-right: $gutter/2;
   }
   // Mimic current icon styles on a smaller scale
   .icon--download {

--- a/styleguide/source/assets/scss/02-molecules/_download-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_download-link.scss
@@ -1,0 +1,28 @@
+.ama__download-link {
+  display: inline-flex;
+  align-items: flex-end;
+
+  & > * {
+    display: inline-block;
+    flex: 0 0 auto;
+  }
+
+  &__text {
+    margin-right: 14px;
+  }
+
+  &__details {
+    text-decoration: none;
+  }
+  // Mimic current icon styles on a smaller scale
+  .icon--download {
+    $dimensions: .7em;
+    min-width: $dimensions;
+    min-height: $dimensions;
+    max-width: $dimensions;
+    max-height: $dimensions;
+    background-size: contain;
+    margin-left: 7px;
+  }
+}
+

--- a/styleguide/source/assets/scss/02-molecules/_download-link.scss
+++ b/styleguide/source/assets/scss/02-molecules/_download-link.scss
@@ -21,7 +21,7 @@
   }
   // Mimic current icon styles on a smaller scale
   .icon--download {
-    $dimensions: .7em;
+    $dimensions: .8em;
     min-width: $dimensions;
     min-height: $dimensions;
     max-width: $dimensions;

--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -212,3 +212,7 @@ section#related_links ul {
     margin: 0;
   }
 }
+
+#downloads .ama__resource-tabs__item{
+  margin-bottom: $gutter-mobile;
+}


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6154 | there should be a file type, file size and download icon](https://issues.ama-assn.org/browse/EWL-6154)

## Description
Updates the resource page download tab items to match [Zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5ac399758c5bcb5a61ba6022). Adds class style to help with vertical spacing in D8.


## To Test
- Pull `feature/EWL-6154-resource-download-items` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Go to [SG2 resource page](http://localhost:3000/?p=pages-resource) and on download tab confirm that item styles match what is seen in Zeplin linked above.
- Test this in IE 11, Safari, and Firefox to ensure everything works as expected.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6154-resource-download-items/html_report/index.html).


## Relevant Screenshots/GIFs
Screenshot from SG2
![image](https://user-images.githubusercontent.com/4438120/48503764-a32fc780-e808-11e8-828d-73fa1e1dc7f1.png)



## Remaining Tasks
N/A


## Additional Notes
N/A
