### PR TITLE
EWL-7451: Solving Issue with Image Floated on IE11.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -23,6 +23,7 @@
       @include gutter($margin-top-half...);
       @include gutter($margin-bottom-half...);
       float: right;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-7541: Event Detail image not rendering correctly in IE](https://issues.ama-assn.org/browse/EWL-7541)

## Description
Making the parent item of the image if it is floated to use the width to 100%; that will fix the issue on IE, since in IE11 if you have a child element within an element with a floated property, will ignore the width and height. Now it is working on all browsers


## To Test
- [ ] Checkout this branch
- [ ] Pull a db from production
- [ ] Set the variables to work with local assets in the provisioning scripts
- [ ] Run styleguide assets `gulp serve`
- [ ] Clear cache `drush @ama.local cr`
- [ ] Go to the page `house-delegates/interim-meeting/2019-ama-groups-sections-interim-meeting`
- [ ] The image should be displayed correctly on all browsers including IE11

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![Chrome Event](https://user-images.githubusercontent.com/5325044/63967678-8c8af200-ca63-11e9-9224-1cca2d6313d7.png)
![FF event](https://user-images.githubusercontent.com/5325044/63967679-8c8af200-ca63-11e9-85c5-0be6f84cb9fd.png)
![IE 11 Event](https://user-images.githubusercontent.com/5325044/63967680-8c8af200-ca63-11e9-97a0-326defc605c4.png)

## Remaining Tasks
N/A


## Additional Notes
N/A

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
