### PR TITLE
EWL-7141 Theming Sales Landing theming 

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
@@ -11,6 +11,11 @@
 
   .ama__image {
     border: 1px solid $gray-20;
+    float: none;
+
+    @include breakpoint($bp-small) {
+      float: right;
+    }
   }
 
   &__content {

--- a/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
@@ -1,4 +1,8 @@
 .ama__sales-landing-page {
+  &__section {
+    overflow: hidden;
+  }
+
   &__cta {
     @include gutter($margin-top-full...);
     @include gutter($margin-bottom-full...);
@@ -25,6 +29,8 @@
 
     form {
       padding: 0;
+      margin: 0;
+      max-width: 556px;
     }
 
     &__heading {

--- a/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
@@ -47,13 +47,17 @@
   .paragraph {
     overflow: hidden;
   }
-}
 
-.ama__sales-landing-page__form {
-  .webform-confirmation {
-    h1 {
-      display: block;
-      text-align: center;
+  &__form {
+    .webform-confirmation {
+      h1 {
+        display: block;
+        text-align: center;
+      }
     }
+  }
+
+  .webform-confirmation {
+    max-width: 100%;
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_sales-landing-page.scss
@@ -19,6 +19,12 @@
     }
   }
 
+.webform-button--submit {
+  @include breakpoint($bp-small min-width) {
+    width: 50%;
+  }
+}
+
   &__form {
     @include gutter($padding-top-full...);
     @include gutter($margin-bottom-full...);


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7141: Sales Landing Theme Templates](https://issues.ama-assn.org/browse/EWL-7141)

## Description
Theme sales landing page

## To Test
- [x] switch your SG2 branch to `feature/EWL-7141-Theming-Sales-Landing-theming`
- [x] run `gulp serve`
- [x] switch your D8 branch to `feature/EWL-7141-Theming-Sales-Landing-theming`
- [x] Enable local SG2 for your D8 environment in local.yml
- [x] run `drush @one.local cim -y`
- [x] run `drush @one.local cr`
- [x] create a new sales landing page in content
- [x] Add all the component types:
 - sales_wysiwyg
 - sales_text
 - sales_hero 
 - sales_cta
- sales_webform
- [x] View new sales landing page
- [x] observe it looks the body width is approx 862px and the webform is 556px
- [x] Did you test in IE 11?

## Visual Regressions
n/a



## Relevant Screenshots/GIFs
![screencapture-ama-one-local-sales-landing-page-title-2019-04-12-12_40_30](https://user-images.githubusercontent.com/2271747/56055823-302b6e00-5d20-11e9-9798-373a45647299.png)



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
