### PR TITLE
EWL-6738 View all link fix

### DIFF
--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -14,7 +14,7 @@
       var $subcategoryListContainer = $('.ama__subcategory-exploration__list');
       var $subcategoryList  = $('.ama__subcategory-exploration__list ul');
       var $subcategoryListExpander = $('.ama__subcategory-exploration__show-more');
-      var $subcategoryListContainerHeight = $subcategoryListContainer.outerHeight();
+      var $subcategoryListContainerHeight = $subcategoryListContainer.outerHeight() + 1;
       var $subcategoryListLinkText = $('.ama__subcategory-exploration__text');
 
       // If the unordered list outerHeight is greater than the parent container then show the show more link


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6738: Ticket Title](https://issues.ama-assn.org/browse/EWL-6738)

## Description
View all link was showing when there were no other categories 

## To Test
- [ ] `gulp serve`
- [ ] enable local SG2 in your D8
- [ ] `drush @one.local cr`
- [ ] visit http://ama-one.local/member-groups-sections
- [ ] observe the link `View all subcategories ` does not show
- [ ] edit the menu for this section http://ama-one.local/admin/structure/taxonomy/manage/menu/overview
- [ ] drag links into the member groups section
- [ ] save
- [ ] reload http://ama-one.local/member-groups-sections
- [ ] observe `View all subcategories` shows
- [ ] Did you test in IE 11?

## Visual Regressions

n/a
 
## Relevant Screenshots/GIFs
![screen shot 2019-02-04 at 4 18 53 pm](https://user-images.githubusercontent.com/2271747/52241159-94e9c880-2898-11e9-88c6-5947b86bc862.png)


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
