### PR TITLE
EWL-6581 right aligns subscribe button to text input field for mobile and tablet

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -72,13 +72,13 @@
   }
 
   .ama__subscribe-promo--wide .ama__subscribe-promo__form {
-    .form-actions {
-      margin: 0;
-    }
+     flex-direction: row;
 
-    form{
-      @include breakpoint(max-width $bp-small){
-        flex-direction: row;
+    form {
+      flex-direction: row;
+
+      .form-actions {
+        margin: 0;
       }
     }
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6581: Footer - tablet view - right align subscribe button.](https://issues.ama-assn.org/browse/EWL-6581)

## Description
Fix tablet view subscribe buttons needs to right align with the email textfield in the footer

## To Test

D8 
- [ ] switch your branch to `bugfix/EWL-6581-footer-tablet-subscribe`
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/
- [ ] scroll down to the footer
- [ ] resize your browser to tablet size
- [ ] observe the email subscription button is now aligned with the email textfield input

Styleguide update
- [ ] visit http://localhost:3000/?p=pages-homepage
- [ ] scroll to the footer
- [ ] resize your browser to tablet size
- [ ] observe the email subscription button is now aligned with the email textfield input

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
![screen shot 2018-11-15 at 2 22 02 pm](https://user-images.githubusercontent.com/2271747/48579759-fb3afc80-e8e2-11e8-82ef-5fec497fccb8.png)




## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
