### PR TITLE
EWL-6775 Social Sharing Icons - sticky

### DIFF
--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -101,6 +101,42 @@
       $($mobileSearchTrigger).unbind('click').click(function () {
         $mobileSearch.slideToggle();
       });
+
+      function moveSocialSharePosition(){
+        var mainNavPosition = $('.ama__main-navigation .container').offset().left - 100;
+        var $socialIcons = $('.ama__masthead__content__share');
+
+        if($('.ama__masthead__content__share').length && $(window).width() > 768) {
+          $socialIcons.sticky({
+            wrapperClassName: 'ama__masthead__content__share-wrapper',
+            zIndex: 501
+          });
+
+          $socialIcons.on('sticky-start', function () {
+            $('.ama__social-share').addClass('ama__social-share--fixed').css('left', mainNavPosition).hide().fadeTo('slow', 1);
+          });
+
+          $socialIcons.on('sticky-update', function () {
+            $('.ama__social-share').addClass('ama__social-share--fixed').hide().fadeTo('slow', 1);
+          });
+
+          $socialIcons.on('sticky-end', function () {
+            $('.ama__social-share--fixed').removeClass('ama__social-share--fixed');
+          });
+        }
+      }
+
+      // Initialize getSocialShare()
+      moveSocialSharePosition();
+
+      //Checks the layout position of article on window resize and moves the social icons accordingly
+      $( window ).resize(function() {
+
+        var mainNavPositionUpdate = $('.ama__main-navigation .container').offset().left - 100;
+
+        $('.ama__social-share.ama__social-share--fixed').css('left', mainNavPositionUpdate);
+
+      });
     }
   };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -149,10 +149,6 @@
           window.clearTimeout(debounce_timer);
         }
 
-        if($(window).height() < 745) {
-          $('.ama__social-share.ama__social-share--fixed').hide();
-        }
-
         debounce_timer = window.setTimeout(function() {
           if(socialIconPositionBottom > footerPosition) {
             $('.ama__masthead__content__share').fadeOut('fast');

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -150,7 +150,7 @@
         }
 
         if($(window).height() < 745) {
-          $('.ama__masthead__content__share').hide();
+          $('.ama__social-share.ama__social-share--fixed').hide();
         }
 
         debounce_timer = window.setTimeout(function() {

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -104,25 +104,27 @@
 
       function moveSocialSharePosition(){
         var mainNavPosition = $('.ama__main-navigation .container').offset().left;
-        var categoryNavWrapperHeight = $(window).height();
+        var $amaSocialShare = $('.ama__social-share');
 
-        if(mainNavPosition > 50) {
-          mainNavPosition = mainNavPosition - 100;
+        // Checks to see if there is enough for the sticky nav
+        if(mainNavPosition > 60) {
 
+          var socialStickyPosition = mainNavPosition - 60;
           var $socialIcons = $('.ama__masthead__content__share');
 
-          if($('.ama__masthead__content__share').length && $(window).width() > 1400) {
+          // Check to see if viewport width is greater 850px then the social icons will be sticky
+          if($socialIcons.length && $(window).width() > 850) {
             $socialIcons.sticky({
               wrapperClassName: 'ama__masthead__content__share-wrapper',
               zIndex: 501
             });
 
             $socialIcons.on('sticky-start', function () {
-              $('.ama__social-share').addClass('ama__social-share--fixed').css('left', mainNavPosition).hide().fadeTo('slow', 1);
+              $amaSocialShare.addClass('ama__social-share--fixed').css('left', socialStickyPosition).hide().fadeTo('slow', 1);
             });
 
             $socialIcons.on('sticky-update', function () {
-              $('.ama__social-share').addClass('ama__social-share--fixed').hide().fadeTo('slow', 1);
+              $amaSocialShare.addClass('ama__social-share--fixed').hide().fadeTo('slow', 1);
             });
 
             $socialIcons.on('sticky-end', function () {
@@ -135,14 +137,13 @@
       // Initialize getSocialShare()
       moveSocialSharePosition();
 
-
       // Onscroll check to see if social icon position is greater than footer position
       var debounce_timer;
 
       $(window).scroll(function() {
-        var socialIconPosition = $('.ama__masthead__content__share .ama__social-share').offset().top - $(window).scrollTop();
-        var footerPosition = $('footer').offset().top - $(window).scrollTop() - 200 > 0 ? $('footer').offset().top - $(window).scrollTop() - 200 : -245;
-        var socialIconPositionUpdate = 0;
+        var $socialIcons = $('.ama__masthead__content__share .ama__social-share');
+        var socialIconPositionBottom = $socialIcons.offset().top + $socialIcons.outerHeight();
+        var footerPosition = $('footer').offset().top;
 
         if(debounce_timer) {
           window.clearTimeout(debounce_timer);
@@ -153,14 +154,7 @@
         }
 
         debounce_timer = window.setTimeout(function() {
-
-          if(socialIconPosition > 0) {
-            socialIconPositionUpdate = socialIconPosition;
-          } else {
-            socialIconPositionUpdate = 0;
-          }
-
-          if(socialIconPositionUpdate >= footerPosition) {
+          if(socialIconPositionBottom > footerPosition) {
             $('.ama__masthead__content__share').fadeOut('fast');
           } else {
             $('.ama__masthead__content__share').fadeIn('fast');

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -111,7 +111,7 @@
 
           var $socialIcons = $('.ama__masthead__content__share');
 
-          if($('.ama__masthead__content__share').length && $(window).width() > 1400 && categoryNavWrapperHeight > 850) {
+          if($('.ama__masthead__content__share').length && $(window).width() > 1400) {
             $socialIcons.sticky({
               wrapperClassName: 'ama__masthead__content__share-wrapper',
               zIndex: 501
@@ -134,6 +134,33 @@
 
       // Initialize getSocialShare()
       moveSocialSharePosition();
+
+
+      // Onscroll check to see if social icon position is greater than footer position
+      var debounce_timer;
+
+      $(window).scroll(function() {
+        if(debounce_timer) {
+          window.clearTimeout(debounce_timer);
+        }
+        debounce_timer = window.setTimeout(function() {
+          var socialIconPosition = $('.ama__masthead__content__share .ama__social-share').offset().top - $(window).scrollTop();
+          var footerPosition = $('footer').offset().top - $(window).scrollTop() - 80;
+          var socialIconPositionUpdate = 0;
+
+          if(socialIconPosition > 0) {
+            socialIconPositionUpdate = socialIconPosition;
+          } else {
+            socialIconPositionUpdate = 0;
+          }
+
+          if(socialIconPositionUpdate > footerPosition) {
+            $('.ama__masthead__content__share').fadeOut('fast');
+          } else {
+            $('.ama__masthead__content__share').fadeIn('fast');
+          }
+        }, 50);
+      });
 
       //Checks the layout position of article on window resize and moves the social icons accordingly
       $( window ).resize(function() {

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -103,26 +103,32 @@
       });
 
       function moveSocialSharePosition(){
-        var mainNavPosition = $('.ama__main-navigation .container').offset().left - 100;
-        var $socialIcons = $('.ama__masthead__content__share');
+        var mainNavPosition = $('.ama__main-navigation .container').offset().left;
+        var categoryNavWrapperHeight = $(window).height();
 
-        if($('.ama__masthead__content__share').length && $(window).width() > 768) {
-          $socialIcons.sticky({
-            wrapperClassName: 'ama__masthead__content__share-wrapper',
-            zIndex: 501
-          });
+        if(mainNavPosition > 50) {
+          mainNavPosition = mainNavPosition - 100;
 
-          $socialIcons.on('sticky-start', function () {
-            $('.ama__social-share').addClass('ama__social-share--fixed').css('left', mainNavPosition).hide().fadeTo('slow', 1);
-          });
+          var $socialIcons = $('.ama__masthead__content__share');
 
-          $socialIcons.on('sticky-update', function () {
-            $('.ama__social-share').addClass('ama__social-share--fixed').hide().fadeTo('slow', 1);
-          });
+          if($('.ama__masthead__content__share').length && $(window).width() > 1400 && categoryNavWrapperHeight > 850) {
+            $socialIcons.sticky({
+              wrapperClassName: 'ama__masthead__content__share-wrapper',
+              zIndex: 501
+            });
 
-          $socialIcons.on('sticky-end', function () {
-            $('.ama__social-share--fixed').removeClass('ama__social-share--fixed');
-          });
+            $socialIcons.on('sticky-start', function () {
+              $('.ama__social-share').addClass('ama__social-share--fixed').css('left', mainNavPosition).hide().fadeTo('slow', 1);
+            });
+
+            $socialIcons.on('sticky-update', function () {
+              $('.ama__social-share').addClass('ama__social-share--fixed').hide().fadeTo('slow', 1);
+            });
+
+            $socialIcons.on('sticky-end', function () {
+              $('.ama__social-share--fixed').removeClass('ama__social-share--fixed');
+            });
+          }
         }
       }
 

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -140,13 +140,19 @@
       var debounce_timer;
 
       $(window).scroll(function() {
+        var socialIconPosition = $('.ama__masthead__content__share .ama__social-share').offset().top - $(window).scrollTop();
+        var footerPosition = $('footer').offset().top - $(window).scrollTop() - 200 > 0 ? $('footer').offset().top - $(window).scrollTop() - 200 : -245;
+        var socialIconPositionUpdate = 0;
+
         if(debounce_timer) {
           window.clearTimeout(debounce_timer);
         }
+
+        if($(window).height() < 745) {
+          $('.ama__masthead__content__share').hide();
+        }
+
         debounce_timer = window.setTimeout(function() {
-          var socialIconPosition = $('.ama__masthead__content__share .ama__social-share').offset().top - $(window).scrollTop();
-          var footerPosition = $('footer').offset().top - $(window).scrollTop() - 80;
-          var socialIconPositionUpdate = 0;
 
           if(socialIconPosition > 0) {
             socialIconPositionUpdate = socialIconPosition;
@@ -154,7 +160,7 @@
             socialIconPositionUpdate = 0;
           }
 
-          if(socialIconPositionUpdate > footerPosition) {
+          if(socialIconPositionUpdate >= footerPosition) {
             $('.ama__masthead__content__share').fadeOut('fast');
           } else {
             $('.ama__masthead__content__share').fadeIn('fast');

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -68,14 +68,14 @@
 
       // Hide/Show menu
       function hideShow() {
-        categoryNavHeight();
-        submMenuFlyoutResize();
-
         if ($('#global-menu').prop('checked')) {
           $categoryNavigationMenu.slideDown();
+          categoryNavHeight();
+          submMenuFlyoutResize();
         }
         else {
           $categoryNavigationMenu.slideUp();
+          categoryNavHeight(0);
         }
       }
 

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -105,16 +105,36 @@
       display: none;
 
       @include breakpoint($bp-small) {
+        left: 0;
         grid-column: 4 / 5;
         grid-row: 3;
         display: flex;
         justify-content: center;
         align-items: center;
         height: 66px;
+        min-width: 50px;
+
+
+        &.is-sticky {
+        }
       }
 
       .ama__social-share {
         justify-content: flex-end;
+
+        &--fixed {
+          top: 0;
+          left: 0;
+          position: absolute;
+          transform: rotate(90deg);
+          margin-top: 250px;
+          width: 50px;
+
+          li {
+            transform: rotate(-90deg);
+          }
+
+        }
       }
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -119,17 +119,18 @@
         justify-content: flex-end;
 
         &--fixed {
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
           top: 0;
           left: 0;
           position: absolute;
-          transform: rotate(90deg);
           margin-top: 250px;
           width: 50px;
 
           li {
-            transform: rotate(-90deg);
+            margin: 0 0 $gutter/2 0 ;
           }
-
         }
       }
     }

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -113,10 +113,6 @@
         align-items: center;
         height: 66px;
         min-width: 50px;
-
-
-        &.is-sticky {
-        }
       }
 
       .ama__social-share {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-6775: Social Sharing Icons - sticky](https://issues.ama-assn.org/browse/EWL-6775)

## Description
The social icons need to move the left of the article and stayed pinned when the header no longer is in view. 

## To Test
- [ ] switch your SG2 branch to `feature/EWL-6955-sticky-social-icons`
- [ ] run `gulp serve`
- [ ] visit http://localhost:3000/?p=pages-event
- [ ] scroll page
- [ ] observe the social icons move to the left of the article and remained fixed
- [ ] enable local SG2 for your D8 environment
- [ ] visit any interior page with social icons
- [ ] scroll page
- [ ] observe how the social icons move to the left of the article and stays pinned
- [ ] Did you test in IE 11?

## Visual Regressions


## Relevant Screenshots/GIFs
![Screen Shot 2019-04-29 at 2 23 05 PM](https://user-images.githubusercontent.com/2271747/56921005-52481e80-6a8a-11e9-8f5f-4f5ae824f99e.png)

## Remaining Tasks
n/a

## Additional Notes
n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
