### PR TITLE
EWL-6637: Related news article font is bold.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -188,11 +188,11 @@
 .ama__page--news__teasers {
   .ama__h5--purple {
     font-size: 12px;
-    font-weight: normal;
+    font-weight: bold;
   }
 
   .ama__article-stub__title {
     font-size: 12px;
-    font-weight: normal;
+    font-weight: bold;
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6637: News Article – Promoted article titles text styling is incorrect.](https://issues.ama-assn.org/browse/EWL-6637)

## Description
The related article font is now bold.


## To Test
- View a news page, http://localhost:3000/?p=pages-news
- Confirm the font is bold

Drupal
- View a news article with related content, such as /practice-management/medicare/debunking-regulatory-myths
- Confirm the font is bold

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6637-related-text/html_report/index.html).

## Relevant Screenshots/GIFs

![example](https://user-images.githubusercontent.com/397902/49115512-9d9e9c80-f260-11e8-9cf8-78898111383e.jpg)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
