### PR TITLE
[EWL-6594] Event Detail Masthead Regression

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -66,6 +66,7 @@
     &__container {
       overflow: hidden;
       display: grid;
+      grid-template-columns: 4fr 1fr;
     }
 
     .ama__h1 {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6594 | Event detail - regression - social icons are overlapping the date within IE](https://issues.ama-assn.org/browse/EWL-6594)

## Description
Adds missing css declaration for css grid container in mastheads. Fixes the scrunching on event detail and resource pages.


## To Test
- Pull `bugfix/EWL-6594-masthead-overlapping-IE` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work affects visuals in D8 and should be tested against it to ensure there are no regressions. Update ama-d8 branch and local provision vars accordingly. 
- Go to any event detail page such as [State Advocacy Summit](http://ama-one.local/advocacy/physician-advocacy/state-advocacy-summit) in IE and confirm that the date is on the far left while social share icons are on the far right of the masthead.
- Go to any resource page in IE such as [Transition to new payment models: Start here](http://ama-one.local/practice-management/payment-delivery-models/transition-new-payment-models-start-here) and confirm that the date is on the far left while social share icons are on the far right of the masthead.
- Confirm that this does not cause issues for other page mastheads. Check against prod pages to confirm there are not regressions.
- Test this in Chrome, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6594-masthead-overlapping-IE/html_report/index.html).


## Relevant Screenshots/GIFs
I cannot upload screenshots to GitHub at this time.


## Remaining Tasks
N/A


## Additional Notes
N/A
