### PR TITLE
EWL-6949: EWL-6949: A1 | Image alignment for JAMA component

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_jama.scss
+++ b/styleguide/source/assets/scss/02-molecules/_jama.scss
@@ -199,6 +199,9 @@
     .ama__image__text {
       padding: 0;
     }
+    .ama__image-wrap {
+      margin-left: inherit;
+    }
   }
 
   .ama__image {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
- [EWL-6949: EWL-6949: A1 | Image alignment for JAMA component](https://issues.ama-assn.org/browse/EWL-6949)

## Description
- Fixes regression bug from original fix for JAMA article alignment. Previous PR: https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/588 
- Fixes image alignment of JAMA article for "horizontal" JAMA article layout. 

## To Test
- [ ] Pull down code and enable local styleguide for Drupal
- [ ] Visit: http://ama-one.local/advocacy
- [ ] Add JAMA article image, if not available
- [ ] Observe images are **not** mis-aligned as seen below:
![2019-03-22_EWL-6949_JAMA example Right](https://user-images.githubusercontent.com/541745/56165792-dd60e900-5fa1-11e9-9207-0814cbaecbeb.png)

## Visual Regressions

N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
