### PR TITLE
EWL-7536 added borderless style for new index page layout

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -56,6 +56,15 @@
     }
   }
 
+  &__row--no-border-with-padding {
+    border: 0;
+    padding: $gutter 0;
+    //remove the double border from the category pages but retain the padding on the list items beneath
+    &:first-of-type + * + .ama__layout--two-col-right--75-25 {
+      border: 0;
+    }
+  }
+
   &__row--hidden-mobile {
     @include breakpoint($bp-small max-width) {
       display: none;


### PR DESCRIPTION


## Ticket(s)
related to D8 PR: https://github.com/AmericanMedicalAssociation/ama-d8/pull/1598

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [Ewl 7536 create new layout #1598
](https://issues.ama-assn.org/browse/EWL-7536)

## Description
Added new style to render the masthead without a border but with proper row padding


## To Test
In the Styleguide repo
- run `git checkout feature/EWL-7536-new-index-layout'
- run `gulp serve` to start the stuleguide

In the AMA-D8 repo
- run `git checkout EWL-7536-create-new-layout'
- set up local.yml to pull locally from the styleguide.
- run `drush @one.local cim -y && drush @one.local cr'
- go to a [term listing page](http://ama-one.local/topics/council-science-public-health)
- Under the share icons of the masthead, you should see a border one single pixel thick, and you should see 28px of padding between the border and the first content item.

## Visual Regressions

N/A 


## Relevant Screenshots/GIFs
<img width="1216" alt="Screen Shot 2019-10-03 at 5 18 25 PM" src="https://user-images.githubusercontent.com/10862145/66168127-f28a0c80-e601-11e9-9699-48a48002dceb.png">



## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
