### PR TITLE
EWL-7104 Updates sales landing page confirmation to be inline

### DIFF
--- a/styleguide/source/assets/js/webforms.js
+++ b/styleguide/source/assets/js/webforms.js
@@ -63,14 +63,17 @@
   var initialLoad = true;
 
   Drupal.behaviors.webForm = {
+    detach: function (context, settings, trigger) {
+      if (trigger === 'serialize') {
+        initialLoad = false;
+      }
+    },
     attach: function (context, settings) {
-
-      $(".ama__sales-landing-page__form form").validate({
-        success: function(element) {
+      if (!initialLoad) {
+        if (!context.innerText.match("Error message")) {
           $('.ama__sales-landing-page__form__heading').hide();
         }
-      });
-
+      }
 
       $.validator.addMethod(
         "regex",

--- a/styleguide/source/assets/js/webforms.js
+++ b/styleguide/source/assets/js/webforms.js
@@ -52,7 +52,7 @@
   $('.ama__button--decline').click(function(e) {
     e.preventDefault();
 
-    if (document.referrer == "") {
+    if (document.referrer === "") {
       document.location.href='/';
     }
     else {
@@ -64,6 +64,14 @@
 
   Drupal.behaviors.webForm = {
     attach: function (context, settings) {
+
+      $(".ama__sales-landing-page__form form").validate({
+        success: function(element) {
+          $('.ama__sales-landing-page__form__heading').hide();
+        }
+      });
+
+
       $.validator.addMethod(
         "regex",
         function(value, element, regexp) {

--- a/styleguide/source/assets/scss/00-base/_webform_confirmation.scss
+++ b/styleguide/source/assets/scss/00-base/_webform_confirmation.scss
@@ -17,11 +17,4 @@
     display: flex;
     justify-content: center;
   }
-
-  &.ama__sales-landing-page__confirmation {
-    h1 {
-      display: block;
-      text-align: center;
-    }
-  }
 }

--- a/styleguide/source/assets/scss/00-base/_webform_confirmation.scss
+++ b/styleguide/source/assets/scss/00-base/_webform_confirmation.scss
@@ -17,4 +17,11 @@
     display: flex;
     justify-content: center;
   }
+
+  &.ama__sales-landing-page__confirmation {
+    h1 {
+      display: block;
+      text-align: center;
+    }
+  }
 }

--- a/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
@@ -32,3 +32,12 @@
     }
   }
 }
+
+.ama__sales-landing-page__form {
+  .webform-confirmation {
+    h1 {
+      display: block;
+      text-align: center;
+    }
+  }
+}


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-7104: A1 | Theme SLP Confirmation Page](https://issues.ama-assn.org/browse/EWL-7104)

## Description
Updates sale landing page webform confirmation styles and hides header if form succeeds

## To Test
- [ ] switch your SG2 branch to `feature/SLP-Confirmation-Page`
- [ ] run `gulp serve`
- [ ] switch your D8 branch to `feature/SLP-Confirmation-Page`
- [ ] run `drush @one.local cim -y`
- [ ] If you don't have a sales landing page then create one
- [ ] Create a new webform and make the confirmation inline
- [ ] Link the new webform to the sales landing page webform component
- [ ] Observe new sales landing page
- [ ] Fill in webform
- [ ] Observe the webform header disappears and a thank you appears
- [ ] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
![Screen Shot 2019-04-04 at 3 33 59 PM](https://user-images.githubusercontent.com/2271747/55586635-16ba6e80-56ef-11e9-92fb-3c02a4759445.png)


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
