### PR TITLE
EWL-7555: Change padding on/around Listicle component in News Article template

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -19,7 +19,7 @@
       color: $white;
       width: 25px;
       height: 25px;
-      top: 0;
+      top: 4px;
       text-align: center;
       font-size: 22px;
       font-weight: 600;

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -8,6 +8,7 @@
 
     counter-increment: ama-listicle;
     position: relative;
+    margin-left: 43px;
     @include gutter($margin-bottom-half...);
     @include gutter($margin-top-half...);
 
@@ -16,9 +17,9 @@
       position: absolute;
       background: $homepagePurple;
       color: $white;
-      width: 21px;
-      height: 19px;
-      top: 5px;
+      width: 25px;
+      height: 25px;
+      top: 0;
       text-align: center;
       font-size: 22px;
       font-weight: 600;
@@ -26,16 +27,16 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      left: -43px
     }
 
     &-sub {
       list-style: none;
-      margin-left: 55px;
       padding-left: 0 !important;
 
       &-item {
-        @include gutter($margin-bottom-full...);
-        @include gutter($margin-top-full...);
+        @include gutter($margin-bottom-half...);
+        @include gutter($margin-top-half...);
       }
     }
   }
@@ -43,7 +44,7 @@
   &__title {
     font-size: 22px;
     font-weight: 600;
-    margin-left: 55px;
+    @include gutter($margin-bottom-full...);
 
     a {
       font-weight: inherit;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-7555: Change padding on/around Listicle component in News Article template](https://issues.ama-assn.org/browse/EWL-7555)

## Description
Modify, paddings, sizes, margins for whole component listicle items according Zeplin Specs

## To Test
- [ ] Checkout this branch
- [ ] Run the local assets to bring up styleguide
- [ ] Open the listicle component `atoms-listicle`
- [ ] Ensure that all padding, margin, sizes matches the Zeplin specs https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5d360bd566bb484104df5e77

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
