### PR TITLE
EWL-7504: Create List component in style guide and style

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -55,7 +55,8 @@
       "source/assets/js/bp-calculator.js",
       "source/assets/js/people-listing.js",
       "source/assets/js/resource.js",
-      "source/assets/js/tables.js"
+      "source/assets/js/tables.js",
+      "source/assets/js/listicle.js"
     ],
     "dest"  : "public/assets/js/"
   },

--- a/styleguide/source/_patterns/01-atoms/lists/listicle.json
+++ b/styleguide/source/_patterns/01-atoms/lists/listicle.json
@@ -23,8 +23,8 @@
       ]
     },
     {
-      "text": "This is an item on a list. It is bolded and can be longer than one line long. List with multiple descriptions text",
-      "url": "#",
+      "text": "This is an item on a list. It is bolded and can be longer than one line long. List with multiple descriptions text and link",
+      "link": "#",
       "description": [
         {
           "text": "Text with link. Cras ultricies ligula sed magna dictum porta. Pellentesque in ipsum id orci porta dapibus. Donec rutrum congue leo eget malesuada. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Donec rutrum congue leo eget malesuada."

--- a/styleguide/source/assets/js/listicle.js
+++ b/styleguide/source/assets/js/listicle.js
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Listicle Clases.
+ *
+ * Handling classes to build listicle properly outside ckeditor.
+ */
+(function ($, Drupal) {
+  Drupal.behaviors.listicle = {
+    attach: function(context, settings) {
+      if ($('.listicle', context).length) {
+        $('.listicle').each(function () {
+          $(this).children().each(function (idx, e) {
+            $(e).addClass('listicle__item');
+            $(e).children('ol').each(function (idx, f) {
+              $(f).addClass('listicle__item-sub');
+              $(f).children('li').addClass('listicle__item-sub-item');
+            });
+          });
+        });
+      }
+    }
+  };
+})(jQuery, Drupal);

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -31,7 +31,7 @@
     &-sub {
       list-style: none;
       margin-left: 55px;
-      padding-left: 0;
+      padding-left: 0 !important;
 
       &-item {
         @include gutter($margin-bottom-full...);


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7504: Create List component in style guide and style](https://issues.ama-assn.org/browse/EWL-7504)

## Description
Adding Script to handle styles in the listicle coming from ckeditor and add link to json dummy content to display how the text will be displayed with link.


## To Test
- [ ] Checkout this branch
- [ ] Change your local variables to test this locally with local assets in `provisioning/vars/local.yml`
- [ ] Rebuild assets `scripts/build`
- [ ] Run `gulp serve`
- [ ] Now you can see there is new item in the list that supports link in the title and should be displayed like in the designs
 

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
- Once this PR is merged https://github.com/AmericanMedicalAssociation/ama-d8/pull/1556 should be tested.


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
