### PR TITLE
EWL-6781: A1 – Video support for homepage article stubs

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_videos.scss
+++ b/styleguide/source/assets/scss/01-atoms/_videos.scss
@@ -12,7 +12,7 @@ figcaption {
 .ama__video__container {
   position: relative;
   width: 100%;
-  padding-top: 50%;
+  padding-top: 56%;
 
   iframe {
     width: 100%;

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -28,7 +28,8 @@
   }
 
   .ama__image,
-  .ama__video {
+  .ama__video,
+  .ama__video__container {
     @include gutter($margin-bottom-half...);
     width: 100%;
   }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -72,10 +72,6 @@
     align-items: center;
     height: 100%;
 
-    @include breakpoint($bp-small) {
-      flex-basis: 50%;
-    }
-
     .ama__video {
       height: 100%;
       width: 100%;

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -19,6 +19,14 @@
         display: block;
       }
 
+      .ama__hub-hero__video {
+        width: 100%;
+
+        .ama__video__container {
+          padding-bottom: 0;
+        }
+      }
+
       @include breakpoint($bp-small) {
         & div a {
           display: flex;

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -23,6 +23,8 @@
         width: 100%;
 
         .ama__video__container {
+          width: 100%;
+          height: 100%;
           padding-bottom: 0;
         }
       }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6781: A1 – Video support for homepage article stubs](https://issues.ama-assn.org/browse/EWL-6781)

## Description
Made some small style modifications to improve the formatting of embedded video elements in Related Article blocks on the Homepage.


## To Test
- [ ] Follow the instructions in the D8 ticket to set up the homepage content
- [ ] Confirm that the videos appear in the correct place, and have similar spacing to their sibling images
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6781-homepage-article-stub-video-support/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1208" alt="screen shot 2019-01-15 at 11 53 56 am" src="https://user-images.githubusercontent.com/1919263/51199434-51fd8c00-18bc-11e9-93ae-2bae15ace740.png">
<img width="1201" alt="screen shot 2019-01-15 at 11 54 09 am" src="https://user-images.githubusercontent.com/1919263/51199437-53c74f80-18bc-11e9-97e2-1735c330ee74.png">


## Remaining Tasks
N/A


## Additional Notes
D8 PR: https://github.com/AmericanMedicalAssociation/ama-d8/pull/1185

I did modify the `padding-top` value for all `.ama__video__container` elements, but the regression testing didn't turn anything up, and I think it improved the way videos were rendered overall (especially for Vimeo videos). However, if there was a reason for it having been `50%` initially please let me know.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
