### PR TITLE
EWL-6771 homepage announcement banner

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -36,6 +36,7 @@
     ],
     "drupalfiles" : [
       "source/assets/js/init.js",
+      "source/assets/js/alert.js",
       "source/assets/js/form-items.js",
       "source/assets/js/nav.js",
       "source/assets/js/subcategory.js",

--- a/styleguide/source/assets/js/alert.js
+++ b/styleguide/source/assets/js/alert.js
@@ -12,9 +12,7 @@
      attach: function (context, settings) {
        $.cookie('ama__alert--hide');
        var alertCookie = $.cookie('ama__alert--hide');
-
-       console.log( $.cookie('ama__alert--hide') );
-
+       
        (function ($) {
          // If the 'hide cookie is not set we show the alert
          if (alertCookie !== '1') {

--- a/styleguide/source/assets/js/alert.js
+++ b/styleguide/source/assets/js/alert.js
@@ -12,9 +12,12 @@
      attach: function (context, settings) {
        $.cookie('ama__alert--hide');
        var alertCookie = $.cookie('ama__alert--hide');
+
+       console.log( $.cookie('ama__alert--hide') );
+
        (function ($) {
          // If the 'hide cookie is not set we show the alert
-         if (alertCookie != 1) {
+         if (alertCookie !== '1') {
            $('.ama__alert__wrap').fadeIn("slow");
          }
 


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-6771: Announcement banner (frontend)](https://issues.ama-assn.org/browse/EWL-6771)


## Description:
- Adds `banner` content type.
- Adds `admin/announcement-banner` view page for admins to order multiple banners
- Adds `banner.feature` Behat test to test if users can publish banner, tests if banner is unpublished for users without access to view unpublished banner nodes. 
- Adds `page.banner` variable to `page.html.twig` to render banner node objects - applies to all pages site-wide. 

## To Test:
- In SG2 pull branch `feature/EWL-6771-annoucement-banner`
- `gulp serve`
- D8 switch branch to `feature/EWL-6771-annoucement-banner` (https://github.com/AmericanMedicalAssociation/ama-d8/pull/1233)
- Enable local SG2 testing your D8
- Pull down branch and import configuration changes: 
  - `drush @one.local cim -y`
  - `drush @one.local cr`
- Add multiple node banners: http://ama-one.local/node/add/banner (create two one published and one unpublished) 
- Navigate to: http://ama-one.local/admin/announcement-banner (notice there will be a Drupal warning message)
- Save order of nodes (place published banner node first)
- Observe that banner is visible to all users. 
- Navigate back to: http://ama-one.local/admin/announcement-banner (notice there will be NO a Drupal warning message)
- Save order of nodes (place unpublished banner node first)
- Observe that banner is NOT visible to `anonymous` users. 

## Relevant Screenshots/GIFs:
![screen shot 2019-02-13 at 2 33 12 pm](https://user-images.githubusercontent.com/2271747/52741982-50e37b80-2f9c-11e9-9bc6-832c438e448b.png)


## Additional Notes:
Anything more to add?


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
