### PR TITLE
EWL-7097 SG2 | Theme Sales Landing Page

### DIFF
--- a/styleguide/source/_patterns/03-organisms/sales-landing-page-header.twig
+++ b/styleguide/source/_patterns/03-organisms/sales-landing-page-header.twig
@@ -2,7 +2,11 @@
   {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : salesLandingPage.siteLogo } %}
 
   <div class="ama__sales-landing-page__header__contact">
-    <p class="info">{{ salesLandingPage.header.contact }}</p>
+    <div class="info">
+      <p>
+        {{ salesLandingPage.header.contact }}
+      </p>
+    </div>
     {% set button = salesLandingPage.header.button %}
     {% include '@atoms/button/button.twig' %}
   </div>

--- a/styleguide/source/assets/scss/00-base/_webform_confirmation.scss
+++ b/styleguide/source/assets/scss/00-base/_webform_confirmation.scss
@@ -1,4 +1,7 @@
 .webform-confirmation {
+  @include gutter($padding-top-full...);
+  @include gutter($padding-bottom-full...);
+
   &__header {
     border-bottom: 1px solid $gray-7;
   }

--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-header.scss
@@ -1,7 +1,9 @@
 .ama__sales-landing-page {
   &__header {
     @include gutter($margin-top-full...);
-    @include gutter($padding-bottom-full...);
+    @include gutter($margin-bottom-full...);
+    @include gutter-all($padding-all-full...);
+
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -31,23 +33,25 @@
     flex-direction: column;
     flex: 1;
     justify-content: flex-end;
-    text-align: right;
+    text-align: center;
 
     @include breakpoint($bp-small min-width) {
       margin-top: 0;
       flex-direction: row;
+      text-align: right;
     }
 
     .info {
-      max-width: 300px;
+      max-width: 400px;
     }
 
     .ama__button--cta {
       @include gutter($margin-top-full...);
-      @include gutter($margin-left-half...);
 
       @include breakpoint($bp-small min-width) {
+        @include gutter($margin-left-half...);
         margin-top: 0;
+        align-self: flex-start;
       }
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
@@ -1,6 +1,7 @@
 .ama__sales-landing-page-hero {
   @include gutter($margin-top-full...);
   @include gutter($margin-bottom-full...);
+
   display: flex;
   flex-direction: column;
 
@@ -14,10 +15,10 @@
 
   &__content {
     @include gutter($margin-top-full...);
-    @include gutter($margin-left-full...);
-    @include gutter($margin-right-full...);
 
     @include breakpoint($bp-small) {
+      @include gutter($margin-left-full...);
+      @include gutter($margin-right-full...);
       margin-top: 0;
       width: 60%;
     }

--- a/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
@@ -1,0 +1,20 @@
+.ama__sales-landing-page {
+  &__cta {
+    @include gutter($margin-top-full...);
+    @include gutter($margin-bottom-full...);
+
+    .ama__button {
+      display: block;
+      margin: 0 auto;
+
+      @include breakpoint($bp-small min-width) {
+        width: 25%;
+      }
+    }
+  }
+
+  &__form {
+    @include gutter($margin-top-full...);
+    @include gutter($margin-bottom-full...);
+  }
+}

--- a/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
@@ -2,6 +2,8 @@
   &__cta {
     @include gutter($margin-top-full...);
     @include gutter($margin-bottom-full...);
+    @include gutter($padding-top-full...);
+    @include gutter($padding-bottom-full...);
 
     .ama__button {
       display: block;
@@ -14,7 +16,19 @@
   }
 
   &__form {
-    @include gutter($margin-top-full...);
+    @include gutter($padding-top-full...);
     @include gutter($margin-bottom-full...);
+
+    h1 {
+      display: none;
+    }
+
+    form {
+      padding: 0;
+    }
+
+    &__heading {
+      @include gutter($padding-top-full...);
+    }
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7097: Sales Landing Theme Templates)

## Description
Theme sales landing page

## To Test
- [ ] switch your SG2 branch to `feature/EWL-7097-sales-landing-theme`
- [ ] run `gulp serve`
- [ ] switch your D8 branch to `feature/EWL-7097-Sales-Landing-Theme-Templates`
- [ ] Enable local SG2 for your D8 environment in local.yml
- [ ] run `drush @one.local cim -y`
- [ ] run `drush @one.local cr`
- [ ] create a new sales landing page in content
- [ ] Add all the component types:
 - sales_wysiwyg
 - sales_text
 - sales_hero 
 - sales_cta
- sales_webform

- [ ] View new sales landing page
- [ ] observe it looks like the attached mockups

- [ ] Did you test in IE 11?

## Visual Regressions
n/a



## Relevant Screenshots/GIFs
![screencapture-ama-one-local-sales-landing-page-title-2019-04-01-15_16_13](https://user-images.githubusercontent.com/2271747/55356778-22105e80-5491-11e9-8823-fe62f7092adb.png)

[Gen Lead Physician and Residents Designs.pdf](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/files/3030633/Gen.Lead.Physician.and.Residents.Designs.pdf)
[Gen Lead Template Designs.pdf](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/files/3030634/Gen.Lead.Template.Designs.pdf)


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
There are slight differences from the mockups. These include the padding around the button and margin and padding. The margin and paddings are derived from already approved styles from AMA One.
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
