### PR TITLE
EWL-7283: Mobile Evergreen Page Padding

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -44,7 +44,6 @@
   }
 
   &__page-content__flush-left {
-    @include gutter($padding-right-full...);
     position: relative;
     grid-column: 1 / 5;
     grid-row: 2;
@@ -55,6 +54,7 @@
     }
 
     @include breakpoint($bp-med min-width) {
+      @include gutter($padding-right-full...);
       grid-column: 1 / 3;
       grid-row: 2;
     }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-7283: Mobile Evergreen Page Padding](https://issues.ama-assn.org/browse/EWL-7283)

## Description
Changes padding on 2 column layout for event and evergreen pages to be removed on md and small sizes so that the padding is uniform.

## To Test
- [ ] Pull branch EWL-7283-Mobile-Evergreen-Page-Padding
- [ ] run gulp serve
- [ ] Go to http://localhost:3000/?p=pages-event
- [ ] Verify the horizontal spacing is even on medium and small sizes

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
**Before**
<img width="436" alt="Screen Shot 2019-06-13 at 3 58 25 PM" src="https://user-images.githubusercontent.com/43501792/59466960-268fb680-8df4-11e9-9428-92ecf6b0d346.png">



**After**
<img width="452" alt="Screen Shot 2019-06-13 at 3 57 04 PM" src="https://user-images.githubusercontent.com/43501792/59466903-ff38e980-8df3-11e9-8972-668ba002bece.png">



## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
