### PR TITLE
EWL-6638 - High - enhancement - Menu Expansion

### DIFF
--- a/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
+++ b/styleguide/source/_patterns/03-organisms/category-navigation-menu.twig
@@ -1,44 +1,47 @@
-<nav id="ama_category_navigation_menu" class="ama_category_navigation_menu">
-  {% for menuGroup in categoryNavigationMenu.menuGroups %}
-    <ul class="ama_category_navigation_menu__group sm sm-vertical">
-      {% for group in menuGroup.group %}
-        {% set link = group.link %}
-        {% set heading = group.heading %}
-        <li class="ama_category_navigation_menu__section" data-sm-horizontal-sub="true">
-          {% if heading %}
-            {% include "@atoms/heading/heading.twig" %}
-          {% else %}
-            {% include "@atoms/link/link.twig" %}
-          {% endif %}
-          {#Submenu array#}
-          {% if link.subMenu %}
-            <ul class="ama_category_navigation_menu__flyout">
-              <li class="ama_category_navigation_menu__flyout__container">
-                <div class="ama_category_navigation_menu__submenu">
-                  <ol>
-                    {% for subMenuItem in link.subMenu %}
-                      {% set link = subMenuItem.link %}
-                      <li>
-                        {% include "@atoms/link/link.twig" %}
-                      </li>
-                    {% endfor %}
-                  </ol>
-                </div>
-                {#article stubs#}
-                {% set link = group.link %}
-                {% if link.articleStubs %}
-                  <div class="ama_category_navigation_menu__articles">
-                    {% for article in link.articleStubs %}
-                      {% set articleStub = article %}
-                      {% include "@molecules/article-stub/article-stub.twig" %}
-                    {% endfor %}
+<div class="ama_category_navigation_wrapper">
+  <nav id="ama_category_navigation_menu" class="ama_category_navigation_menu">
+    {% for menuGroup in categoryNavigationMenu.menuGroups %}
+      <ul class="ama_category_navigation_menu__group sm sm-vertical">
+        {% for group in menuGroup.group %}
+          {% set link = group.link %}
+          {% set heading = group.heading %}
+          <li class="ama_category_navigation_menu__section" data-sm-horizontal-sub="true">
+            {% if heading %}
+              {% include "@atoms/heading/heading.twig" %}
+            {% else %}
+              {% include "@atoms/link/link.twig" %}
+            {% endif %}
+            {#Submenu array#}
+            {% if link.subMenu %}
+              <ul class="ama_category_navigation_menu__flyout">
+                <li class="ama_category_navigation_menu__flyout__container">
+                  <div class="ama_category_navigation_menu__submenu">
+                    <ol>
+                      {% for subMenuItem in link.subMenu %}
+                        {% set link = subMenuItem.link %}
+                        <li>
+                          {% include "@atoms/link/link.twig" %}
+                        </li>
+                      {% endfor %}
+                    </ol>
                   </div>
-                {% endif %}
-              </li>
-            </ul>
-          {% endif %}
-        </li>
-      {% endfor %}
-    </ul>
-  {% endfor %}
-</nav>
+                  {#article stubs#}
+                  {% set link = group.link %}
+                  {% if link.articleStubs %}
+                    <div class="ama_category_navigation_menu__articles">
+                      {% for article in link.articleStubs %}
+                        {% set articleStub = article %}
+                        {% include "@molecules/article-stub/article-stub.twig" %}
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </li>
+              </ul>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
+  </nav>
+
+</div>

--- a/styleguide/source/_patterns/04-templates/one-column.twig
+++ b/styleguide/source/_patterns/04-templates/one-column.twig
@@ -1,25 +1,27 @@
-{% block header %}
-  {% include '@organisms/main-navigation/main-navigation.twig' %}
-{% endblock %}
+<div class="layout-container">
+  {% block header %}
+    {% include '@organisms/main-navigation/main-navigation.twig' %}
+  {% endblock %}
 
-<div class="ama__layout--one-column container {{ class }}">
-  {# Keeping tabindex for accessibility purposes #}
+  <div class="ama__layout--one-column container {{ class }}">
+    {# Keeping tabindex for accessibility purposes #}
 
-  <section class="ama__layout--one-column__content-top">
-    {% block contentTop %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
-    {% endblock %}
-  </section>
+    <section class="ama__layout--one-column__content-top">
+      {% block contentTop %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
+      {% endblock %}
+    </section>
 
-  <article class="ama__layout--one-column__page-content" role="article">
-    {% block pageContent %}
-      {% set placeholder = one_column.page_content.placeholder %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page main content'}}%}
-    {% endblock %}
-  </article>
+    <article class="ama__layout--one-column__page-content" role="article">
+      {% block pageContent %}
+        {% set placeholder = one_column.page_content.placeholder %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page main content'}}%}
+      {% endblock %}
+    </article>
 
+  </div>
+
+  {% block footer %}
+    {% include "@organisms/footer/footer.twig" %}
+  {% endblock %}
 </div>
-
-{% block footer %}
-  {% include "@organisms/footer/footer.twig" %}
-{% endblock %}

--- a/styleguide/source/_patterns/04-templates/split.twig
+++ b/styleguide/source/_patterns/04-templates/split.twig
@@ -1,34 +1,35 @@
 {% if pageName %}
   <div class="{{ pageName }}">
 {% endif %}
+  <div class="layout-container">
+    {% block header %}
+      {% include '@organisms/main-navigation/main-navigation.twig' %}
+    {% endblock %}
 
-  {% block header %}
-    {% include '@organisms/main-navigation/main-navigation.twig' %}
-  {% endblock %}
+    <div class="ama__layout--split container {{ class }}">
+      {# Keeping tabindex for accessibility purposes #}
+      <section class="ama__layout--split__content-top">
+        {% block contentTop %}
+          {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
+        {% endblock %}
+      </section>
 
-  <div class="ama__layout--split container {{ class }}">
-    {# Keeping tabindex for accessibility purposes #}
-    <section class="ama__layout--split__content-top">
-      {% block contentTop %}
-        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
-      {% endblock %}
-    </section>
+      <section class="ama__layout--split__left">
+        {% block contentLeft %}
+          {% include '@base/placeholder.twig' with {'placeholder':{'text':'Left region content'}}%}
+        {% endblock %}
+      </section>
 
-    <section class="ama__layout--split__left">
-      {% block contentLeft %}
-        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Left region content'}}%}
-      {% endblock %}
-    </section>
+      <section class="ama__layout--split__right">
+        {% block contentRight %}
+          {% include '@base/placeholder.twig' with {'placeholder':{'text':'Right region content'}}%}
+        {% endblock %}
+      </section>
+    </div>
 
-    <section class="ama__layout--split__right">
-      {% block contentRight %}
-        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Right region content'}}%}
-      {% endblock %}
-    </section>
+    {% include "@organisms/footer/footer.twig" with {'footer':{'class': 'ama__footer ama__resource-page__mobile-footer'}} %}
+
+  {% if pageName %}
+    </div>
+  {% endif %}
   </div>
-
-  {% include "@organisms/footer/footer.twig" with {'footer':{'class': 'ama__footer ama__resource-page__mobile-footer'}} %}
-
-{% if pageName %}
-  </div>
-{% endif %}

--- a/styleguide/source/_patterns/04-templates/three-column.twig
+++ b/styleguide/source/_patterns/04-templates/three-column.twig
@@ -1,38 +1,40 @@
-{% block header %}
-  {% include '@organisms/main-navigation/main-navigation.twig' %}
-{% endblock %}
+<div class="layout-container">
+  {% block header %}
+    {% include '@organisms/main-navigation/main-navigation.twig' %}
+  {% endblock %}
 
-<div class="ama__layout--three-column container {{ class }}">
-  {# Keeping tabindex for accessibility purposes #}
+  <div class="ama__layout--three-column container {{ class }}">
+    {# Keeping tabindex for accessibility purposes #}
 
-  <section class="ama__layout--three-column__content-top">
-    {% block contentTop %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
-    {% endblock %}
-  </section>
+    <section class="ama__layout--three-column__content-top">
+      {% block contentTop %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
+      {% endblock %}
+    </section>
 
-  <article class="ama__layout--three-column__page-content" role="article">
-    {% block pageContent %}
-      {% set placeholder = three_column.page_content.placeholder %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page main content'}}%}
-    {% endblock %}
-  </article>
+    <article class="ama__layout--three-column__page-content" role="article">
+      {% block pageContent %}
+        {% set placeholder = three_column.page_content.placeholder %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page main content'}}%}
+      {% endblock %}
+    </article>
 
-  <aside id="sidebar-primary" class="ama__layout--three-column__sidebar--primary" role="complementary">
-    {% block sidebarPrimary %}
-      {% set placeholder = three_column.sidebar_primary.placeholder %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page sidebar primary content'}} %}
-    {% endblock %}
-  </aside>
+    <aside id="sidebar-primary" class="ama__layout--three-column__sidebar--primary" role="complementary">
+      {% block sidebarPrimary %}
+        {% set placeholder = three_column.sidebar_primary.placeholder %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page sidebar primary content'}} %}
+      {% endblock %}
+    </aside>
 
-  <aside id="sidebar-secondary" class="ama__layout--three-column__sidebar--secondary" role="complementary">
-    {% block sidebarSecondary %}
-      {% set placeholder = three_column.sidebar_secondary.placeholder %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page sidebar secondary content'}} %}
-    {% endblock %}
-  </aside>
+    <aside id="sidebar-secondary" class="ama__layout--three-column__sidebar--secondary" role="complementary">
+      {% block sidebarSecondary %}
+        {% set placeholder = three_column.sidebar_secondary.placeholder %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page sidebar secondary content'}} %}
+      {% endblock %}
+    </aside>
+  </div>
+
+  {% block footer %}
+    {% include "@organisms/footer/footer.twig" %}
+  {% endblock %}
 </div>
-
-{% block footer %}
-  {% include "@organisms/footer/footer.twig" %}
-{% endblock %}

--- a/styleguide/source/_patterns/04-templates/two-column-left.twig
+++ b/styleguide/source/_patterns/04-templates/two-column-left.twig
@@ -1,28 +1,30 @@
-{% block header %}
-  {% include '@organisms/main-navigation/main-navigation.twig' %}
-{% endblock %}
+<div class="layout-container">
+  {% block header %}
+    {% include '@organisms/main-navigation/main-navigation.twig' %}
+  {% endblock %}
 
-<div class="ama__layout--two-column--left container {{ class }}">
-  {# Keeping tabindex for accessibility purposes #}
-  <section class="ama__layout--two-column--left__content-top">
-    {% block contentTop %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
-    {% endblock %}
-  </section>
+  <div class="ama__layout--two-column--left container {{ class }}">
+    {# Keeping tabindex for accessibility purposes #}
+    <section class="ama__layout--two-column--left__content-top">
+      {% block contentTop %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
+      {% endblock %}
+    </section>
 
-  <article class="ama__layout--two-column--left__page-content" role="article">
-    {% block pageContent %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page Content region content'}}%}
-    {% endblock %}
-  </article>
+    <article class="ama__layout--two-column--left__page-content" role="article">
+      {% block pageContent %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page Content region content'}}%}
+      {% endblock %}
+    </article>
 
-   <aside id="sidebar-primary" class="ama__layout--two-column--left__sidebar--primary" role="complementary">
-    {% block sidebarPrimary %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Primary Sidebar region content'}}%}
-    {% endblock %}
-  </aside>
+     <aside id="sidebar-primary" class="ama__layout--two-column--left__sidebar--primary" role="complementary">
+      {% block sidebarPrimary %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Primary Sidebar region content'}}%}
+      {% endblock %}
+    </aside>
+  </div>
+
+  {% block footer %}
+    {% include "@organisms/footer/footer.twig" %}
+  {% endblock %}
 </div>
-
-{% block footer %}
-  {% include "@organisms/footer/footer.twig" %}
-{% endblock %}

--- a/styleguide/source/_patterns/04-templates/two-column-right-75-25.twig
+++ b/styleguide/source/_patterns/04-templates/two-column-right-75-25.twig
@@ -1,17 +1,19 @@
-<div class="ama__layout--two-col-right--75-25 {{ layoutClass }}">
-  <div class="ama__layout--two-col-right--75-25__top">
-    {% block contentTop %}
-      {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Top content' } } %}
-    {% endblock %}
-  </div>
-  <div class="ama__layout--two-col-right--75-25__left">
-    {% block contentLeft %}
-      {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Left side content' } } %}
-    {% endblock %}
-  </div>
-  <div class="ama__layout--two-col-right--75-25__right">
-    {% block contentRight %}
-      {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Right side content' } } %}
-    {% endblock %}
+<div class="layout-container">
+  <div class="ama__layout--two-col-right--75-25 {{ layoutClass }}">
+    <div class="ama__layout--two-col-right--75-25__top">
+      {% block contentTop %}
+        {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Top content' } } %}
+      {% endblock %}
+    </div>
+    <div class="ama__layout--two-col-right--75-25__left">
+      {% block contentLeft %}
+        {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Left side content' } } %}
+      {% endblock %}
+    </div>
+    <div class="ama__layout--two-col-right--75-25__right">
+      {% block contentRight %}
+        {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Right side content' } } %}
+      {% endblock %}
+    </div>
   </div>
 </div>

--- a/styleguide/source/_patterns/04-templates/two-column-right-full-width.twig
+++ b/styleguide/source/_patterns/04-templates/two-column-right-full-width.twig
@@ -1,27 +1,29 @@
-{% block header %}
-  {% include '@organisms/main-navigation/main-navigation.twig' %}
-{% endblock %}
+<div class="layout-container">
+  {% block header %}
+    {% include '@organisms/main-navigation/main-navigation.twig' %}
+  {% endblock %}
 
-<div class="ama__layout--two-col-right--full-width {{ layoutClass }}">
-  <div class="ama__layout--two-col-right--full-width__top">
-    {% block contentTop %}
-      {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Top content' } } %}
-    {% endblock %}
-  </div>
-  <div class="ama__layout--two-col-right--full-width__page-content">
-    <div class="ama__layout--two-col-right--full-width__page-content__left">
-      {% block contentLeft %}
-        {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Left side content' } } %}
+  <div class="ama__layout--two-col-right--full-width {{ layoutClass }}">
+    <div class="ama__layout--two-col-right--full-width__top">
+      {% block contentTop %}
+        {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Top content' } } %}
       {% endblock %}
     </div>
-    <div class="ama__layout--two-col-right--full-width__page-content__right">
-      {% block contentRight %}
-        {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Right side content' } } %}
-      {% endblock %}
+    <div class="ama__layout--two-col-right--full-width__page-content">
+      <div class="ama__layout--two-col-right--full-width__page-content__left">
+        {% block contentLeft %}
+          {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Left side content' } } %}
+        {% endblock %}
+      </div>
+      <div class="ama__layout--two-col-right--full-width__page-content__right">
+        {% block contentRight %}
+          {% include '@base/placeholder.twig' with { placeholder : { 'text' : 'Right side content' } } %}
+        {% endblock %}
+      </div>
     </div>
   </div>
+
+  {% block footer %}
+    {% include "@organisms/footer/footer.twig" %}
+  {% endblock %}
 </div>
-
-{% block footer %}
-  {% include "@organisms/footer/footer.twig" %}
-{% endblock %}

--- a/styleguide/source/_patterns/04-templates/two-column-right.twig
+++ b/styleguide/source/_patterns/04-templates/two-column-right.twig
@@ -1,34 +1,36 @@
-{% if not pageContentClass %}
-  {% set pageContentClass = 'ama__layout--two-column--right__page-content' %}
-{% endif %}
+<div class="layout-container">
+  {% if not pageContentClass %}
+    {% set pageContentClass = 'ama__layout--two-column--right__page-content' %}
+  {% endif %}
 
-{% block header %}
-  {% include '@organisms/main-navigation/main-navigation.twig' %}
-{% endblock %}
+  {% block header %}
+    {% include '@organisms/main-navigation/main-navigation.twig' %}
+  {% endblock %}
 
-<div class="ama__layout--two-column--right container {{ class }}">
-  {# Keeping tabindex for accessibility purposes #}
-  <section class="ama__layout--two-column--right__content-top">
-    {% block contentTop %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
-    {% endblock %}
-  </section>
+  <div class="ama__layout--two-column--right container {{ class }}">
+    {# Keeping tabindex for accessibility purposes #}
+    <section class="ama__layout--two-column--right__content-top">
+      {% block contentTop %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Content Top region content'}}%}
+      {% endblock %}
+    </section>
 
-  <article class="{{ pageContentClass }}" role="article">
-    {% block pageContent %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page Content region content'}}%}
-    {% endblock %}
-  </article>
+    <article class="{{ pageContentClass }}" role="article">
+      {% block pageContent %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Page Content region content'}}%}
+      {% endblock %}
+    </article>
 
-  <aside id="sidebar-primary" class="ama__layout--two-column--right__sidebar--primary" role="complementary"></aside>
+    <aside id="sidebar-primary" class="ama__layout--two-column--right__sidebar--primary" role="complementary"></aside>
 
-  <aside id="sidebar-secondary" class="ama__layout--two-column--right__sidebar--secondary" role="complementary">
-    {% block sidebarSecondary %}
-      {% include '@base/placeholder.twig' with {'placeholder':{'text':'Sidebar Secondary region content'}}%}
-    {% endblock %}
-  </aside>
+    <aside id="sidebar-secondary" class="ama__layout--two-column--right__sidebar--secondary" role="complementary">
+      {% block sidebarSecondary %}
+        {% include '@base/placeholder.twig' with {'placeholder':{'text':'Sidebar Secondary region content'}}%}
+      {% endblock %}
+    </aside>
+  </div>
+
+  {% block footer %}
+    {% include "@organisms/footer/footer.twig" %}
+  {% endblock %}
 </div>
-
-{% block footer %}
-  {% include "@organisms/footer/footer.twig" %}
-{% endblock %}

--- a/styleguide/source/assets/js/category-menu.js
+++ b/styleguide/source/assets/js/category-menu.js
@@ -10,6 +10,5 @@
 
 
 jQuery('.ama_category_navigation_menu__group').smartmenus({
-  subMenusSubOffsetY: -28,
   subIndicatorsPos: 'append'
 });

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -3,16 +3,16 @@
   Drupal.behaviors.ama_mainNavigation = {
     attach: function (context, settings) {
 
-      var $categoryNavWrapper = $('.ama_category_navigation_wrapper');
-      var $categoryNavigationMenu = $('.ama_category_navigation_menu');
-      var $mobileSearchTrigger = $('.global-search-trigger');
-      var $mobileSearch = $('.ama__global-search');
-      var $mainNav = $('.ama__main-navigation ');
-      var $productNav = $('.ama__product-nav');
-      var $productNavHeight = $productNav.length ? $productNav.outerHeight() : 0;
-      var viewportHeight = $(window).innerHeight() - $productNavHeight;
-      var categoryNavMenuHeight = $('.ama_category_navigation_menu').outerHeight() ;
-      var categoryNavMenuMResizedHeight = 0;
+      var $categoryNavWrapper = $('.ama_category_navigation_wrapper'),
+          $categoryNavigationMenu = $('.ama_category_navigation_menu'),
+          $mobileSearchTrigger = $('.global-search-trigger'),
+          $mobileSearch = $('.ama__global-search'),
+          $mainNav = $('.ama__main-navigation '),
+          $productNav = $('.ama__product-nav'),
+          $productNavHeight = $productNav.length ? $productNav.outerHeight() : 0,
+          viewportHeight = 0,
+          categoryNavMenuHeight = $('.ama_category_navigation_menu').outerHeight(),
+          categoryNavMenuMResizedHeight = 0;
 
       // Calculate whether or not the category nav should have scrollbars
       function categoryNavHeight($resizeViewportHeight) {
@@ -33,10 +33,21 @@
       }
 
       function submMenuFlyoutResize() {
+
+        // Calculate the visible height of article
+        var $el = $('article'),
+            scrollTop = $(this).scrollTop(),
+            scrollBot = scrollTop + $(this).height(),
+            elTop = $el.offset().top,
+            elBottom = elTop + $el.outerHeight(),
+            visibleTop = elTop < scrollTop ? scrollTop : elTop,
+            visibleBottom = elBottom > scrollBot ? scrollBot : elBottom,
+            viewportHeight =  visibleBottom - visibleTop;
+
         $('.ama_category_navigation_menu ul li').each(function () {
           $(this).hover(function () {
             if ($(this).find('.ama_category_navigation_menu__flyout').length) {
-              if($(this).find('.ama_category_navigation_menu__flyout').outerHeight() > viewportHeight - 100) {
+              if($(this).find('.ama_category_navigation_menu__flyout').outerHeight() > viewportHeight) {
                 $('.ama_category_navigation_menu__group').on('activate.smapi', function (e, item) {
                   $(item).next().addClass('pinned').outerHeight(viewportHeight);
                 });

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -40,14 +40,14 @@
       function submMenuFlyoutResize() {
 
         // Calculate the visible height of article
-        var $el = $('article'),
+        var $el = $('.layout-container'),
             scrollTop = $(this).scrollTop(),
             scrollBottom = scrollTop + $(this).height(),
             elTop = $el.offset().top,
             elBottom = elTop + $el.outerHeight(),
             visibleTop = elTop < scrollTop ? scrollTop : elTop,
             visibleBottom = elBottom > scrollBottom ? scrollBottom : elBottom,
-            viewportHeight =  visibleBottom - visibleTop;
+            viewportHeight =  visibleBottom - visibleTop - $mainNav.outerHeight() - productNavHeight ;
 
         $('.ama_category_navigation_menu ul li').each(function () {
           $(this).hover(function () {

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -9,12 +9,17 @@
           $mobileSearch = $('.ama__global-search'),
           $mainNav = $('.ama__main-navigation '),
           $productNav = $('.ama__product-nav'),
-          $productNavHeight = $productNav.length ? $productNav.outerHeight() : 0,
           viewportHeight = 0,
+          $productNavHeight = 0,
           categoryNavMenuHeight = $('.ama_category_navigation_menu').outerHeight(),
           categoryNavMenuMResizedHeight = 0;
 
-      // Calculate whether or not the category nav should have scrollbars
+
+      if($productNav.length){
+        $productNavHeight = $productNav.outerHeight();
+      }
+
+        // Calculate whether or not the category nav should have scrollbars
       function categoryNavHeight($resizeViewportHeight) {
 
         if(typeof $resizeViewportHeight !== 'undefined') {

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -7,45 +7,51 @@
       var $categoryNavigationMenu = $('.ama_category_navigation_menu');
       var $mobileSearchTrigger = $('.global-search-trigger');
       var $mobileSearch = $('.ama__global-search');
-      var $viewportHeight = $(window).innerHeight();
       var $mainNav = $('.ama__main-navigation ');
-      var $categoryNavMenuHeight = $('.ama_category_navigation_menu').outerHeight();
-      var $categoryNavMenuMResizedHeight = 0;
+      var $productNav = $('.ama__product-nav');
+      var $productNavHeight = $productNav.length ? $productNav.outerHeight() : 0;
+      var viewportHeight = $(window).innerHeight() - $productNavHeight;
+      var categoryNavMenuHeight = $('.ama_category_navigation_menu').outerHeight() ;
+      var categoryNavMenuMResizedHeight = 0;
 
       // Calculate whether or not the category nav should have scrollbars
       function categoryNavHeight($resizeViewportHeight) {
-        $viewportHeight = typeof $resizeViewportHeight !== 'undefined' ? $resizeViewportHeight : $(window).innerHeight();
-        $categoryNavMenuMResizedHeight = $viewportHeight - $mainNav.outerHeight();
 
-        if ($categoryNavMenuHeight > $viewportHeight) {
-          $categoryNavWrapper.outerHeight($categoryNavMenuMResizedHeight);
+        if(typeof $resizeViewportHeight !== 'undefined') {
+          viewportHeight = $resizeViewportHeight - $productNavHeight;
         } else {
-          $categoryNavWrapper.outerHeight($viewportHeight);
+          viewportHeight = $(window).innerHeight();
+        }
+
+        categoryNavMenuMResizedHeight = viewportHeight - $mainNav.outerHeight();
+
+        if (categoryNavMenuHeight > viewportHeight) {
+          $categoryNavWrapper.outerHeight(categoryNavMenuMResizedHeight);
+        } else {
+          $categoryNavWrapper.outerHeight(viewportHeight);
         }
       }
 
       function submMenuFlyoutResize() {
         $('.ama_category_navigation_menu ul li').each(function () {
           $(this).hover(function () {
-
             if ($(this).find('.ama_category_navigation_menu__flyout').length) {
-
-              if ($('.ama_category_navigation_menu__submenu', this).outerHeight() > $viewportHeight) {
-                $('.ama_category_navigation_menu__submenu', this).outerHeight($viewportHeight);
-              }
-
-              if ($('.ama_category_navigation_menu__articles', this).outerHeight() > $viewportHeight) {
-                $('.ama_category_navigation_menu__articles', this).outerHeight($viewportHeight);
+              if($(this).find('.ama_category_navigation_menu__flyout').outerHeight() > viewportHeight - 100) {
+                $('.ama_category_navigation_menu__group').on('activate.smapi', function (e, item) {
+                  $(item).next().addClass('pinned').outerHeight(viewportHeight);
+                });
+              } else {
+                $('.ama_category_navigation_menu__group').on('activate.smapi', function (e, item) {
+                  $(item).next().removeClass('pinned');
+                });
               }
             }
           });
         });
       }
 
-
       // Hide/Show menu
       function hideShow() {
-
         categoryNavHeight();
         submMenuFlyoutResize();
 
@@ -76,7 +82,7 @@
         }
       });
 
-      $($mobileSearchTrigger).unbind('click').click(function (e) {
+      $($mobileSearchTrigger).unbind('click').click(function () {
         $mobileSearch.slideToggle();
       });
     }

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -42,11 +42,11 @@
         // Calculate the visible height of article
         var $el = $('article'),
             scrollTop = $(this).scrollTop(),
-            scrollBot = scrollTop + $(this).height(),
+            scrollBottom = scrollTop + $(this).height(),
             elTop = $el.offset().top,
             elBottom = elTop + $el.outerHeight(),
             visibleTop = elTop < scrollTop ? scrollTop : elTop,
-            visibleBottom = elBottom > scrollBot ? scrollBot : elBottom,
+            visibleBottom = elBottom > scrollBottom ? scrollBottom : elBottom,
             viewportHeight =  visibleBottom - visibleTop;
 
         $('.ama_category_navigation_menu ul li').each(function () {

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -1,36 +1,87 @@
 (function ($, Drupal) {
+
   Drupal.behaviors.ama_mainNavigation = {
     attach: function (context, settings) {
 
+      var $categoryNavWrapper = $('.ama_category_navigation_wrapper');
       var $categoryNavigationMenu = $('.ama_category_navigation_menu');
       var $mobileSearchTrigger = $('.global-search-trigger');
       var $mobileSearch = $('.ama__global-search');
+      var $viewportHeight = $(window).innerHeight();
+      var $mainNav = $('.ama__main-navigation ');
+      var $categoryNavMenuHeight = $('.ama_category_navigation_menu').outerHeight();
+      var $categoryNavMenuMResizedHeight = 0;
+
+      // Calculate whether or not the category nav should have scrollbars
+      function categoryNavHeight($resizeViewportHeight) {
+        $viewportHeight = typeof $resizeViewportHeight !== 'undefined' ? $resizeViewportHeight : $(window).innerHeight();
+        $categoryNavMenuMResizedHeight = $viewportHeight - $mainNav.outerHeight();
+
+        if ($categoryNavMenuHeight > $viewportHeight) {
+          $categoryNavWrapper.outerHeight($categoryNavMenuMResizedHeight);
+        } else {
+          $categoryNavWrapper.outerHeight($viewportHeight);
+        }
+      }
+
+      function submMenuFlyoutResize() {
+        $('.ama_category_navigation_menu ul li').each(function () {
+          $(this).hover(function () {
+
+            if ($(this).find('.ama_category_navigation_menu__flyout').length) {
+
+              if ($('.ama_category_navigation_menu__submenu', this).outerHeight() > $viewportHeight) {
+                $('.ama_category_navigation_menu__submenu', this).outerHeight($viewportHeight);
+              }
+
+              if ($('.ama_category_navigation_menu__articles', this).outerHeight() > $viewportHeight) {
+                $('.ama_category_navigation_menu__articles', this).outerHeight($viewportHeight);
+              }
+            }
+          });
+        });
+      }
+
 
       // Hide/Show menu
       function hideShow() {
+
+        categoryNavHeight();
+        submMenuFlyoutResize();
+
         if ($('#global-menu').prop('checked')) {
           $categoryNavigationMenu.slideDown();
-        } 
+        }
         else {
           $categoryNavigationMenu.slideUp();
         }
       }
 
-      $('.ama__global-menu').click(function(e){
+      $(window).resize(function () {
+        var $resizeViewportHeight = $(window).innerHeight()
+        categoryNavHeight($resizeViewportHeight);
+
+        submMenuFlyoutResize();
+      });
+
+      $('.ama__global-menu').click(function (e) {
         e.stopPropagation();
         hideShow();
       });
 
-      $(document).click(function(e) {
+      $(document).click(function (e) {
         if (!$categoryNavigationMenu.is(e.target) && $categoryNavigationMenu.has(e.target).length === 0) {
-          $('#global-menu').prop('checked',false);
+          $('#global-menu').prop('checked', false);
           hideShow();
         }
       });
 
-      $($mobileSearchTrigger).unbind('click').click(function(e) {
+      $($mobileSearchTrigger).unbind('click').click(function (e) {
         $mobileSearch.slideToggle();
       });
     }
-  };
+  }
 })(jQuery, Drupal);
+
+
+

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -10,20 +10,20 @@
           $mainNav = $('.ama__main-navigation '),
           $productNav = $('.ama__product-nav'),
           viewportHeight = 0,
-          $productNavHeight = 0,
+          productNavHeight = 0,
           categoryNavMenuHeight = $('.ama_category_navigation_menu').outerHeight(),
           categoryNavMenuMResizedHeight = 0;
 
 
       if($productNav.length){
-        $productNavHeight = $productNav.outerHeight();
+        productNavHeight = $productNav.outerHeight();
       }
 
         // Calculate whether or not the category nav should have scrollbars
       function categoryNavHeight($resizeViewportHeight) {
 
         if(typeof $resizeViewportHeight !== 'undefined') {
-          viewportHeight = $resizeViewportHeight - $productNavHeight;
+          viewportHeight = $resizeViewportHeight - productNavHeight;
         } else {
           viewportHeight = $(window).innerHeight();
         }
@@ -102,7 +102,7 @@
         $mobileSearch.slideToggle();
       });
     }
-  }
+  };
 })(jQuery, Drupal);
 
 

--- a/styleguide/source/assets/js/nav.js
+++ b/styleguide/source/assets/js/nav.js
@@ -26,9 +26,9 @@
         });
 
         $(document).click( function(){
-          $('.ama__ribbon__dropdown__trigger', this).removeClass(class_active).children().removeClass(class_active)
+          $('.ama__ribbon__dropdown__trigger', this).removeClass(class_active).children().removeClass(class_active);
         });
-      })
+      });
     }
-  }
+  };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -129,11 +129,16 @@
       width: 550px !important;
       max-width: none !important;
       margin-left: 250px !important;
+      overflow: auto;
     }
 
     @include breakpoint($bp-large) {
       width: 940px !important;
       max-width: none !important;
+    }
+
+    &.pinned {
+      margin-top: -65px !important;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -118,6 +118,7 @@
   }
 
   &__flyout {
+    @include gutter($padding-bottom-full...);
     display: none;
     color: $black;
     list-style: none;
@@ -145,6 +146,7 @@
       box-shadow: 0 2px 3px 2px rgba(0, 0, 0, 0.4);
       width: 250px;
       float: left;
+      overflow-y: auto;
     }
 
     ol {
@@ -213,6 +215,8 @@
       }
 
       @include breakpoint($bp-small) {
+        overflow: auto;
+
         &:nth-child(2):nth-last-child(1) {
           @include gutter($margin-top-full...);
         }

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -136,10 +136,6 @@
       width: 940px !important;
       max-width: none !important;
     }
-
-    //&.pinned {
-    //  margin-top: -65px !important;
-    //}
   }
 
   &__submenu {

--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -137,9 +137,9 @@
       max-width: none !important;
     }
 
-    &.pinned {
-      margin-top: -65px !important;
-    }
+    //&.pinned {
+    //  margin-top: -65px !important;
+    //}
   }
 
   &__submenu {

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -32,7 +32,9 @@
 
   .ama_category_navigation_menu {
     display: none;
-    flex-direction: column;
+    position: absolute;
+    top: 60px;
+    left: 0;
     width: calc(100vw - 70px);
     z-index: 500;
 

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -32,9 +32,7 @@
 
   .ama_category_navigation_menu {
     display: none;
-    position: absolute;
-    top: 60px;
-    left: 0;
+    flex-direction: column;
     width: calc(100vw - 70px);
     z-index: 500;
 

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -20,11 +20,19 @@
     @include gutter($margin-right-half...);
   }
 
-  .ama_category_navigation_menu {
-    display: none;
+  .ama_category_navigation_wrapper {
+    overflow: auto;
+    -ms-overflow-style: none;
+    width: 110%;
     position: absolute;
     top: 60px;
     left: 0;
+    z-index: 500;
+  }
+
+  .ama_category_navigation_menu {
+    display: none;
+    flex-direction: column;
     width: calc(100vw - 70px);
     z-index: 500;
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6638: High - enhancement - Menu Expansion](https://issues.ama-assn.org/browse/EWL-6638)

## Description
When the main navigation drop down doesn't the viewport a user should be able to scroll the main navigation and see the rest of the navigation links. If the flyout content doesn't fit within the viewport a user should be able able to scroll and see the rest of it.

## To Test
- [ ] switch your SG2 branch to [feature/EWL-6638-menu-expansion](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/601)
- [ ] run `gulp serve`
- [ ] switch your D8 branch to `feature/EWL-6638-menu-expansion`
- [ ] enable local SG2 testing in your D8 environment
- [ ] navigate to http://ama-one.local/
- [ ] resize browser viewport so not all the main navigation drop fits within it
- [ ] observe how you are able to scroll the main purple drop down navigation
- [ ] resize the viewport so it accommodates all of the main dropdown navigation content
- [ ] observe how the scrolling functionality disappears because it's not needed anymore
- [ ] hover over the category links in the purple main navigation dropdown
- [ ] observe how a user is able to scroll if it doesn't all fit in the viewport''
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-6638-menu-expansionv/html_report/index.html).


## Relevant Screenshots/GIFs
![screen shot 2019-03-08 at 10 40 24 am](https://user-images.githubusercontent.com/2271747/54041966-ade2e380-418e-11e9-8c6b-b74e58d079f8.png)


## Remaining Tasks
Test in D8 


## Additional Notes
This PR is related to a PR in D8 `feature/EWL-6638-menu-expansion`

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)