### PR TITLE
Hot Fix: removes padding that causes differences in grid

### DIFF
--- a/styleguide/source/assets/scss/00-base/_grid.scss
+++ b/styleguide/source/assets/scss/00-base/_grid.scss
@@ -61,7 +61,6 @@ $one-col-width: 8.333333333333333%;
 @media (min-width: 768px) {
   .container {
     width: 750px;
-    padding: 0;
   }
 }
 


### PR DESCRIPTION
## Ticket(s)
n/a

**Jira Ticket**
n/a

## Description
Removes padding: 0 in grid.css introduced in PR https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/536

## JIRA Ticket(s)
- [EWL-6547: Resource page - mobile. tables not showing complete data](https://issues.ama-assn.org/browse/EWL-6547)

## To Test:
- switch your SG2 branch to `bugfix/EWL-6547-amendment`
- `gulp serve`
- visit http://localhost:3000/?p=pages-resource
- click on the schedule tab
- observe the schedules table has stacked events with grey and white zebra striping
- observe the .ama__layout--split .container .container no longer has padding: 0
- enable local SG2 in your D8 instance
- `drush @one.local cr`
- visit http://ama-one.local/about/cpt-editorial-panel/cptr-editorial-panel-meeting-process-calendar#tables
- observe the .ama__layout--split .container .container no longer has padding: 0


## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6547-amendment/html_report/index.html).

## Relevant Screenshots/GIFs
![screen shot 2018-11-19 at 9 37 01 am](https://user-images.githubusercontent.com/2271747/48717249-a2b77800-ebde-11e8-9f0f-e803a7251f35.png)


## Remaining Tasks
This is has a dependency in D8 https://github.com/AmericanMedicalAssociation/ama-d8/pull/1060


## Additional Notes
The table info on the resource page needs to be moved to the schedule tab in D8

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
