### PR TITLE
EWL-6623 IE11 specific fix to prevent hub card images from blowing out of porp…

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -55,10 +55,12 @@
 
     //This targets all hub cards in IE11
     &__image .ama__image {
-      max-height: 186px;
+      max-width: 379px;
+      max-height: 400px;
     }
     //This targets all hub hero images and prevents them from having a max-height
     &.ama__hub-hero .ama__hub-card__image .ama__image {
+      max-width: 100%;
       max-height: none;
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -51,6 +51,10 @@
 
   //IE11 hack becaue IE does not understand object-fit
   @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    // Select only first child div without any classes.
+    > div:not([class]) {
+      flex-shrink: 0;
+    }
 
     //This targets all hub cards in IE11
     &__image {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -35,7 +35,6 @@
     margin: 0;
     height: 100%;
     display: flex;
-    height: 100%;
 
     .ama__image {
       height: auto;
@@ -54,9 +53,12 @@
   @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
 
     //This targets all hub cards in IE11
-    &__image .ama__image {
-      max-width: 379px;
-      max-height: 400px;
+    &__image {
+      height: auto;
+
+      .ama__image {
+        max-height: 400px;
+      }
     }
     //This targets all hub hero images and prevents them from having a max-height
     &.ama__hub-hero .ama__hub-card__image .ama__image {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -50,6 +50,19 @@
     }
   }
 
+  //IE11 hack becaue IE does not understand object-fit
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+
+    //This targets all hub cards in IE11
+    &__image .ama__image {
+      max-height: 186px;
+    }
+    //This targets all hub hero images and prevents them from having a max-height
+    &.ama__hub-hero .ama__hub-card__image .ama__image {
+      max-height: none;
+    }
+  }
+
   @at-root {
     a:hover#{&} {
       background-color: darken($gray-7, 10%);

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -29,6 +29,7 @@
   &__copy,
   &__text {
     @include gutter-all($padding-all-full...);
+    width: 100%;
   }
 
   &__list {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6623: Hub Pages Images are stretched in IE11](https://issues.ama-assn.org/browse/EWL-6623)

## Description
Hub Card Images are stretched in IE11
[
![screen shot 2018-11-19 at 4 44 11 pm](https://user-images.githubusercontent.com/2271747/48739682-52f6a200-ec1a-11e8-96ba-cbad9162a4a5.png)
](url)

## To Test
- [ ] switch your branch to 
- [ ] `gulp serve`
- [ ] enable local SG2 on your D8 instance
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/node/24416 in IE11 (I used browserstack)
- [ ] observe the hub card images are no longer out of proportion and stretched

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6623-hub-image-proportions-IE11/html_report/index.html).



## Relevant Screenshots/GIFs
![screen shot 2018-11-19 at 4 47 20 pm](https://user-images.githubusercontent.com/2271747/48739946-3870f880-ec1b-11e8-95d6-43014e04cc91.png)


## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
