### PR TITLE
EWL-6979: A1 | Scroll resource tab content instead of page

### DIFF
--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -45,8 +45,8 @@
        */
       function smoothScroll($tabNav, $target) {
         var navCoords = $tabNav[0].getBoundingClientRect();
-        $('html,body').animate({
-          scrollTop: window.scrollY + navCoords.top
+        $('.ama__resource-tabs__content').animate({
+          scrollTop: 0
         }, 850, function () {
           // update focus for keyboard only navigation
           $target.attr('tabindex', '-1');
@@ -69,6 +69,8 @@
         $tabObj.tabs({
           active: tabIndex
         });
+        // Scroll to top of ui tabs navigation
+        smoothScroll($tabObj, $(widget.active[0]));
         // Stop bubbling and default actions
         return false;
       }

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -69,8 +69,6 @@
         $tabObj.tabs({
           active: tabIndex
         });
-        // Scroll to top of ui tabs navigation
-        smoothScroll($tabObj, $(widget.active[0]));
         // Stop bubbling and default actions
         return false;
       }

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -44,8 +44,8 @@
        * @param {jQuery Object} $target
        */
       function smoothScroll($tabNav, $target) {
-        var navCoords = $tabNav[0].getBoundingClientRect();
-        $('.ama__resource-tabs__content').animate({
+        var scrollTarget = window.innerWidth < 600 ? 'html,body' : '.ama__resource-tabs__content';
+        $(scrollTarget).animate({
           scrollTop: 0
         }, 850, function () {
           // update focus for keyboard only navigation

--- a/styleguide/source/assets/js/tabs.js
+++ b/styleguide/source/assets/js/tabs.js
@@ -44,7 +44,7 @@
        * @param {jQuery Object} $target
        */
       function smoothScroll($tabNav, $target) {
-        var scrollTarget = window.innerWidth < 600 ? 'html,body' : '.ama__resource-tabs__content';
+        var scrollTarget = window.innerWidth >= 1200 ? '.ama__resource-tabs__content' : 'html,body';
         $(scrollTarget).animate({
           scrollTop: 0
         }, 850, function () {

--- a/styleguide/source/assets/scss/04-templates/_split.scss
+++ b/styleguide/source/assets/scss/04-templates/_split.scss
@@ -33,6 +33,7 @@
 .ama__layout--split__right {
   grid-column: 1 / 3;
   grid-row: 3;
+  position: relative;
 
   @include breakpoint($bp-small) {
     grid-row: 2;


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6979: A1 | Scroll resource tab content instead of page](https://issues.ama-assn.org/browse/EWL-6979)

## Description
Change `smoothScroll` function to target tab content instead of body for non-mobile viewports.


## To Test
- [ ] Open http://localhost:3000/patterns/05-pages-resource/05-pages-resource.html directly (the links don't work in the iframe)
- [ ] Check that the "Download 1" links no longer scroll the page downward, but only affects the resource tab content (right half of the page)
- [ ] Shrink your viewport to mobile, and check that the "Download 1" links scroll the page to the top as they did before

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/resource-page-link-scrolling/html_report/index.html).

# Related PR on ama-d8
https://github.com/AmericanMedicalAssociation/ama-d8/pull/1251

## Relevant Screenshots/GIFs
See ama-d8 PR


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
