### PR TITLE
EWL-6805: Align Article Stub Title and Image

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -186,5 +186,6 @@
 .ama__column-teaser {
   @include breakpoint($bp-small max-width) {
         @include gutter($padding-left-half...);
+        @include gutter($padding-right-half...);
       }
 }

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -29,6 +29,12 @@
     width: 100%;
   }
 
+  .ama__image img {
+    @include breakpoint($bp-small max-width) {
+      width: 100%;
+    }
+  }
+
   &--related {
     @include ama-rules(1px, '', solid, $gray-50);
     @include gutter($padding-top-half...);

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -61,12 +61,6 @@
       align-self: start;
     }
 
-    // Only if we have an image, do we set a width on things...
-    .ama__video + .ama__article-stub__title,
-    .ama__image + .ama__article-stub__title {
-      width: 75%;
-    }
-
     .ama__article-stub__copy {
       width: 75%;
     }

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -11,7 +11,7 @@
     padding: 0;
     width: 100%;
   }
-
+  
   &__copy {
     @include gutter($padding-left-full...);
     @include gutter($padding-right-full...);
@@ -72,7 +72,7 @@
       width: 75%;
     }
   }
-  
+
   &--small {
     display: flex;
     flex-wrap: wrap;
@@ -182,4 +182,10 @@
     font-size: 12px;
     font-weight: bold;
   }
+}
+
+.ama__column-teaser {
+  @include breakpoint($bp-small max-width) {
+        @include gutter($padding-left-half...);
+      }
 }

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -11,7 +11,7 @@
     padding: 0;
     width: 100%;
   }
-  
+
   &__copy {
     @include gutter($padding-left-full...);
     @include gutter($padding-right-full...);
@@ -45,7 +45,6 @@
     .ama__image,
     .ama__video {
       @extend .col-xs-3;
-      @include gutter($padding-right-half...);
       align-self: flex-start;
       margin-bottom: 0;
 

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -10,11 +10,6 @@
   &__title {
     padding: 0;
     width: 100%;
-
-    @include breakpoint($bp-med min-width) {
-      @include gutter($padding-left-full...);
-      @include gutter($padding-right-full...);
-    }
   }
 
   &__copy {
@@ -77,16 +72,7 @@
       width: 75%;
     }
   }
-
-  &--related + &--image,
-  &--related + &--video {
-    .ama__image,
-    .ama__video {
-      @include gutter($padding-left-half...);
-      order: 1;
-    }
-  }
-
+  
   &--small {
     display: flex;
     flex-wrap: wrap;

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -12,8 +12,6 @@
   }
 
   .ama__article-stub {
-    @include gutter($margin-left-full...);
-    @include gutter($margin-bottom-full...);
     width: 100%;
 
     &:first-child {
@@ -21,6 +19,8 @@
     }
 
     @include breakpoint($bp-small min-width) {
+      @include gutter($margin-left-full...);
+      @include gutter($margin-bottom-full...);
       width: 47%;
     }
 


### PR DESCRIPTION
**Jira Ticket**
- [EWL-6805: Align Article Stub Title and Image](https://issues.ama-assn.org/browse/EWL-6805)

## Description
Revise CSS in order to align the title and image on the article stub(right side column) at mobile and desktop viewports as presented in the zeplin(check ticket).


## To Test
- [ ] run `gulp serve`
- [ ] enable local SG2 testing in your D8 env, clear cache `drush @one.local cr`
- [ ] Navigate to (http://ama-one.local/residents-students/specialty-profiles/residents-share-4-tips-assessing-specialty-lifestyle) and check that the title and image in the article stub are aligned to the left. For example, this screenshot, from the URL above: ![screen shot 2019-02-26 at 11 53 17 am](https://user-images.githubusercontent.com/541745/53430901-6e154280-39bd-11e9-822d-8e2f3b109730.png)
- [ ] Did you test in IE 11?

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6805-align-article-stub-title-and-image/html_report/index.html).


## Relevant Screenshots/GIFs
### Desktop
![image](https://user-images.githubusercontent.com/17749755/52806870-b5134780-304f-11e9-91dc-3152054852ae.png)


### Mobile
![image](https://user-images.githubusercontent.com/17749755/52806905-c78d8100-304f-11e9-917d-c93a3960d56f.png)

#### Four up list of article stub, below content, before the footer. 
### BEFORE
![screen shot 2019-02-19 at 12 54 33 pm](https://user-images.githubusercontent.com/541745/53430870-5ccc3600-39bd-11e9-841c-3ac58dbd18cd.png)
### AFTER
![screen shot 2019-02-26 at 11 52 41 am](https://user-images.githubusercontent.com/541745/53430886-65bd0780-39bd-11e9-9ca8-f70322964396.png)

#### Right sidebar column, article stub list
### BEFORE
![screen shot 2019-02-26 at 11 52 52 am](https://user-images.githubusercontent.com/541745/53430900-6e154280-39bd-11e9-81f6-7259b6d82ac2.png)
### AFTER
![screen shot 2019-02-26 at 11 53 17 am](https://user-images.githubusercontent.com/541745/53430901-6e154280-39bd-11e9-822d-8e2f3b109730.png)




## Remaining Tasks
N/A


## Additional Notes
N/A

---