### PR TITLE
EWL-7076: Menu doesn't expand on people listing pages

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -45,6 +45,7 @@
     top: 60px;
     left: 0;
     z-index: 500;
+    scrollbar-width: none;
   }
 
   .ama_category_navigation_menu {

--- a/styleguide/source/assets/scss/05-pages/_people-listing.scss
+++ b/styleguide/source/assets/scss/05-pages/_people-listing.scss
@@ -1,7 +1,4 @@
 .ama__people-listing {
-  .container {
-    overflow: hidden;
-  }
 
   &__card-container {
     @include gutter($padding-top-full...);

--- a/styleguide/source/assets/scss/05-pages/_people-listing.scss
+++ b/styleguide/source/assets/scss/05-pages/_people-listing.scss
@@ -1,4 +1,7 @@
 .ama__people-listing {
+  .ama__people-listing__card-container {
+    overflow: hidden;
+  }
 
   &__card-container {
     @include gutter($padding-top-full...);


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-7076: Menu doesn't expand on people listing pages](https://issues.ama-assn.org/browse/EWL-7076)

## Description
- Fixes main menu behavior to dropdown/appear when user clicks on white X in purple main menu on people listing pages
  - http://ama-one.local/about/board-trustees/board-trustees-members
  - http://ama-one.local/member-groups-sections/medical-students/medical-student-section-mss-governing-council
- Hides scrollbar on Firefox/Safari browser (after clicking on X to expand main menu)
- See production to see bug
  - https://www.ama-assn.org/member-groups-sections/medical-students/medical-student-section-mss-governing-council
  - https://www.ama-assn.org/about/board-trustees/board-trustees-members 

## To Test
- [ ] Pull down code and enable local styleguide
- [ ] Navigate to the following pages to test main menu dropdown behavior: 
  - http://ama-one.local/about/board-trustees/board-trustees-members
  - http://ama-one.local/member-groups-sections/medical-students/medical-student-section-mss-governing-council 
- [ ] Click on X to expand main menu
- [ ] Ensure on other pages (any page) the main menu are not affected by fix.

## Visual Regressions
A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/bugfix/EWL-7076-menu-people-listing/html_report/index.html).

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
