### PR TITLE
EWL-7092 SG2 | Create simple header organism for SLP

### DIFF
--- a/styleguide/source/_patterns/03-organisms/sales-landing-page-header.json
+++ b/styleguide/source/_patterns/03-organisms/sales-landing-page-header.json
@@ -1,0 +1,25 @@
+{
+  "salesLandingPage": {
+    "siteLogo": {
+      "src": "../../assets/images/brand/logo.svg",
+      "href": "#",
+      "class": "ama__site-logo",
+      "imageClass": "logo",
+      "alt": "American Medical Association",
+      "reversed": {
+        "src": "../../assets/images/brand/logo.svg"
+      }
+    },
+    "header": {
+      "contact": "For immediate assistance, please call Jim Gilligan at (312) 464-4521.",
+      "button": {
+        "href": "",
+        "info": "alt",
+        "text": "Lorem ipsum",
+        "type": "button",
+        "style": "cta",
+        "size": ""
+      }
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/sales-landing-page-header.twig
+++ b/styleguide/source/_patterns/03-organisms/sales-landing-page-header.twig
@@ -1,0 +1,9 @@
+<div class="ama__sales-landing-page__header">
+  {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : salesLandingPage.siteLogo } %}
+
+  <div class="ama__sales-landing-page__header__contact">
+    <p class="info">{{ salesLandingPage.header.contact }}</p>
+    {% set button = salesLandingPage.header.button %}
+    {% include '@atoms/button/button.twig' %}
+  </div>
+</div>

--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
@@ -1,0 +1,29 @@
+.ama__sales-landing-page {
+  &__header {
+    @include gutter($margin-top-full...);
+    @include gutter($padding-bottom-full...);
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid $black;
+  }
+
+  &__header .ama__site-logo .logo {
+    height: 70px;
+    width: 159px;
+  }
+
+  &__header__contact {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+    text-align: right;
+
+    .info {
+      max-width: 300px;
+    }
+
+    .ama__button--cta {
+      @include gutter($margin-left-half...);
+    }
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
@@ -12,13 +12,16 @@
     }
   }
 
-  &__header .ama__site-logo .logo {
-    @include gutter($margin-bottom-full...);
-    height: 70px;
-    width: 159px;
+  &__header .ama__site-logo {
+    height: auto;
 
-    @include breakpoint($bp-small min-width) {
-      margin-bottom: 0;
+    .logo {
+      height: 70px;
+      width: 159px;
+
+      @include breakpoint($bp-small min-width) {
+        margin-bottom: 0;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
@@ -3,27 +3,49 @@
     @include gutter($margin-top-full...);
     @include gutter($padding-bottom-full...);
     display: flex;
+    flex-direction: column;
     align-items: center;
     border-bottom: 1px solid $black;
+
+    @include breakpoint($bp-small min-width) {
+      flex-direction: row;
+    }
   }
 
   &__header .ama__site-logo .logo {
+    @include gutter($margin-bottom-full...);
     height: 70px;
     width: 159px;
+
+    @include breakpoint($bp-small min-width) {
+      margin-bottom: 0;
+    }
   }
 
   &__header__contact {
+    @include gutter($margin-top-full...);
     display: flex;
+    flex-direction: column;
     flex: 1;
     justify-content: flex-end;
     text-align: right;
+
+    @include breakpoint($bp-small min-width) {
+      margin-top: 0;
+      flex-direction: row;
+    }
 
     .info {
       max-width: 300px;
     }
 
     .ama__button--cta {
+      @include gutter($margin-top-full...);
       @include gutter($margin-left-half...);
+
+      @include breakpoint($bp-small min-width) {
+        margin-top: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7092: SG2 | Create simple header organism for SLP](https://issues.ama-assn.org/browse/EWL-7092)

## Description
Create sales landing page header organism

## To Test
- [ ] switch your SG2 branch to `feature/EWL-7092-SLP-header`
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=organisms-sales-landing-page-header
- [ ] observe the header looks like the two mockups in https://issues.ama-assn.org/browse/EWL-7092 with the exception of the button look and feel. The button look and feel has been already established. 
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-7092-SLP-header/html_report/index.html).



## Relevant Screenshots/GIFs
![Screen Shot 2019-03-27 at 1 22 07 PM](https://user-images.githubusercontent.com/2271747/55101967-5d76eb80-5093-11e9-9e45-e37e54d9e398.png)
![Screen Shot 2019-03-27 at 1 13 21 PM](https://user-images.githubusercontent.com/2271747/55101969-5d76eb80-5093-11e9-9d3e-11a90fcfe279.png)


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
There are slight differences from the mockups. These include the padding around the button and margin and padding. The margin and paddings are derived from already approved styles from AMA One.
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
