### PR TITLE
EWL-7098 SG2 | Create SLP Hero Organism

### DIFF
--- a/styleguide/source/_patterns/03-organisms/sales-landing-page-hero.json
+++ b/styleguide/source/_patterns/03-organisms/sales-landing-page-hero.json
@@ -1,0 +1,25 @@
+{
+  "salesLandingPageHero": {
+    "image": {
+      "alt": "alt text",
+      "src": "https://ipsumimage.appspot.com/600x400x186?l=3:2|600x400&s=36",
+      "height": "400",
+      "width": "600"
+    },
+    "subtitle": {
+      "text": "Hero title optional"
+    },
+    "paragraph" : {
+      "text": "A paragraph (from the Greek paragraphos, \"to write beside\" or \"written beside\") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.",
+      "class": "description"
+    },
+    "button": {
+      "href": "",
+      "info": "alt",
+      "text": "Optional CTA",
+      "type": "button",
+      "style": "",
+      "size": ""
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/sales-landing-page-hero.twig
+++ b/styleguide/source/_patterns/03-organisms/sales-landing-page-hero.twig
@@ -1,0 +1,15 @@
+<div class="ama__sales-landing-page-hero">
+  {% set image = salesLandingPageHero.image %}
+  {% include '@atoms/image/image.twig' %}
+
+  <div class="ama__sales-landing-page-hero__content">
+    {% set subtitle = salesLandingPageHero.subtitle %}
+    {% include '@atoms/subtitle.twig' %}
+
+    {% set paragraph = salesLandingPageHero.paragraph %}
+    {% include '@atoms/paragraph.twig' %}
+
+    {% set button = salesLandingPageHero.button %}
+    {% include '@atoms/button/button.twig' %}
+  </div>
+</div>

--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
@@ -1,0 +1,36 @@
+.ama__sales-landing-page-hero {
+  @include gutter($margin-top-full...);
+  @include gutter($margin-bottom-full...);
+  display: flex;
+  flex-direction: column;
+
+  @include breakpoint($bp-small) {
+    flex-direction: row;
+  }
+
+  .ama__image {
+    border: 1px solid $gray-20;
+  }
+
+  &__content {
+    @include gutter($margin-top-full...);
+    @include gutter($margin-left-full...);
+    @include gutter($margin-right-full...);
+
+    @include breakpoint($bp-small) {
+      margin-top: 0;
+    }
+
+    .description {
+      @include gutter($margin-bottom-full...);
+    }
+
+    .ama__button {
+      width: 100%;
+
+      @include breakpoint($bp-small) {
+        width: auto;
+      }
+    }
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
@@ -19,6 +19,7 @@
 
     @include breakpoint($bp-small) {
       margin-top: 0;
+      width: 60%;
     }
 
     .description {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7098: SG2 | Create SLP Hero Organism](https://issues.ama-assn.org/browse/EWL-7098)

## Description
Create sales landing page header organism

## To Test
- [ ] switch your SG2 branch to `feature/EWL-7098-slp-hero`
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=organisms-sales-landing-page-header
- [ ] observe the hero looks like the two mockups in https://issues.ama-assn.org/browse/EWL-7098 with the exception of the button look and feel. The button look and feel has been already established. 
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/feature/EWL-7098-slp-herohtml_report/index.html).



## Relevant Screenshots/GIFs
![Screen Shot 2019-03-27 at 2 06 01 PM](https://user-images.githubusercontent.com/2271747/55104997-7aaeb880-5099-11e9-8c5e-b6c487b4ac37.png)
![Screen Shot 2019-03-27 at 2 05 27 PM](https://user-images.githubusercontent.com/2271747/55104998-7aaeb880-5099-11e9-95d8-191bbea197de.png)


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
There are slight differences from the mockups. These include the padding around the button and margin and padding. The margin and paddings are derived from already approved styles from AMA One.
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
