### PR TITLE
EWL-6538: Enable OL on resource pages.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_resource.scss
+++ b/styleguide/source/assets/scss/05-pages/_resource.scss
@@ -9,7 +9,10 @@
 
 .ama____page--resources__page-content {
   ol {
-    list-style: decimal;
-    padding-left: 1em;
+    list-style-position: inside;
+
+    ol {
+      padding-left: 1em;
+    }
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_resource.scss
+++ b/styleguide/source/assets/scss/05-pages/_resource.scss
@@ -6,3 +6,10 @@
     text-decoration: underline;
   }
 }
+
+.ama____page--resources__page-content {
+  ol {
+    list-style: decimal;
+    padding-left: 1em;
+  }
+}


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6538: News Article - numbered list options not displaying on frontend](https://issues.ama-assn.org/browse/EWL-6538)

## Description

Style ordered lists in the resource page body.

A style guide example content was not created for this because this was a high priority request with a short deadline.

## To Test

This should be tested in Drupal.

- Create or edit a resource page
- Add a list of items using the body WYSIWYG and the ordered list button
- Save the page
- View the page

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/EWL-6538-resource-page-ol/html_report/index.html).

## Relevant Screenshots/GIFs

![example](https://user-images.githubusercontent.com/397902/48585691-03029d00-e8f3-11e8-9aa1-ba6d6e60cb49.jpg)



## Remaining Tasks
Add an example to the style guide


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
