### PR TITLE
EWL-7287: Footer on Gated Pages and email subscribe in footer region

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_gate.scss
+++ b/styleguide/source/assets/scss/01-atoms/_gate.scss
@@ -2,7 +2,7 @@
   background:rgba(0,0,0,0.6);
   min-height: 235px;
   padding-top: 30px;
-  position: absolute;
+  margin-bottom: 60px;
   width: 100%;
   z-index:1;
 

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -73,7 +73,14 @@
 
       .ama__form-group input {
         @include gutter($margin-bottom-full...);
+        max-width: 100%;
         height: 49px;
+        @include breakpoint($bp-small min-width) {
+          max-width: 275px;
+        }
+        @include breakpoint($bp-med min-width) {
+          max-width: 220px;
+        }
       }
 
       @include breakpoint($bp-small min-width) {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [EWL-7287: IE | Footer on Gated pages without right rail content hiding login](https://issues.ama-assn.org/browse/EWL-7287)

## Description
- Fixes bug found by Gwen during qa of #649 
- AMA gated block for gated pages was flush with the footer. 
- Removes `position:absolute` as it was causing the block to be flush with footer
- Adds bottom margin to ama gate block to give it some additional whitespace 
- Sets max-width for small and medium display to fix IE bug

### Todo:
- [x] Fixes email subscribe button in the footer

## To Test
- [ ] Enable local styleguide
- [ ] Clear Drupal cache and navigate to (as a logged out user): http://ama-one.local/member-groups-sections/senior-physicians/senior-physicians-section-sps-governing-council-election
- [ ] Observe ama gate block is not flush with the purple global footer. See below: 
<img width="1062" alt="Screen Shot 2019-06-20 at 2 32 03 PM" src="https://user-images.githubusercontent.com/541745/59872638-336a5800-9368-11e9-95b5-1c01cb0550ec.png">

- [ ] Observe email subscribe in the footer is not overflowing and causing the left <-> right scrollbars to appear on IE 


Test in the following browsers: 
- [ ] IE 11
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Visual Regressions


A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/653/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.


## Remaining Tasks
N/a

## Additional Notes
N/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
