### PR TITLE
EWL-7161: View All Subcategories link display

### DIFF
--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -45,7 +45,7 @@
           }
 
           showHideMoreLink();
-          $(window).resize(checkWidth);
+          $(window).resize(showHideMoreLink);
       });
 
 

--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -16,11 +16,38 @@
       var $subcategoryListExpander = $('.ama__subcategory-exploration__show-more');
       var $subcategoryListContainerHeight = $subcategoryListContainer.outerHeight() + 3;
       var $subcategoryListLinkText = $('.ama__subcategory-exploration__text');
+      var $initialWindowWidth = $(window).width();
 
-      // If the unordered list outerHeight is greater than the parent container then show the show more link
-      if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
-        $subcategoryListExpander.show();
-      }
+      // Determine when to show link based on window size.
+      $(document).ready(function () {
+          function showHideMoreLink () {
+              // Set intial window width to 1024 pixel.
+              // @todo: Check if this is an issue to set 1024 width limit.
+	          if ($initialWindowWidth <= 1024) {
+		          // If the unordered list outerHeight is greater than the parent container then show the show more link,
+		          // hide otherwise.
+		          if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
+			          $subcategoryListExpander.show();
+		          }
+		          if ($subcategoryList.outerHeight() < $subcategoryListContainerHeight) {
+			          $subcategoryListExpander.hide();
+		          }
+	          }
+              if ($initialWindowWidth !== $(window).width()) {
+                  // If the unordered list outerHeight is greater than the parent container then show the show more link
+                  if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
+                      $subcategoryListExpander.show();
+
+                  } else {
+                      $subcategoryListExpander.hide();
+                  }
+              }
+          }
+
+          showHideMoreLink();
+          $(window).resize(checkWidth);
+      });
+
 
       // Drupal compels me to unbind clicks otherwise double clicks occur
       $subcategoryListExpander.unbind('click').click(function(e){

--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -20,31 +20,31 @@
 
       // Determine when to show link based on window size.
       $(document).ready(function () {
-          function showHideMoreLink () {
-              // Set intial window width to 1024 pixel.
-              // @todo: Check if this is an issue to set 1024 width limit.
-	          if ($initialWindowWidth <= 1024) {
-		          // If the unordered list outerHeight is greater than the parent container then show the show more link,
-		          // hide otherwise.
-		          if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
-			          $subcategoryListExpander.show();
-		          }
-		          if ($subcategoryList.outerHeight() < $subcategoryListContainerHeight) {
-			          $subcategoryListExpander.hide();
-		          }
-	          }
-              if ($initialWindowWidth !== $(window).width()) {
-                  // If the unordered list outerHeight is greater than the parent container then show the show more link
-                  if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
-                      $subcategoryListExpander.show();
-
-                  } else {
-                      $subcategoryListExpander.hide();
-                  }
-              }
+        function showHideMoreLink () {
+          // Set intial window width to 1024 pixel.
+          // @todo: Check if this is an issue to set 1024 width limit.
+          if ($initialWindowWidth <= 1024) {
+            // If the unordered list outerHeight is greater than the parent container then show the show more link,
+            // hide otherwise.
+            if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
+              $subcategoryListExpander.show();
+            }
+            if ($subcategoryList.outerHeight() < $subcategoryListContainerHeight) {
+              $subcategoryListExpander.hide();
+            }
           }
+          if ($initialWindowWidth !== $(window).width()) {
+            // If the unordered list outerHeight is greater than the parent container then show the show more link
+            if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
+              $subcategoryListExpander.show();
 
-          showHideMoreLink();
+            } else {
+              $subcategoryListExpander.hide();
+            }
+          }
+        }
+
+        showHideMoreLink();
           $(window).resize(showHideMoreLink);
       });
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [EWL-7161: View All Subcategories link display](https://issues.ama-assn.org/browse/EWL-7161)

## Description
- Better user experience accessing the 'View all subcategories' / `View fewer subcategories` when resizing a browser window. 
- Example page can be found here: http://ama-one.local/practice-management


## To Test
- [ ] Pull down code and enable local styleguide
- [ ] Navigate to this page: http://ama-one.local/practice-management (or similar page with the category listing)
- [ ] Ensure you can see the view more/fewer links at appropriate times. For example, for the page linked above, as you resize the window you should see "Career Development" disappear, at that moment a "View more subcategories" link should be visible and clickable to show the now hidden "Career Development". 
- [ ] Test on other pages to ensure regression is not introduced.
  - http://ama-one.local/advocacy (this is the only one I could find, LMK if there are others with bugs).

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

N/A

## Remaining Tasks

N/A

## Additional Notes

N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
