### PR TITLE
EWL-6801: A1 | Put Workflow Form in a Standard Position

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -69,6 +69,13 @@
       grid-template-columns: 4fr 1fr;
     }
 
+    .content-moderation-entity-moderation-form {
+      @include gutter($margin-top-half...);
+      grid-column: 1 / 5;
+      -ms-grid-column-span: 5;
+      grid-row: 1;
+    }
+
     .ama__h1 {
       @include gutter($margin-bottom-half...);
       grid-column: 1 / 5;

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -48,6 +48,13 @@
 
     }
 
+    .content-moderation-entity-moderation-form {
+      @include gutter($margin-top-half...);
+      grid-column: 1 / 5;
+      -ms-grid-column-span: 5;
+      grid-row: 1;
+    }
+
     &__link {
       @extend %ama__link--blue;
       @extend %ama__h4;
@@ -59,7 +66,7 @@
         display: block;
         grid-column: 1 / 5;
         -ms-grid-column-span: 5;
-        grid-row: 1;
+        grid-row: 2;
       }
     }
 
@@ -69,18 +76,11 @@
       grid-template-columns: 4fr 1fr;
     }
 
-    .content-moderation-entity-moderation-form {
-      @include gutter($margin-top-half...);
-      grid-column: 1 / 5;
-      -ms-grid-column-span: 5;
-      grid-row: 1;
-    }
-
     .ama__h1 {
       @include gutter($margin-bottom-half...);
       grid-column: 1 / 5;
       -ms-grid-column-span: 5;
-      grid-row: 2;
+      grid-row: 3;
     }
 
     .ama__subtitle {
@@ -90,7 +90,7 @@
     &__date {
       @include gutter($padding-top-full...);
       grid-column: 1/3;
-      grid-row: 3;
+      grid-row: 4;
     }
 
     &__share {
@@ -99,7 +99,7 @@
       @include breakpoint($bp-small) {
         @include gutter($padding-top-full...);
         grid-column: 4 / 5;
-        grid-row: 3;
+        grid-row: 4;
         display: block;
       }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
- [EWL-6801: A1 | Put Workflow Form in a Standard Position](https://issues.ama-assn.org/browse/EWL-6801)

## Description
- Adds grid and margin styling for content moderation workflow form
- Positions content workflow form above h1 title. 
- Depends on this PR on `amd-d8` repo: AmericanMedicalAssociation/ama-d8#1267

## To Test
- Enable sg-development on `local.yml` file (in `ama-d8` repo).
- Pull down code. 
- Pull down the branch for this corresponding pr: https://github.com/AmericanMedicalAssociation/ama-d8/pull/1267
- Edit any of the following node types to view the content moderation workflow form:
   - Banner:
 (no prod->local copy, add a banner here:  http://ama-one.local/node/add/banner, and content workflow form should be visible after saving)
   - Best Bet :
http://ama-one.local/node/24831/latest
 http://ama-one.local/node/24831
   - News Article :
http://ama-one.local/node/27916/latest
 http://ama-one.local/delivering-care/hypertension/how-office-blood-pressure-reading-accuracy-can-still-improve  
   - Press Release: 
http://ama-one.local/node/766/latest 
http://ama-one.local/press-center/press-releases/ama-adopts-guidance-reduce-harm-high-intensity-street-lights
   - Resource Page:
 http://ama-one.local/node/21751/latest 
http://ama-one.local/education/accelerating-change-medical-education/join-medical-school-conversation

Observe that content moderation workflow form is consistent across the listed content types.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/597/html_report/index.html).

## Relevant Screenshots/GIFs
### Themed pages
<img width="1269" alt="screen shot 2019-03-05 at 10 16 17 am" src="https://user-images.githubusercontent.com/541745/53820764-70861800-3f3a-11e9-9770-590d8de1976e.png">
<img width="1271" alt="screen shot 2019-03-05 at 10 16 43 am" src="https://user-images.githubusercontent.com/541745/53820765-70861800-3f3a-11e9-8f73-63a4ac91bc94.png">

### No theme/template pages
![screen shot 2019-03-05 at 11 32 10 am](https://user-images.githubusercontent.com/541745/53820812-898ec900-3f3a-11e9-881b-0d7fc6483cb0.png)

## Remaining Tasks
N/A

## Additional Notes

Some of the content listed in PR: https://github.com/AmericanMedicalAssociation/ama-d8/pull/1267 are not styled and only ensures content workflow form is standardize in position.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
