### PR TITLE
EWL-7358: Fixes to Evergreen Hero Organism

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
+++ b/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
@@ -32,6 +32,7 @@
     flex-direction: column;
     justify-content: flex-end;
     background-size: cover;
+    min-height: 366px;
 
     .hero-evergreen__buttons {
       @include gutter($padding-top-half...);
@@ -69,7 +70,7 @@
         align-items: unset;
       }
 
-      @include breakpoint($bp-med min-width) {
+      @include breakpoint($bp-small min-width) {
         flex-flow: row nowrap;
         align-self: unset;
         align-items: center;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7358: Fixes to Evergreen Hero Organism](https://issues.ama-assn.org/browse/EWL-7358)

## Description
- Gives the background container a min height
- For tablet, has the two buttons stack or be side by side (whichever is specified), like desktop


## To Test
- [ ] Pull branch bugfix/EWL-7358-Fixes-Evergreen-Hero
- [ ] run gulp serve
- [ ] Go to http://localhost:3000/?p=molecules-hero-evergreen-as-double-button
- [ ] Verify the button does not stack on tablet size
- [ ] Verify there is a minimum height of 366px on the background container on tablet and desktop (this height makes an approximate aspect ratio of 2:3 when the hero is placed within a tabbed section on the d8 site)
- [ ] Go to http://localhost:3000/?p=molecules-hero-evergreen-as-stacked-button
- [ ] Verify the buttons are stacked on tablet size
- [ ] Verify there is a minimum height of 366px on the background container on tablet and desktop


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
**Before**
![Screen Shot 2019-06-19 at 3 35 38 PM](https://user-images.githubusercontent.com/43501792/59798568-0d7d7e80-92a8-11e9-982f-577ce4a0ed39.png)
![Screen Shot 2019-06-19 at 3 36 10 PM](https://user-images.githubusercontent.com/43501792/59798582-1706e680-92a8-11e9-9dd0-b4133734e228.png)


**After**
![Screen Shot 2019-06-19 at 3 35 56 PM](https://user-images.githubusercontent.com/43501792/59798591-1bcb9a80-92a8-11e9-9d29-91586998ba38.png)
![Screen Shot 2019-06-19 at 3 36 19 PM](https://user-images.githubusercontent.com/43501792/59798607-2423d580-92a8-11e9-9263-066437ca9e58.png)



## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
