### PR TITLE
EWL-6659 Updates mobile click event to open filter panel.

### DIFF
--- a/styleguide/source/_patterns/03-organisms/filter.twig
+++ b/styleguide/source/_patterns/03-organisms/filter.twig
@@ -3,10 +3,6 @@
 <div class="ama__filter">
   {% include "@molecules/applied-filters.twig" %}
   {% include "@molecules/expand-list.twig" %}
-
-  <div class="ama__filter__collapse-panels">
-    {% include "@atoms/button/button.twig"  with { 'class': 'ama__filter__see-results' } %}
-  </div>
 </div>
 
 

--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -268,20 +268,12 @@
           });
 
           // Open accordion panels for mobile
-          $('.ama__applied-filters__show-filters').click(function(){
-            $('.ama__expand-list, .ama__applied-filters__tags').slideDown();
-            $('.ama__filter__see-results').fadeIn();
-            $(this).fadeOut();
+          $('.ama__applied-filters__show-filters').once().click(function(){
+            $('.ama__expand-list, .ama__applied-filters__tags').slideToggle(function() {
+              $('.ama__applied-filters__show-filters').text($(this).is(':visible') ? 'Hide Filter' : 'Filter');
+            });
           });
 
-          // Close accordion panels
-          $('.ama__filter__see-results').click(function(){
-            $('.ama__expand-list, .ama__applied-filters__tags').slideUp();
-            $('.ama__applied-filters__show-filters').fadeIn();
-            $(this).fadeOut();
-          });
-
-          // search filter
           function listFilter(input, list) { // header is any element, list is an unordered list
             // custom css expression for a case-insensitive contains()
             jQuery.expr[':'].Contains = function(a,i,m){

--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -268,7 +268,7 @@
           });
 
           // Open accordion panels for mobile
-          $('.ama__applied-filters__show-filters').once().click(function(){
+          $('.ama__applied-filters__show-filters').unbind('click').click(function(){
             $('.ama__expand-list, .ama__applied-filters__tags').slideToggle(function() {
               $('.ama__applied-filters__show-filters').text($(this).is(':visible') ? 'Hide Filter' : 'Filter');
             });

--- a/styleguide/source/assets/scss/02-molecules/_applied_filters.scss
+++ b/styleguide/source/assets/scss/02-molecules/_applied_filters.scss
@@ -33,6 +33,7 @@
     display: block;
     text-decoration: underline;
     color: $purple;
+    background-color: transparent;
 
     &:hover {
       cursor: pointer;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6659: High - Filter Box disappears on Mobile and Tablet](https://issues.ama-assn.org/browse/EWL-6659)

## Description
The filter button is disappearing on mobile and tablet views when clicked. UX has asked that the filter button does not disappear. Instead change the word to close filter when the filter panel is open. When a user clicks the close filter button the filter panel should close

## To Test
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-event-listing
- [ ] change your viewport to tablet and mobile
- [ ] click the filter button right under the header
- [ ] observe a filter panel opens
- [ ] observe the filter button text has changed to close filter
- [ ] enable local SG2 testing your D8 environment
- [ ] visit http://ama-one.local/events
- [ ] switch your viewport to tablet 
- [ ] click the filter button 
- [ ] observe the filter panel opens
- [ ] click the filter close button
- [ ] observe the filter panel closes
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6659-filter-box/html_report/index.html).



## Relevant Screenshots/GIFs
![screen shot 2019-01-09 at 1 19 09 pm](https://user-images.githubusercontent.com/2271747/50922882-2b99a580-1411-11e9-8d38-8cf9aecbb3b5.png)

## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
