### PR TITLE
[EWL-7009] Bugfix: Resource page links ghost box

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -238,7 +238,7 @@ li {
   }
 
   &:focus,
-  &:focus  * {
+  *:focus {
     outline: none;
   }
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7009: Resource page links ghost box](https://issues.ama-assn.org/browse/EWL-7009)

## Description
Corrects style rule so that is properly targets the focus state of items inside a resource page tab.

## To Test
- Pull `bugfix/EWL-7009-resource-page-links`
- Run `gulp serve` in ama-style-guide-2/styleguide to ensure a local version of style guide is running.
- Update your local AMAOne provision vars to use your local SG2 files.
- Using a Chrome browser navigate to the [SG2 resource pages](https://americanmedicalassociation.github.io/ama-style-guide-2/?p=pages-resource) 
- Click on a link in the left column such as `Media 4` and confirm the title no longer has a blue outline around it
- Load a resource page in D8 and confirm titles do not show blue outline when clicking on associated left hand side link

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
