### PR TITLE
EWL-7271: Evergreen Pages | Flex cards do not span full width if only 3 cards

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -169,6 +169,14 @@
       @include type($myriad-pro, $font-weight-bold);
     }
   }
+
+  &--add-padding {
+    padding: $gutter 0;
+
+    @include  breakpoint($bp-small) {
+      padding: 0;
+    }
+  }
 }
 
 .ama__page--news__teasers {
@@ -189,3 +197,4 @@
         @include gutter($padding-right-half...);
       }
 }
+

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -169,14 +169,6 @@
       @include type($myriad-pro, $font-weight-bold);
     }
   }
-
-  &--add-padding {
-    padding: $gutter 0;
-
-    @include  breakpoint($bp-small) {
-      padding: 0;
-    }
-  }
 }
 
 .ama__page--news__teasers {
@@ -197,4 +189,12 @@
         @include gutter($padding-right-half...);
       }
 }
+.ama__category__article-stub-three-up {
+  .ama__article-stub {
+    padding: $gutter 0;
 
+    @include  breakpoint($bp-small) {
+      padding: 0;
+    }
+  }
+}


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-7271: Evergreen Pages | Flex cards do not span full width if only 3 cards](https://issues.ama-assn.org/browse/EWL-7271)

## Description
Added padding to article stub for this PR:
https://github.com/AmericanMedicalAssociation/ama-d8/pull/1426


## To Test
Test on this PR:
https://github.com/AmericanMedicalAssociation/ama-d8/pull/1426

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
