### PR TITLE
EWL-6641: Align category links in mega menu.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -150,10 +150,17 @@
     }
 
     ol {
-      @include gutter-all($padding-all-half...);
+      padding: 10px 28px;
       list-style: none;
 
+      @include breakpoint($bp-small) {
+        @include gutter-all($padding-all-half...);
+      }
+
       li {
+        padding: 0px;
+        margin: 0px;
+
         a {
           @include gutter($padding-left-half...);
           @include gutter($padding-right-half...);
@@ -167,15 +174,18 @@
             text-decoration: underline;
           }
         }
-      }
-    }
 
-    &__header {
-      @include gutter($margin-bottom-half...);
-      @include gutter($padding-left-half...);
-      @include gutter($padding-right-half...);
-      color: $homepagePurple;
-      text-transform: uppercase;
+        &.ama_category_navigation_menu__submenu__header {
+
+          @include breakpoint($bp-small) {
+            @include gutter($margin-bottom-half...);
+            @include gutter($padding-left-half...);
+            @include gutter($padding-right-half...);
+          }
+          color: $homepagePurple;
+          text-transform: uppercase;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6641: Category Link misaligned](https://issues.ama-assn.org/browse/EWL-6641)

## Description

Align category links in the mega menu.

The existing styles were most appropriate for the desktop view, so they have been moved to media queries.

The base styles now support the mobile view.


## To Test
- View the mega menu category links in the style guide, http://localhost:3000/?p=pages-news
- View the mega menu category links on the d8 site (any page)
- View the links on mobile, tablet, desktop

The category header and links should be aligned.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6641-mobile-nav-category-padding/html_report/index.html).

## Relevant Screenshots/GIFs
![example](https://user-images.githubusercontent.com/397902/49186059-2123c080-f329-11e8-99e3-89739fb30076.jpg)

![desktop](https://user-images.githubusercontent.com/397902/49186235-a7400700-f329-11e8-8aed-e4702402f79d.jpg)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
