### PR TITLE
EWL-6648: Center subscribe button mobile

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -123,7 +123,7 @@
       }
 
       .ama__button {
-        margin: 0;
+        margin: 0 auto;
       }
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -11,6 +11,10 @@
 
   &__form {
     .ama__button {
+      // Fix appearance issues on Safari iOS.
+      -webkit-appearance: none;
+      border-radius: 0;
+
       @extend .ama__button--homepage;
       display: block;
       margin: 0 auto;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6648: Subscribe button Centered on Mobile](https://issues.ama-assn.org/browse/EWL-6648)

## Description
Center the button on the subscribe promo on the homepage.

This includes #563 since they both affect the same file and would cause a conflict.

## To Test
- Open the styleguide page http://localhost:3000/?p=pages-homepage
- You can also test on the homepage in Drupal

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6648-center-subscribe-button-mobile/html_report/index.html).

## Relevant Screenshots/GIFs

![example](https://user-images.githubusercontent.com/397902/49460238-7c850100-f7b6-11e8-991f-0329e2227d2f.jpg)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
