### PR TITLE
EWL-7287: IE | Footer on Gated pages without right rail content hiding login

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_gate.scss
+++ b/styleguide/source/assets/scss/01-atoms/_gate.scss
@@ -2,6 +2,7 @@
   background:rgba(0,0,0,0.6);
   min-height: 235px;
   padding-top: 30px;
+  position: absolute;
   width: 100%;
   z-index:1;
 

--- a/styleguide/source/assets/scss/01-atoms/_gate.scss
+++ b/styleguide/source/assets/scss/01-atoms/_gate.scss
@@ -2,7 +2,6 @@
   background:rgba(0,0,0,0.6);
   min-height: 235px;
   padding-top: 30px;
-  position: absolute;
   width: 100%;
   z-index:1;
 

--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -6,6 +6,10 @@
   padding: 0;
   overflow: hidden;
 
+  .layout__region--main {
+    min-height: 500px;
+  }
+
   &__content-top {
     grid-column: 1 / 5;
     grid-row: 1;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Jira Ticket**
- [EWL-7287: IE | Footer on Gated pages without right rail content hiding login](https://issues.ama-assn.org/browse/EWL-7287)

## Description
- Removes `position:absolute` from `_gate.scss` file so IE browsers can display block for login or sign up to access gated content. 

## To Test
- [ ] Enable local styleguide
- [ ] Using an IE browser (or browserstack), navigate to the following pages:
- http://ama-one.local/about/leadership/ama-emergency-response-app
- http://ama-one.local/member-groups-sections/senior-physicians/senior-physicians-section-sps-governing-council-election
- http://ama-one.local/residents-students/usmle/how-apply-kaplan-ama-member-discount
- http://ama-one.local/ama-member-benefits/member-benefits-plus/headspace-ama-members
- [ ] Observe that you can see`ama__gate` div w/o a **Gated Teaser**


I believe content team added **Gated Teaser** field values to pages on production so it can display the `ama__gate` block - as a quick fix. If the page doesn't have a **Gated Teaser** field value, then the `ama__gate` div will be hidden. If there is a value in the Gated Teaser text area field, it will appear above the `ama__gate` div. This PR will help ensure `ama_gate` is visible w/o a **Gated Teaser** text value saved.

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/649/html_report/index.html).

## Relevant Screenshots/GIFs
See ticket for example of screenshot.

## Remaining Tasks
N/A

## Additional Notes
N/A


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
