### PR TITLE
EWL-7269: Evergreen Pages | Embedded image caption does not wrap

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -26,3 +26,12 @@
     }
   }
 }
+//embedded image with caption - wrap caption
+figure.embed-entity--caption {
+  display: table;
+
+  figcaption {
+    display: table-caption;
+    caption-side: bottom;
+  }
+}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7269: Evergreen Pages | Embedded image caption does not wrap](https://issues.ama-assn.org/browse/EWL-7269)

## Description
Added CSS to wrap caption on embedded images.


## To Test
- [ ] Pull SG branch /feature/EWL-7222-centered-masthead
- [ ] Pull AMAONE branch /feature/EWL-7211-EP-Twig-Template-Page
- [ ] run gulp serve
- [ ] Enable local SG2 in your local.yml in D8
- [ ] run drush @one.local cr
- [ ] Import config
- [ ] Create a new Evergreen page
- [ ] Add an Evergreen tab
- [ ] Add a wysiwyg paragraph in the evergreen tab
- [ ] Add text and embed an image (thumbnail) in the wysiwyg with a long caption
- [ ] Save and verify that the text of the caption is wrapping

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
<img width="404" alt="Screen Shot 2019-05-29 at 4 02 37 PM" src="https://user-images.githubusercontent.com/43501792/58591154-412a3300-822b-11e9-8225-a8b6d3de4e76.png">



## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
