### PR TITLE
[EWL-6314] Layout builder - block title check box

### DIFF
--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -193,12 +193,11 @@
             });
           }
 
-          $('[type=checkbox]').each( function() {
+          $('form:not([class*="layout-builder"]) [type=checkbox]').each( function() {
             $('[type=checkbox]').checkboxradio();
           });
 
-
-          $('[type=radio]').checkboxradio().buttonset().find('label').css('width', '19.4%');
+          $('form:not([class*="layout-builder"]) [type=radio]').checkboxradio().buttonset().find('label').css('width', '19.4%');
 
           $('.textarea').keyup(function() {
             count_remaining_character();


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6314 Bug: Layout builder -  block title check box](https://issues.ama-assn.org/browse/EWL-6314)

## Description
The checkbox to regulate whether or not the backend block title appears on the front end does not show correctly. This work limits the scope of checkboxradio() to forms not classed for layout builder.

## To Test
- Pull `bugfix/EWL-6314-layout-builder-block-title-checkbox` branch
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Update your local AMAOne provision vars to use your local SG2 files.
- Ensure you have prod content before testing further.
- Go to any category/subcategory layout builder page  and attempt to either add or edit a block's configuration.
- Confirm the show block title form element shows the checkbox to the left of the options label.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-6314-layout-builder-block-title-checkbox/html_report/index.html).


## Relevant Screenshots/GIFs
Category page layout builder block config

![image](https://user-images.githubusercontent.com/4438120/52223356-10348580-286b-11e9-953f-d8b38d82769f.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
