### PR TITLE
EWL-6566 removes height of 100% to resource tabs

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -1,5 +1,4 @@
 .ama__resource-tabs {
-  height: 100%;
   border: 0 !important;
   margin: 0;
   padding: 0;
@@ -37,7 +36,7 @@
     margin: 0;
     border-right: solid 1px $white;
     a.ui-tabs-anchor{
-      color: #FFF;
+      color: $white;
       padding: 0;
       margin: 0;
 


### PR DESCRIPTION
This fix was already done in this PR
https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/540

 and reintroduced in this PR due to a merge conflict
https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/536

The height of 100% should not be there.