### PR TITLE
EWL-5996: Sub Category: Index Search Event Tracking

### DIFF
--- a/styleguide/package-lock.json
+++ b/styleguide/package-lock.json
@@ -4131,7 +4131,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "0.1.1",
@@ -11318,7 +11318,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "openurl": {

--- a/styleguide/source/_patterns/03-organisms/subcategory-index.twig
+++ b/styleguide/source/_patterns/03-organisms/subcategory-index.twig
@@ -15,8 +15,10 @@
 {% block contentLeft %}
   <div class="ama__subcategory-index__stubs">
     {% for stub in subcategoryIndex.articleStubs %}
-      {% set subCatArticleStub = stub %}
-      {% include '@molecules/subcategory-page-article-stub.twig' %}
+      <div class="ama__subcategory-index__stub">
+        {% set subCatArticleStub = stub %}
+        {% include '@molecules/subcategory-page-article-stub.twig' %}
+      </div>
     {% endfor %}
   </div>
 

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
@@ -21,9 +21,6 @@
   }
 
   .ama__subcategory-page-article-stub {
-    &:first-child {
-      padding-top: 0;
-    }
 
     &:nth-child(n+7) {
       @include breakpoint($bp-small max-width) {
@@ -37,6 +34,14 @@
 
     padding: $gutter 0;
     border-bottom: solid 2px $gray-7;
+  }
+
+  .ama__subcategory-index__stub {
+
+    &:first-child .ama__subcategory-page-article-stub {
+      padding-top: 0;
+    }
+
   }
 
   .ama__subcategory-index__stubs__load-more {


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-5996: Sub Category: Index Search Event Tracking](https://issues.ama-assn.org/browse/EWL-5996)

## Description
Added a `<div>` around each listing in the subcategory index organism.
Modified the relevant SCSS rules to fix padding issues introduced by adding said wrapper.


## To Test
- [ ] Visit the [Subcategory Index organism](http://localhost:3000/?p=organisms-subcategory-index)
- [ ] Confirm that it looks the same, and that the wrapper is present
- [ ] Did you test in IE 11?

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
<img width="751" alt="screen shot 2018-12-20 at 2 14 42 pm" src="https://user-images.githubusercontent.com/1919263/50308680-a64e5100-0461-11e9-9f17-f5757d9293d8.png">


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Related D8 PR: https://github.com/AmericanMedicalAssociation/ama-d8/pull/1164

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
