### PR TITLE
EWL-7083: People listing word break fix

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_people-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_people-listing.scss
@@ -50,7 +50,6 @@
   &__details {
     @include gutter-all($padding-all-half...);
     border-top: 1px solid $gray-50;
-    word-break: break-all;
 
     .ama__link--icon {
       @extend .ama__type--small;

--- a/styleguide/source/assets/scss/02-molecules/_people-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_people-listing.scss
@@ -50,6 +50,7 @@
   &__details {
     @include gutter-all($padding-all-half...);
     border-top: 1px solid $gray-50;
+    word-break: break-word;
 
     .ama__link--icon {
       @extend .ama__type--small;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [EWL-7083: People listing word break fix](https://issues.ama-assn.org/browse/EWL-7083)

## Description
- Fixes word-break for people listing page
- Removes `word-break` on detail section of people bio on listing page.


## To Test
- [ ] Enable local styleguide
- [ ] Clear Drupal cache and navigate to: http://ama-one.local/member-groups-sections/integrated-physician-practices/integrated-physician-practice-section-ipps
- [ ] Ensure word break for each bio is not looking like production: https://www.ama-assn.org/member-groups-sections/integrated-physician-practices/integrated-physician-practice-section-ipps  (Words being chopped of without any hyphens)

## Visual Regressions

N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
