### PR TITLE
EWL-7527: Social share icons not appearing on News Article template

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -177,6 +177,9 @@
 .ama__news-article, .ama__resource-page {
   .ama__masthead__content__share {
     display: none;
+    @include breakpoint($bp-small) {
+      display: flex;
+    }
   }
 }
 .ama__masthead__content__share.is-sticky {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-7527: Social share icons not appearing on News Article template](https://issues.ama-assn.org/browse/EWL-7527)

## Description
Adds the social icons back in for the News article on desktop

## To Test
- [x] Pull branch bugfix/EWL-7527-Social-icons-missing
- [x] Run gulp serve
- [x] Enable local SG2 in your local.yml in D8
- [x] Run drush @one.local cr
- [x] Visit http://ama-one.local/
- [x] Verify social icons show on the following content types/taxonomy pages:

Content Types with social icons on mobile:
- [x] Event Detail
- [x] Evergreen Page
- [x] People Bio
- [x] People Listing
- [x] Press Release
- [x] Subcategory
- [x] Category
- [x] Topics

Content Types with social icons on desktop:
- [x] Event Detail
- [x] Evergreen Page
- [x] News Article
- [x] People Bio
- [x] People Listing
- [x] Press Release
- [x] Resources
- [x] Subcategory
- [x] Category
- [x] Topics

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
