### PR TITLE
EWL-6632: Address overlapping when expanding / contracting.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_expand-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_expand-list.scss
@@ -70,6 +70,9 @@
     @include gutter($padding-top-half...);
     @include gutter($padding-bottom-half...);
     width: 100%;
+
+    // Avoid overlapping on expand / contract.
+    min-height: 72px;
   }
 
   .ui-accordion-content {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6632: Search - Category Drop-down](https://issues.ama-assn.org/browse/EWL-6632)

## Description
Prevent overlapping when expanding / contacting the filters.


## To Test

In the style guide
- Go to http://localhost:3000/?p=pages-search-results

In Drupal
- Search for a term that has many results, like `doctor`
- Expand the filters
- Contract the filters
- See that the search bar in the filters does not overlap the options during the animation

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6632-search-expand-overlapping/html_report/index.html).

## Relevant Screenshots/GIFs

![example](https://user-images.githubusercontent.com/397902/49113948-7e9e0b80-f25c-11e8-8b1d-8f89486264dd.jpg)

## Remaining Tasks
N/A


## Additional Notes
There may be a better option with flexbox. This is commented and seems to work.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
