### PR TITLE
EWL-6582 Fixes hover and active state for sub cat search box

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -72,6 +72,13 @@
 
     input[type="text"] {
       border: 1px solid $purple;
+      margin: 0;
+
+      &:hover,
+      &:active,
+      &:focus {
+        border: 1px solid $purple;
+      }
     }
 
 

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -95,8 +95,8 @@
     }
 
     .subcategory_listing {
-      min-height: 35px;
-      max-height: 35px;
+      min-height: 36px;
+      max-height: 36px;
 
       svg {
         height: 24px;

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -95,8 +95,8 @@
     }
 
     .subcategory_listing {
-      min-height: 36px;
-      max-height: 36px;
+      min-height: 37px;
+      max-height: 37px;
 
       svg {
         height: 24px;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-6582: Sub-Category - Search bug](https://issues.ama-assn.org/browse/EWL-6582)

## Description
Fix active and hover state of search box on subcategory pages. The search box should not turn blue when active

## To Test
- [ ] switch branch to `bugfix/EWL-6582-search-bug`
- `gulp serve`
- enable local SG2 in your D8 instance (it should be on the develop branch)
- visit http://ama-one.local/practice-management/cptr
- click on the search box
- observe the search box no longer turns blue
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6582-search-bug/html_report/index.html).


## Relevant Screenshots/GIFs
Before:
![screen shot 2018-11-15 at 11 19 49 am](https://user-images.githubusercontent.com/2271747/48569822-62978300-e8c8-11e8-8930-93585146ae3d.png)

After:
![screen shot 2018-11-15 at 11 19 56 am](https://user-images.githubusercontent.com/2271747/48569826-675c3700-e8c8-11e8-9a19-dd7ff9c24bac.png)



## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
