### PR TITLE
EWL-6730 Prevent text from flowing outside of container

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_people-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_people-listing.scss
@@ -40,7 +40,7 @@
   &__details {
     @include gutter-all($padding-all-half...);
     border-top: 1px solid $gray-50;
-    word-break: break-word;
+    word-break: break-all;
 
     .ama__link--icon {
       @extend .ama__type--small;

--- a/styleguide/source/assets/scss/02-molecules/_people-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_people-listing.scss
@@ -40,6 +40,7 @@
   &__details {
     @include gutter-all($padding-all-half...);
     border-top: 1px solid $gray-50;
+    word-break: break-word;
 
     .ama__link--icon {
       @extend .ama__type--small;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6730: People Listing – Profile outside of container bug](https://issues.ama-assn.org/browse/EWL-6730)

## Description
Email addresses and long words that don't have breaks in them are breaking the flow of the people listing containers. The containers are either getting pushed too wide or the text is flowing outside of them.

## To Test
- [ ] run `gulp serve`
- [ ] enable local SG2 in your D8 environment
- [ ] clear cache `drush @one.local cr`
- [ ] visit http://ama-one.local/member-groups-sections/medical-students/medical-student-section-mss-councilors-representatives
- [ ] compare the page to https://one-test.ama-assn.org/member-groups-sections/medical-students/medical-student-section-mss-councilors-representatives
- [ ] observe email addresses and text do not outside of their respective containers or push them wider
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6730-people-listing-wrap/html_report/index.html).


## Relevant Screenshots/GIFs
![medical_student_section__mss__councilors___representatives___american_medical_association](https://user-images.githubusercontent.com/2271747/52239186-792ff380-2893-11e9-8e0a-ff48c4d2441d.png)

## Remaining Tasks
n/a


## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
