### PR TITLE
EWL-7009 - Resource page links ghost box

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -232,8 +232,14 @@ li {
   padding: $gutter / 2 0;
 
   &.ui-state-active {
-    //z-index: 10;
+    outline: none;
     display: block;
+
+  }
+
+  &:focus,
+  &:focus  * {
+    outline: none;
   }
 
   > * + * {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7009: Resource page links ghost box](https://issues.ama-assn.org/browse/EWL-7009)

## Description


## To Test
- [x] switch branch to `feature/EWL-6638-menu-expansion`
- [x] run `gulp serve`
- [x] Using a Chrome browser navigate to pages > resource 
- [ ] click on a link in the left column such as `download 1`
- [ ] observe how the right column no longer has a faint blue outline that appears around it
- [ ] observe how the title no longer has a blue outline around it
- [ ] verify this is also fixed in D8 by enabling local SG2 development
- [ ] http://ama-one.local/education/cme/ama-pra-credit-system
- [ ] follow the same steps as above and verify the blue box doesn't appear
- [x] Did you test in IE 11?

## Visual Regressions

## Relevant Screenshots/GIFs
n/a

## Remaining Tasks
Test in D8 


## Additional Notes
This PR is related to a PR in D8 `feature/EWL-6638-menu-expansion`

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
