### PR TITLE
EWL-6633 Fix search icon stretching in IE

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -34,13 +34,13 @@
   .form-submit {
     @extend .icon--search;
     background-color: transparent;
-    background-size: 23px 45px;
-    background-position: 0 -10px;
-    width: 23px;
-    height: 45px;
+    background-size: 25px 30px;
+    background-position: 0 0;
+    width: 25px;
+    height: 30px;
     padding: 0;
     margin: 0;
-    min-height: 25px;
+    min-height: 30px;
     min-width: 25px;
     max-height: 30px;
     max-width: 25px;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6633: Search IE - Search Icon Bug](https://issues.ama-assn.org/browse/EWL-6633)

## Description
The search icon is stretched in IE11

## To Test
- [ ] run `gulp serve`
- [ ] enable local SG2 testing in your D8 env
- [ ] fire up Browserstack IE11
- [ ] visit http://ama-one.local/search
- [ ] observe the search icon is no longer stretched
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6659-filter-box/html_report/index.html).



## Relevant Screenshots/GIFs

![screen shot 2019-01-14 at 3 45 06 pm](https://user-images.githubusercontent.com/2271747/51143112-63d72480-1813-11e9-9669-401439234293.png)

## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
