### PR TITLE
EWL-6877: Issue form 70: Event template in mobile starts duplicating time and headers

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -48,46 +48,51 @@ table.bt tbody tr:last-child {
   border-bottom: 1px solid $gray-50;
 }
 
-table.bt tbody td {
-  border: 0 solid $gray-20;
-  display: block;
-  vertical-align: top;
+table.bt {
+  &:not(.ama__table-agenda) {
+    tbody td {
+      &:before {
+        content: attr(data-th) ":";
+        font-weight: 900;
+        text-transform: uppercase;
+        display: inline-block;
 
-  &:before {
-    content: attr(data-th) ":";
-    font-weight: 900;
-    text-transform: uppercase;
-    display: inline-block;
-
+      }
+    }
   }
-
-
-  &:first-child + &:first-child {
-    border-top: 1px solid $gray-50;
-  }
-
-  &:last-child {
-    @include gutter($padding-bottom-half...);
-    border-bottom: 1px solid $gray-50;
-
-  }
-
-  &:first-of-type:before,
-  &:first-of-type .bt-content {
-  }
-
-  &:last-of-type:before,
-  &:last-of-type .bt-content {
-  }
-
-  .bt-content {
-    vertical-align: top;
+  tbody td {
+    border: 0 solid $gray-20;
     display: block;
-    hyphens: auto;
-  }
+    vertical-align: top;
 
-  .bt-hide {
-    display: none;
+
+    &:first-child + &:first-child {
+      border-top: 1px solid $gray-50;
+    }
+
+    &:last-child {
+      @include gutter($padding-bottom-half...);
+      border-bottom: 1px solid $gray-50;
+
+    }
+
+    &:first-of-type:before,
+    &:first-of-type .bt-content {
+    }
+
+    &:last-of-type:before,
+    &:last-of-type .bt-content {
+    }
+
+    .bt-content {
+      vertical-align: top;
+      display: block;
+      hyphens: auto;
+    }
+
+    .bt-hide {
+      display: none;
+    }
   }
 }
 

--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -76,14 +76,6 @@ table.bt {
 
     }
 
-    &:first-of-type:before,
-    &:first-of-type .bt-content {
-    }
-
-    &:last-of-type:before,
-    &:last-of-type .bt-content {
-    }
-
     .bt-content {
       vertical-align: top;
       display: block;


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-6877: Issue form 70: Event template in mobile starts duplicating time and headers](https://issues.ama-assn.org/browse/EWL-6877)

## Description
Excludes the event agenda tables from the rule setting the data-th as the :before element on \<td>


## To Test
- [ ] Pull branch bugfix/EWL-6877-Event-mobile-duplicate-time-headers
- [ ] Run `gulp serve`
- [ ] Pull develop branch on local D8
- [ ] Switch D8 /provisioning/vars/local.yml file to use local SG2 styleguide
- [ ] Run scripts/build
- [ ] Run drush @one.local cr
- [ ] In D8, Create event detail page
- [ ]  Add Agenda Tab
- [ ] Add Agenda
- [ ] Add agenda days and agenda entries
- [ ] Verify there is no :before content and the repeated headers are no longer visible on mobile and tablet sizes

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/655/html_report/index.html).

## Relevant Screenshots/GIFs
**Before**
<img width="436" alt="Screen Shot 2019-06-25 at 11 56 01 AM" src="https://user-images.githubusercontent.com/43501792/60117748-5453f400-9740-11e9-9d3d-946b9dcdf069.png">


**After**
<img width="458" alt="Screen Shot 2019-06-25 at 11 56 14 AM" src="https://user-images.githubusercontent.com/43501792/60117752-574ee480-9740-11e9-9f46-c6159228e746.png">


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
