### PR TITLE
EWL-7353: Embedded Video Spacing on EP

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -35,3 +35,15 @@ figure.embed-entity--caption {
     caption-side: bottom;
   }
 }
+
+figure.embedded-entity.align-left {
+  margin-top: $gutter / 2;
+  margin-right: $gutter / 2;
+  margin-bottom: $gutter / 2;
+}
+
+figure.embedded-entity.align-right {
+  margin-top: $gutter / 2;
+  margin-left: $gutter / 2;
+  margin-bottom: $gutter / 2;
+}

--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -37,13 +37,11 @@ figure.embed-entity--caption {
 }
 
 figure.embedded-entity.align-left {
-  margin-top: $gutter / 2;
   margin-right: $gutter / 2;
   margin-bottom: $gutter / 2;
 }
 
 figure.embedded-entity.align-right {
-  margin-top: $gutter / 2;
   margin-left: $gutter / 2;
   margin-bottom: $gutter / 2;
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [EWL-7353: Embedded Video Spacing on EP](https://issues.ama-assn.org/browse/EWL-7353)

## Description
- Adds margin for embedded entities, left and right aligned (for HTML elements using `figure`). Content is embed using `entity_embed` module.

## To Test
- [ ] Enable styleguide
- [ ] Navigate http://ama-one.local/about/foundation/lorem-ipsum-title
- [ ] Observe image has appropriate  14px wrapping sides of the image, depending on alignment. 
- [ ] Applies to left and right aligned images
- [ ] Edit the evergreen page and change align of image to left or right
- [ ] Observe image has appropriate margins

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/651/html_report/index.html).


## Relevant Screenshots/GIFs
See ticket: https://issues.ama-assn.org/browse/EWL-7353


## Remaining Tasks
N/A


## Additional Notes
N/A

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
