### PR TITLE
EWL-6638 Updates global submenu to center within the viewport

### DIFF
--- a/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
+++ b/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
@@ -1,10 +1,10 @@
 <nav id="ama_category_navigation_menu" class="ama_category_navigation_menu">
   {% for menuGroup in categoryNavigationMenu.menuGroups %}
-    <ul class="ama_category_navigation_menu__group">
+    <ul class="ama_category_navigation_menu__group sm sm-vertical">
       {% for group in menuGroup.group %}
         {% set link = group.link %}
         {% set heading = group.heading %}
-        <li class="ama_category_navigation_menu__section">
+        <li class="ama_category_navigation_menu__section" data-sm-horizontal-sub="true">
           {% if heading %}
             {% include "@atoms/heading/heading.twig" %}
           {% else %}

--- a/styleguide/source/assets/js/category-menu.js
+++ b/styleguide/source/assets/js/category-menu.js
@@ -9,4 +9,7 @@
  */
 
 
-jQuery('.ama_category_navigation_menu__group').smartmenus();
+jQuery('.ama_category_navigation_menu__group').smartmenus({
+  subMenusSubOffsetY: -28,
+  subIndicatorsPos: 'append'
+});

--- a/styleguide/source/assets/js/category-menu.js
+++ b/styleguide/source/assets/js/category-menu.js
@@ -9,8 +9,4 @@
  */
 
 
-jQuery('.ama_category_navigation_menu__group').smartmenus({
-  mainMenuSubOffsetX: 250,
-  mainMenuSubOffsetY: 20,
-  keepInViewport: true
-});
+jQuery('.ama_category_navigation_menu__group').smartmenus();

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -60,6 +60,26 @@
         text-decoration: none;
       }
 
+      .sub-arrow {
+        position: absolute;
+        right: 10px;
+        top: 15px;
+        width: 0;
+        height: 0;
+        border-left: 6px solid $white;
+        border-top: 6px solid transparent;
+        border-bottom: 6px solid transparent;
+        transition: all 0.21s ease-out;
+      }
+
+      &.highlighted .sub-arrow {
+        transform: rotate(90deg);
+
+        @include breakpoint($bp-small) {
+          transform: none;
+        }
+      }
+
       @include breakpoint($bp-small) {
         &.has-submenu.highlighted {
           &:after {

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -21,7 +21,7 @@
     }
   }
 
-  @include breakpoint($bp-med) {
+  @include breakpoint($bp-large) {
     flex-direction: row;
 
     &__article-container {
@@ -124,15 +124,12 @@
 
     @include breakpoint($bp-small) {
       position: absolute;
-      top: -50px !important;
-      left: 40px !important;
       z-index: 1;
       width: 550px !important;
       max-width: none !important;
     }
 
-    @include breakpoint($bp-med) {
-      left: 0 !important;
+    @include breakpoint($bp-large) {
       width: 940px !important;
       max-width: none !important;
     }
@@ -204,7 +201,13 @@
         }
       }
 
-      @include breakpoint($bp-med) {
+      @include breakpoint($bp-small) {
+        &:nth-child(2):nth-last-child(1) {
+          @include gutter($margin-top-full...);
+        }
+      }
+
+      @include breakpoint($bp-large) {
         @include gutter($margin-left-full...);
 
         &:nth-child(1) {
@@ -213,6 +216,7 @@
         }
 
         &:nth-child(2):nth-last-child(1) {
+          margin-top: 0;
           margin-left: 12px;
           width: 50%;
         }
@@ -229,7 +233,7 @@
       width: 250px;
     }
 
-    @include breakpoint($bp-med) {
+    @include breakpoint($bp-large) {
       flex-direction: row;
       width: 690px;
     }

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -60,26 +60,6 @@
         text-decoration: none;
       }
 
-      .sub-arrow {
-        position: absolute;
-        right: 10px;
-        top: 15px;
-        width: 0;
-        height: 0;
-        border-left: 6px solid $white;
-        border-top: 6px solid transparent;
-        border-bottom: 6px solid transparent;
-        transition: all 0.21s ease-out;
-      }
-
-      &.highlighted .sub-arrow {
-        transform: rotate(90deg);
-
-        @include breakpoint($bp-small) {
-          transform: none;
-        }
-      }
-
       @include breakpoint($bp-small) {
         &.has-submenu.highlighted {
           &:after {
@@ -127,6 +107,7 @@
       z-index: 1;
       width: 550px !important;
       max-width: none !important;
+      margin-left: 250px !important;
     }
 
     @include breakpoint($bp-large) {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6638: High - enhancement - Menu Expansion](https://issues.ama-assn.org/browse/EWL-6638)

## Description
UX has asked that the global menu flyout submenu to be always centered in viewport to display as much info as possible

## To Test
- [ ] switch your SG2 branch to `bugfix/EWL-6638-menu-expansion`
- [ ] `gulp serve`
- [ ] switch your D8 branch to  `bugfix/EWL-6638-menu-expansion`
- [ ] enable local SG2 on your D8 instance
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/
- [ ] click on the hamburger menu in the global header
- [ ] hover over the categories
- [ ] observer the about category submenu is centered
- [ ] resize your viewport to 1440X900
- [ ] click on the hamburger menu again
- [ ] hover over the about category
- [ ] observer the about category submenu is still centered

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6638-menu-expansion/html_report/index.html).



## Relevant Screenshots/GIFs
<img width="1399" alt="screen shot 2018-11-28 at 11 33 20 am" src="https://user-images.githubusercontent.com/2271747/49170512-ec504300-f301-11e8-8712-d47fbcadb432.png">

## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
