### PR TITLE
EWL-6643: Style footer social links differently on small screens.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_social-share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_social-share.scss
@@ -54,6 +54,10 @@ $social-icons: (
     &:first-child {
       margin-left: 0;
     }
+
+    @include breakpoint(max-width $bp-small){
+      flex-grow: 1;
+    }
   }
 
   li ~ li {

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -28,13 +28,20 @@
   }
 
   .ama__social-share {
-    @include breakpoint(max-width $bp-small){
-        margin: $gutter-mobile auto;
-    }
     a {
       height: 50px;
       width: 50px;
       background-size: 50px;
+    }
+
+    @include breakpoint(max-width $bp-small){
+        margin: $gutter-mobile auto;
+
+        a {
+          height: 43px;
+          width: 43px;
+          background-size: 43px;
+        }
     }
   }
   .ama__site-logo--footer img{


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6643: High Footer Mobile – Instagram logo is getting cut off](https://issues.ama-assn.org/browse/EWL-6643)

## Description

Resize the social links in the footer on mobile so that none are cut off.

43px seems to work OK for Galaxy S5 and iPhone X. The `flex-grow: 1` will space the items evenly across variations in mobile width.

The background size is used to adjust the icon size, so I'm not sure if flexbox can be used to adjust height and width. It might be worth a try if possible.


## To Test
- View the footer (any full page) in the style guide
- View on mobile
- View on desktop
- View on tablet

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6643-footer-social-links-too-wide/html_report/index.html).


## Relevant Screenshots/GIFs

![example](https://user-images.githubusercontent.com/397902/49397440-36ba3100-f701-11e8-99b3-187ac06a9227.jpg)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
