### PR TITLE
EWL-7400: TABLET/MOBILE: Hub page profile photos are getting cut off

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -37,7 +37,12 @@
     display: flex;
 
     .ama__image {
+      @include breakpoint($bp-xs) {
+        height: 100%;
+        object-position: top;
+      }
       height: auto;
+      object-position: center;
       width: 100%;
       object-fit: cover;
     }
@@ -93,7 +98,15 @@
 
   &--image-text {
     .ama__hub-card__image {
-      max-height: 180px;
+      @include breakpoint($bp-xs) {
+        max-height: 280px;
+      }
+      @include breakpoint($bp-med) {
+        max-height: 111px;
+      }
+      @include breakpoint($bp-large) {
+        max-height: 180px;
+      }
       overflow: hidden;
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -102,7 +102,7 @@
         max-height: 280px;
       }
       @include breakpoint($bp-med) {
-        max-height: 111px;
+        max-height: 147px;
       }
       @include breakpoint($bp-large) {
         max-height: 180px;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [EWL-7400: TABLET/MOBILE: Hub page profile photos are getting cut off](https://issues.ama-assn.org/browse/EWL-7400)

## Description

- Fixes hub page profile photos from being chopped off (mobile and tablet), see screenshot below: 
<img width="796" alt="Screen Shot 2019-07-19 at 8 40 32 AM" src="https://user-images.githubusercontent.com/541745/61540053-d1eee500-aa0a-11e9-80fa-4a5d61a0e5bf.png">

## To Test
- [x] Enable local styleguide
- [x] Navigate to http://ama-one.local/amaone/ama-member-spotlight
- [x] Test on different viewports (desktop, tablet, mobile, etc). 
- [ ] Check on IE 11 using Browserstack

## Visual Regressions

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/660/html_report/index.html).

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
