### PR TITLE
EWL-7555: Change padding on/around Listicle component in News Article template

### DIFF
--- a/styleguide/source/_patterns/01-atoms/lists/listicle.json
+++ b/styleguide/source/_patterns/01-atoms/lists/listicle.json
@@ -36,6 +36,117 @@
           "text": "Proin eget tortor risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui. Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vivamus suscipit tortor eget felis porttitor volutpat."
         }
       ]
+    },
+    {
+      "text": "This is an item on a list. Its bolded and can be longer than one line long. Lorem Ipsump. Alsip calr rateir",
+      "description": [
+        {
+          "text": "The founding editor-in chied of AMA of JAMA Network Open will be Frederick P. Rivara, MD, MPH, now editor in-chief of JAMA Pediatrics."
+        },
+        {
+          "text": "Our editorial goal es to publish the very best clinical research across all disciplines, serving the workdwide community of investigators and clinicians and meeting the evolving needs and requirements of authors and funders"
+        }
+      ]
+    },
+    {
+      "text": "This is what an item that only has title and no description text"
+    },
+    {
+      "text": "This is an item on a list. It is bolded and can be longer than one line long.",
+      "description": [
+        {
+          "text": "Cras ultricies ligula sed magna dictum porta. Pellentesque in ipsum id orci porta dapibus. Donec rutrum congue leo eget malesuada. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Donec rutrum congue leo eget malesuada."
+        }
+      ]
+    },
+    {
+      "text": "This is an item on a list. It is bolded and can be longer than one line long. List with multiple descriptions text and link",
+      "link": "#",
+      "description": [
+        {
+          "text": "Text with link. Cras ultricies ligula sed magna dictum porta. Pellentesque in ipsum id orci porta dapibus. Donec rutrum congue leo eget malesuada. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Donec rutrum congue leo eget malesuada."
+        },
+        {
+          "text": "Curabitur aliquet quam id dui posuere blandit. Donec rutrum congue leo eget malesuada. Donec sollicitudin molestie malesuada. Cras ultricies ligula sed magna dictum porta. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui."
+        },
+        {
+          "text": "Proin eget tortor risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui. Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vivamus suscipit tortor eget felis porttitor volutpat."
+        }
+      ]
+    },
+    {
+      "text": "This is an item on a list. Its bolded and can be longer than one line long. Lorem Ipsump. Alsip calr rateir",
+      "description": [
+        {
+          "text": "The founding editor-in chied of AMA of JAMA Network Open will be Frederick P. Rivara, MD, MPH, now editor in-chief of JAMA Pediatrics."
+        },
+        {
+          "text": "Our editorial goal es to publish the very best clinical research across all disciplines, serving the workdwide community of investigators and clinicians and meeting the evolving needs and requirements of authors and funders"
+        }
+      ]
+    },
+    {
+      "text": "This is what an item that only has title and no description text"
+    },
+    {
+      "text": "This is an item on a list. It is bolded and can be longer than one line long.",
+      "description": [
+        {
+          "text": "Cras ultricies ligula sed magna dictum porta. Pellentesque in ipsum id orci porta dapibus. Donec rutrum congue leo eget malesuada. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Donec rutrum congue leo eget malesuada."
+        }
+      ]
+    },
+    {
+      "text": "This is an item on a list. It is bolded and can be longer than one line long. List with multiple descriptions text and link",
+      "link": "#",
+      "description": [
+        {
+          "text": "Text with link. Cras ultricies ligula sed magna dictum porta. Pellentesque in ipsum id orci porta dapibus. Donec rutrum congue leo eget malesuada. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Donec rutrum congue leo eget malesuada."
+        },
+        {
+          "text": "Curabitur aliquet quam id dui posuere blandit. Donec rutrum congue leo eget malesuada. Donec sollicitudin molestie malesuada. Cras ultricies ligula sed magna dictum porta. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui."
+        },
+        {
+          "text": "Proin eget tortor risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui. Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vivamus suscipit tortor eget felis porttitor volutpat."
+        }
+      ]
+    },
+    {
+      "text": "This is an item on a list. Its bolded and can be longer than one line long. Lorem Ipsump. Alsip calr rateir",
+      "description": [
+        {
+          "text": "The founding editor-in chied of AMA of JAMA Network Open will be Frederick P. Rivara, MD, MPH, now editor in-chief of JAMA Pediatrics."
+        },
+        {
+          "text": "Our editorial goal es to publish the very best clinical research across all disciplines, serving the workdwide community of investigators and clinicians and meeting the evolving needs and requirements of authors and funders"
+        }
+      ]
+    },
+    {
+      "text": "This is what an item that only has title and no description text"
+    },
+    {
+      "text": "This is an item on a list. It is bolded and can be longer than one line long.",
+      "description": [
+        {
+          "text": "Cras ultricies ligula sed magna dictum porta. Pellentesque in ipsum id orci porta dapibus. Donec rutrum congue leo eget malesuada. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Donec rutrum congue leo eget malesuada."
+        }
+      ]
+    },
+    {
+      "text": "This is an item on a list. It is bolded and can be longer than one line long. List with multiple descriptions text and link",
+      "link": "#",
+      "description": [
+        {
+          "text": "Text with link. Cras ultricies ligula sed magna dictum porta. Pellentesque in ipsum id orci porta dapibus. Donec rutrum congue leo eget malesuada. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Donec rutrum congue leo eget malesuada."
+        },
+        {
+          "text": "Curabitur aliquet quam id dui posuere blandit. Donec rutrum congue leo eget malesuada. Donec sollicitudin molestie malesuada. Cras ultricies ligula sed magna dictum porta. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui."
+        },
+        {
+          "text": "Proin eget tortor risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui. Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vivamus suscipit tortor eget felis porttitor volutpat."
+        }
+      ]
     }
   ]
 }

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -17,8 +17,8 @@
       position: absolute;
       background: $homepagePurple;
       color: $white;
-      width: 28px;
-      height: 28px;
+      width: 30px;
+      height: 30px;
       top: 4px;
       text-align: center;
       font-size: 22px;

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -17,13 +17,12 @@
       position: absolute;
       background: $homepagePurple;
       color: $white;
-      width: 25px;
-      height: 25px;
+      width: 28px;
+      height: 28px;
       top: 4px;
       text-align: center;
       font-size: 22px;
       font-weight: 600;
-      letter-spacing: -1.78px;
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Jira Ticket**
- [EWL-7555: Change padding on/around Listicle component in News Article template](https://issues.ama-assn.org/browse/EWL-7555)

## Description
Changed the spacing on the numbers


## To Test
- [ ] Pull branch padding-issue-listicle
- [ ] Run `gulp serve`
- [ ] Open atoms > lists > listicle in the style guide
- [ ] Verify that the list numbers are evenly spaced within the purple box (especially the numbers > 9)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
