### PR TITLE
 [EWL-6595] Product Exploration IE Fix

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -73,7 +73,7 @@
       position: absolute;
       top: 0;
       margin-top: 0;
-      align-self: flex-end;
+      right: 0;
     }
 
     @include breakpoint($bp-med) {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6595 | IE - your product text left aligned making page unreadable](https://issues.ama-assn.org/browse/EWL-6595)

## Description
Adds right positioning property to the absolute positioned view more products element.


## To Test
- Pull `bugfix/EWL-6595-product-text-overlap-IE` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- This work affects visuals in D8 and should be tested against it to ensure there are no regressions. Update ama-d8 branch and local provision vars accordingly. 
- Go to homepage in IE and confirm that in the product exploration component the `view all products` element is aligned to the far right of area.
- Test this in Chrome, Safari, and Firefox to ensure that with updates everything works same as before.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6595-product-text-overlap-IE/html_report/index.html).


## Relevant Screenshots/GIFs
Homepage in IE
![image](https://user-images.githubusercontent.com/4438120/48579764-02620a80-e8e3-11e8-970f-40190199b59d.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
