### PR TITLE
EWL-7126 - Removes contains images within paragraphs

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
@@ -32,11 +32,8 @@
     }
   }
 
-  &__paragraph {
-    .ama__image--right {
-      float: none;
-      display: inline;
-    }
+  .paragraph {
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-7126: A1 | Theme SLP Confirmation Page](https://issues.ama-assn.org/browse/EWL-7126)

## Description
Updates sale landing page webform confirmation styles and hides header if form succeeds

## To Test
- [x] switch your SG2 branch to `bugfix/EWL-7126-image-placement`
- [x] run `gulp serve`
- [x] switch your D8 branch to `develop`
- [x] run `drush @one.local cim -y`
- [x] If you don't have a sales landing page then create one
- [x] Create a new sales text and embed an image entity
- [x] Save
- [x] Observe the image no longer goes into the footer or float right
- [x] Did you test in IE 11?

## Visual Regressions

n/a

## Relevant Screenshots/GIFs
![Screen Shot 2019-04-09 at 10 31 39 AM](https://user-images.githubusercontent.com/2271747/55813620-afb40580-5ab2-11e9-9381-820be83d357d.png)


## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
