### PR TITLE
EWL-6638 - High - enhancement - Menu Expansion 

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-navigation-menu.scss
@@ -133,7 +133,7 @@
     }
 
     @include breakpoint($bp-large) {
-      width: 940px !important;
+      width: 980px !important;
       max-width: none !important;
     }
   }
@@ -148,6 +148,18 @@
       width: 250px;
       float: left;
       overflow-y: auto;
+    }
+
+
+    &__header {
+
+      @include breakpoint($bp-small) {
+        @include gutter($margin-bottom-half...);
+        @include gutter($padding-left-half...);
+        @include gutter($padding-right-half...);
+      }
+      color: $homepagePurple;
+      text-transform: uppercase;
     }
 
     ol {
@@ -174,17 +186,6 @@
             background-color: transparent;
             text-decoration: underline;
           }
-        }
-
-        &.ama_category_navigation_menu__submenu__header {
-
-          @include breakpoint($bp-small) {
-            @include gutter($margin-bottom-half...);
-            @include gutter($padding-left-half...);
-            @include gutter($padding-right-half...);
-          }
-          color: $homepagePurple;
-          text-transform: uppercase;
         }
       }
     }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -23,6 +23,22 @@
   .ama_category_navigation_wrapper {
     overflow: auto;
     -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      height: 0;
+      width: 0;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      height: 0;
+      width: 0;
+    }
+
+    &::-webkit-scrollbar-track {
+      height: 0;
+      width: 0;
+    }
+
     width: 110%;
     position: absolute;
     top: 60px;

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -22,6 +22,7 @@
 
   .ama_category_navigation_wrapper {
     overflow: auto;
+    overflow: -moz-scrollbars-none;
     -ms-overflow-style: none;
 
     &::-webkit-scrollbar {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6638: High - enhancement - Menu Expansion](https://issues.ama-assn.org/browse/EWL-6638)

## Description
Fixes width of the flyout menu which causes wrapping of content. 
Fixes category header color

## To Test
- [ ] switch your SG2 branch to [feature/EWL-6638-menu-expansion](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/601)
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-homepage
- [ ] click on the header hamburger menu
- [ ] hover over the categories
- [ ] observe how the flyout content no longer wraps
- [ ] observe the category link color is now purple
- [ ] switch your D8 repo to https://github.com/AmericanMedicalAssociation/ama-d8/pull/1276
- [ ] enable SG2 local development in your D8
- [ ] visit the homepage
- [ ] click on the main menu hamburger icon
- [ ] observe the category header links are still purple
- [ ] observe the flyout menu content does not stack
- [ ] Did you test in IE 11?

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/fature/EWL-6638-menu-expansion?expand=1/html_report/index.html).


## Relevant Screenshots/GIFs
<img width="1814" alt="Screen Shot 2019-04-29 at 12 18 06 PM" src="https://user-images.githubusercontent.com/2271747/56914120-e5785880-6a78-11e9-8d07-37825164e545.png">



## Remaining Tasks



## Additional Notes


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)