### PR TITLE
EWL-7122 BUGFIX: Specialty Landing Visual Regression	

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_event-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_event-stub.scss
@@ -3,6 +3,7 @@
   @include breakpoint($bp-small) {
     flex-direction: row;
   }
+
   &:first-child {
     border-top: 1px solid $gray-50;
   }

--- a/styleguide/source/assets/scss/05-pages/_specialty-landing.scss
+++ b/styleguide/source/assets/scss/05-pages/_specialty-landing.scss
@@ -1,0 +1,8 @@
+.ama__specialty-landing {
+  .ama__event-stub {
+    &:first-child {
+      border-top: 0;
+    }
+  }
+}
+


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-7104: A1 | Theme SLP Confirmation Page](https://issues.ama-assn.org/browse/EWL-7104)

## Description
Updates sale landing page webform confirmation styles and hides header if form succeeds

## To Test
- [ ] switch your SG2 branch to `bugfix/EWL-7122-specialty-Landing-Visual-Regression`
- [ ] run `gulp serve`
- [ ] switch your D8 branch to `bugfix/EWL-7122-specialty-Landing-Visual-Regression`
- [ ] enable local SG2 in your local.yml
- [ ] run `drush @one.local cim -y`
- [ ] visit http://ama-one.local/specialty
- [ ] if you don't have that page then do a db refresh from Prod
- [ ] observe that the lines are removed


## Visual Regressions

n/a

## Relevant Screenshots/GIFs
![Screen Shot 2019-04-05 at 4 43 16 PM](https://user-images.githubusercontent.com/2271747/55658058-ef80a180-57c1-11e9-9fbe-93bf26f72614.png)


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
