### PR TITLE
EWL-6566 Fixes height of resource tabs flowing into footer

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -1,9 +1,9 @@
 .ama__resource-tabs {
-  @include gutter($margin-top-half...);
-  height: 100%;
+  margin: 0;
 }
 
 .ama__resource-tabs__nav.ui-tabs-nav {
+  @include gutter($margin-top-half...);
   position: relative;
   width: 100%;
   background: $purple;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6566: Resources - Resource Tab Display Issue](https://issues.ama-assn.org/browse/EWL-6566)

## Description
The resource page tabs needs space above it to separate it from the global nav. The previous fix caused a regression. The right side of the page was flowing into the footer.

## To Test

D8 
- [ ] switch your branch to `bugfix/EWL-6566-resource-tab`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/about-ama/rvs-update-committee-ruc/ruc-medical-home-recommendations
- [ ] observe the right side of the page no longer flows into the footer

Styleguide update
- [ ] visit http://localhost:3000/?p=pages-resource
- [ ] observe the right side of the page no longer encroaches into the footer

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
![ruc_medical_home_recommendations___american_medical_association](https://user-images.githubusercontent.com/2271747/48579724-e78f9600-e8e2-11e8-955a-2c5f729b71cd.png)




## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
