### PR TITLE
EWL-7175: Contact Us Form - Enhancement - Testing site fix

### DIFF
--- a/styleguide/source/assets/js/webforms.js
+++ b/styleguide/source/assets/js/webforms.js
@@ -49,11 +49,15 @@
   }
 
   // Submits first page of Contact Us form on radio button selection
-  $( document ).ajaxComplete(function() {
+  $.fn.contactSubmit = function(){
     var $webform_buttons = $('.webform-submission-contact-us-form input[type="radio"]');
     $webform_buttons.bind('click', function(e) {
       $('.webform-submission-contact-us-form').submit();
     });
+  }
+  $.fn.contactSubmit();
+  $( document ).ajaxComplete(function() {
+    $.fn.contactSubmit();
   });
 
   // Go back to previous back is user clicks decline submit button


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-7175: Contact Us Form - Enhancement](https://issues.ama-assn.org/browse/EWL-7175)

## Description
- Added functionality to try to fix broken contact form functionality on test site
    - Added function that is called with or without ajax load

## To Test
- [ ] Pull branch /feature/EWL-7175-contact-enhancement
- [ ] run gulp serve
- [ ] Enable local SG2 in your local.yml in D8
- [ ] run drush @one.local cr
- [ ] visit [http://ama-one.local/form/contact-us](http://ama-one.local/form/contact-us)
- [ ] Verify that "Next" button is not visible
- [ ] Verify that form progresses to the next form page (with contact form) on selection of Physician, Resident, or Med Student
- [ ] Verify that form progresses to the next page (with AMA Automated Answer Center) on selection of Public/Other
- [ ] Verify that that the back button works once you get to this page
- [ ] Verify the form still will progress to the next page after pressing the back button

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
**Before**
![contact_us_before](https://user-images.githubusercontent.com/43501792/56990725-7293de00-6b5b-11e9-9b6c-b86f36391bf1.jpg)

**After**
![contact_us_after](https://user-images.githubusercontent.com/43501792/56990739-79baec00-6b5b-11e9-84b7-0398a8e64437.jpg)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
