### PR TITLE
EWL-6644: Address safari button styling.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -11,6 +11,10 @@
 
   &__form {
     .ama__button {
+      // Fix appearance issues on Safari iOS.
+      -webkit-appearance: none;
+      border-radius: 0;
+
       @extend .ama__button--homepage;
       display: block;
       margin: 0 auto;


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6644: High - Footer Mobile – Subscribe buttons are inconsistent with designs.](https://issues.ama-assn.org/browse/EWL-6644)

## Description
Fix for iOS Safari for consistent submit button on email subscription forms.

## To Test
- Using an iPhone / iPhone Simulator
- Visit any page in the styleguide or the Drupal site
- View the subscribe promo in the middle of the page
- View the subscribe promo in the footer

* The iOS simulator / Safari seems to want to hold on to styles. So, you may need to go to `Hardware > Erase all content and settings...` and then load the page.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6644-ios-safari-submit-button/html_report/index.html).

## Relevant Screenshots/GIFs

![example](https://user-images.githubusercontent.com/397902/49402748-4c832280-f710-11e8-9e0a-24ee313b11d6.jpg)

![example-footer](https://user-images.githubusercontent.com/397902/49402762-5a38a800-f710-11e8-955e-e20db0da13c1.jpg)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
