### PR TITLE
EWL-6738: Category - View All Subcategories Bug

### DIFF
--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -14,7 +14,7 @@
       var $subcategoryListContainer = $('.ama__subcategory-exploration__list');
       var $subcategoryList  = $('.ama__subcategory-exploration__list ul');
       var $subcategoryListExpander = $('.ama__subcategory-exploration__show-more');
-      var $subcategoryListContainerHeight = $subcategoryListContainer.outerHeight() + 1;
+      var $subcategoryListContainerHeight = $subcategoryListContainer.outerHeight() + 3;
       var $subcategoryListLinkText = $('.ama__subcategory-exploration__text');
 
       // If the unordered list outerHeight is greater than the parent container then show the show more link


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6738: Category - View All Subcategories Bug](https://issues.ama-assn.org/browse/EWL-6738)

## Description
- View all link was showing when there were no other categories.  
- Ups the additional height from `1` to `3` for IE and FF with different heights of the category list. 
## To Test
- Run `gulp serve`
- Enable local SG2 in your D8
- Run `drush @one.local cr`
- Navigate to http://ama-one.local/member-groups-sections
  - Observe the link `View all subcategories ` does not show
- Edit the menu for this section http://ama-one.local/admin/structure/taxonomy/manage/menu/overview
- Drag links into the "Member Groups (Sections)" parent item and save menu changes
- Reload http://ama-one.local/member-groups-sections
   - Observe `View all subcategories` shows

### Browser testing
- [x] Did you test in IE 11?
- [x] Did you test in Firefox?
- [x] Did you test in Chrome?
- [x] Did you test in Safari?

## Visual Regressions

n/a
 
## Relevant Screenshots/GIFs
![screen shot 2019-02-04 at 4 18 53 pm](https://user-images.githubusercontent.com/2271747/52241159-94e9c880-2898-11e9-88c6-5947b86bc862.png)


## Remaining Tasks
N/a


## Additional Notes


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
