### PR TITLE
EWL-7222: Evergreen Page | Add page title and subtitle to SG

### DIFF
--- a/styleguide/source/_patterns/03-organisms/masthead/masthead.md
+++ b/styleguide/source/_patterns/03-organisms/masthead/masthead.md
@@ -17,6 +17,7 @@ Displays the title (and subtitle), the (sub)category, date of publication, and s
 - [Masthead as Simplified](?p=organisms-masthead-as-simplified)
 - [Masthead with subtitle](?p=organisms-masthead-with-subtitle)
 - [Masthead with Subtitle as Indented](?p=organisms-masthead-with-subtitle-as-indented)
+- [Masthead with Subtitle as Centered](?p=organisms-masthead-with-subtitle-as-centered)
 - [Masthead as Title Only](?p=organisms-masthead-as-title-only)
 
 ### Variables

--- a/styleguide/source/_patterns/03-organisms/masthead/masthead.twig
+++ b/styleguide/source/_patterns/03-organisms/masthead/masthead.twig
@@ -1,5 +1,6 @@
 {%  set
-  indented, link, heading, subtitle, date, social =
+  centered, indented, link, heading, subtitle, date, social =
+  masthead.centered ? "ama__masthead__content__title--centered" : "",
   masthead.indented ? "ama__masthead__content--indented" : "",
   masthead.link,
   masthead.heading|merge({
@@ -15,7 +16,7 @@
   <div class="ama__masthead__sidebar" role="complementary"></div>
   <div class="ama__masthead__content {{ indented }}" role="complementary">
     <div class="ama__masthead__content__title__container">
-      <div class="ama__masthead__content__title">
+      <div class="ama__masthead__content__title {{ centered }}">
         {% if masthead.link.title %}
           {% include "@atoms/link/link.twig" %}
         {% endif %}

--- a/styleguide/source/_patterns/03-organisms/masthead/masthead~with-subtitle-as-centered.json
+++ b/styleguide/source/_patterns/03-organisms/masthead/masthead~with-subtitle-as-centered.json
@@ -9,10 +9,10 @@
       "class": "ama__masthead__content__link"
     },
     "heading": {
-      "text": "JAMA Network to launch fully open-access journal"
+      "text": "Lorem ipsum title for BU Page"
     },
     "subtitle": {
-      "text": "Example text for a subtitle, lorem ipsum sit dolor"
+      "text": "Text describing what this rule means and how the AMA has provided the below to help. Lorem Ipsum. Alsip Clark Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam et felis vel massa consequat congue. Praesent viverra feugiat arcu aliquam posuere. Integer non luctus urna, quis tincidunt nisi. Proin ullamcorper velit in vulputate sodales. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Cras tincidunt id nisi ac ornare. Nam vel fermentum ligula."
     },
     "social": [
       {

--- a/styleguide/source/_patterns/03-organisms/masthead/masthead~with-subtitle-as-centered.json
+++ b/styleguide/source/_patterns/03-organisms/masthead/masthead~with-subtitle-as-centered.json
@@ -1,0 +1,45 @@
+{
+  "masthead": {
+    "centered": true,
+    "link": {
+      "title": "Category link",
+      "href": "#",
+      "text": "Delivering care",
+      "target": "_self",
+      "class": "ama__masthead__content__link"
+    },
+    "heading": {
+      "text": "JAMA Network to launch fully open-access journal"
+    },
+    "subtitle": {
+      "text": "Example text for a subtitle, lorem ipsum sit dolor"
+    },
+    "social": [
+      {
+        "text": "facebook",
+        "icon": "facebook",
+        "url": "www.facebook.com\/AmericanMedicalAssociation"
+      },
+      {
+        "text": "googleplus",
+        "icon": "googleplus",
+        "url": "plus.google.com\/+americanmedicalassociation"
+      },
+      {
+        "text": "twitter",
+        "icon": "twitter",
+        "url": "twitter.com\/AmerMedicalAssn"
+      },
+      {
+        "text": "linkedin",
+        "icon": "linkedin",
+        "url": "www.linkedin.com\/company\/american-medical-association"
+      },
+      {
+        "text": "email",
+        "icon": "email",
+        "url": "mailto:example@ama-assn.org"
+      }
+    ]
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -40,6 +40,12 @@
 
     &__title {
       width: 100%;
+
+      &--centered {
+        p, h1, h2, h3, h4, h5, h6 {
+          text-align: center;
+        }
+      }
     }
     
     &__event__button {

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -42,6 +42,10 @@
       width: 100%;
 
       &--centered {
+        .ama__subtitle {
+          font-size: 18px;
+          font-weight: normal;
+        }
         p, h1, h2, h3, h4, h5, h6 {
           text-align: center;
         }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7222: Evergreen Page | Add page title and subtitle to SG](https://issues.ama-assn.org/browse/EWL-7222)

## Description
Added a variation of the masthead organism that centers the title and subtitle


## To Test
- [ ] Pull branch /feature/EWL-7222-centered-masthead
- [ ] run gulp serve
- [ ] visit [http://localhost:3000/?p=organisms-masthead-with-subtitle-as-centered](http://localhost:3000/?p=organisms-masthead-with-subtitle-as-centered)
- [ ] Verify that new masthead variation has centered text as seen in screenshot below
- [ ] Verify that new masthead variation category is formatted as seen in screenshot below
- [ ] Verify that new masthead variation social icons are formatted as seen in screenshot below (except for color of icons, disregard the purple color in the screenshot)


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
<img width="1214" alt="Screen Shot 2019-05-29 at 12 12 28 PM" src="https://user-images.githubusercontent.com/43501792/58576995-26e05d00-820b-11e9-89d8-8db5eda8ad7a.png">



## Remaining Tasks
Add class to D8 page template for evergreen pages - [https://github.com/AmericanMedicalAssociation/ama-d8/pull/1415](https://github.com/AmericanMedicalAssociation/ama-d8/pull/1415)


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
