### PR TITLE
EWL-6790: changes the h4 font size

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
@@ -50,8 +50,8 @@ $h3-font-sizes--homepage: (
 $h4-font-sizes: (
     null  : (0.9, 1.600),
     small : (0.9, 1.600),
-    medium: (1.556em, 1.250),
-    large : (1.556em, 1.250)
+    medium: (1.111em, 1.250),
+    large : (1.111em, 1.250)
 );
 
 $h4-font-sizes--blue: (

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_font-variables.scss
@@ -50,8 +50,8 @@ $h3-font-sizes--homepage: (
 $h4-font-sizes: (
     null  : (0.9, 1.600),
     small : (0.9, 1.600),
-    medium: (1.111em, 1.250),
-    large : (1.111em, 1.250)
+    medium: (1.111em, 1.60),
+    large : (1.111em, 1.60)
 );
 
 $h4-font-sizes--blue: (


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
- [EWL-6790: H3's are appearing larger than H4's on resource pages](https://issues.ama-assn.org/browse/EWL-6790)

## Description
Changes the font size of the h4 header in order to be smaller than an h3 header.


## To Test
- [ ] Checkout this branch in your styleguide
- [ ] Go to your `local.yml` in the AMA D8 repo and uncomment line 80 and comment out line 82 in order to use the updated assets, run `scripts/build` in your drupal site, run `drush @one.local cr` in yout VM.
- [ ] Go to the drupal site and edit a Resource node like (http://ama-one.local/node/24321) add an h4 in the body of the nodeusing the ckeditor and check for styling ( I used the [What font chrome extention](https://chrome.google.com/webstore/detail/whatfont/jabopobgcpjmedljpbcaablpmlmfcogm)). It should be Myriad Pro Regular 20/32. I referenced this [doc](https://issues.ama-assn.org/secure/attachment/51970/51970_Typography.pdf).
- [ ] Did you test in IE 11?

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6790-h3-appear-larger-than-h4-on-resource-page/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
![image](https://user-images.githubusercontent.com/17749755/51278997-bd6d5980-19a1-11e9-96fe-1f961c08dbbf.png)



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
