### PR TITLE
EWL-7158: SLP Auto Crop Images (IE bugfix)

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_sales-landing-page-hero.scss
@@ -12,6 +12,7 @@
   .ama__image {
     border: 1px solid $gray-20;
     float: none;
+    width: 100%;
 
     @include breakpoint($bp-small) {
       float: right;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
- [EWL-7158: SLP Auto Crop Images (IE bugfix)](https://issues.ama-assn.org/browse/EWL-7158)

## Description
- IE bug with image width breaking hero image layout
- Adds `width` CSS attribute to prevent hero image squeeze text in SLP hero

## To Test
- [ ] Enable SG local development for AMA one. 
- [ ] Create a SLP with a hero paragraph component (add image and text)
- [ ] Observe in IE that image is not squeezing text, right of the image. As seen below: 
![2019-05-02_EWL-7158_New IE11_2](https://user-images.githubusercontent.com/541745/57646738-3dda4a80-758f-11e9-905e-1c840c6170de.png)


## Visual Regressions
- N/A


## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
