### PR TITLE
EWL-7280: Social Icons Color Needs to be Purple

### DIFF
--- a/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-email-purple.twig
+++ b/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-email-purple.twig
@@ -1,0 +1,12 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 155.4 155.4">
+    <defs>
+        <style>
+            .cls-1{fill:#fff;stroke:#46166B;}.cls-1,.cls-2{stroke-miterlimit:10;}.cls-2{fill:none;stroke:#000;stroke-width:5px;}
+        </style>
+    </defs>
+    <title>Email_default</title>
+    <circle cx="77.7" cy="77.7" r="77.7"/>
+    <rect class="cls-1" x="21.01" y="49.52" width="113.38" height="60.6"/>
+    <line class="cls-2" x1="17.47" y1="48.54" x2="79.83" y2="84.55"/>
+    <line class="cls-2" x1="141.14" y1="48.45" x2="77.37" y2="84.64"/>
+</svg>

--- a/styleguide/source/assets/icons/svg/icon-email-purple.svg
+++ b/styleguide/source/assets/icons/svg/icon-email-purple.svg
@@ -1,0 +1,12 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 155.4 155.4">
+    <defs>
+        <style>
+            .cls-0{fill:#46166B}.cls-1{fill:#fff;stroke:#46166B;}.cls-1,.cls-2{strfill:#fffoke-miterlimit:10;}.cls-2{fill:none;stroke:#46166B;stroke-width:5px;}
+        </style>
+    </defs>
+    <title>Email_default</title>
+    <circle class="cls-0" cx="77.7" cy="77.7" r="77.7"/>
+    <rect class="cls-1" x="21.01" y="49.52" width="113.38" height="60.6"/>
+    <line class="cls-2" x1="17.47" y1="48.54" x2="79.83" y2="84.55"/>
+    <line class="cls-2" x1="141.14" y1="48.45" x2="77.37" y2="84.64"/>
+</svg>

--- a/styleguide/source/assets/scss/02-molecules/_social-share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_social-share.scss
@@ -29,7 +29,7 @@ $social-icons: (
 @each $name in $social-icons {
   .social--#{$name} {
     display: inline-block;
-    background: url("../icons/svg/icon-" + $name + ".svg") no-repeat 0 0;
+    background: url("../icons/svg/icon-" + $name + "-purple.svg") no-repeat 0 0;
     background-size: 31px;
     height: 31px;
     width: 31px;


### PR DESCRIPTION
## Ticket(s)

- [EWL-7280: Social Icons Color Needs to be Purple](https://issues.ama-assn.org/browse/EWL-7280)

## Description
- Sets the default color for social share icons to purple
- Adds email purple icon svg and twig file

## To Test
- [x] Enable local styleguide development
- [x] Navigate to http://ama-one.local/advocacy
- [x] Observe that top social and sidebar/aside social (when scrolling up and down) are purple.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/644/html_report/index.html).




## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
