### PR TITLE
EWL-6893 removed rule overriding backgrounds size rules.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -7,7 +7,9 @@
   flex-direction: column;
   text-align: center;
   background-color: $gray-7;
-  background-size: contain;
+  background-size: cover;
+  background-repeat: no-repeat;
+  min-height: 350px;
 
   @include breakpoint($bp-small) {
     background-position: center;

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -103,7 +103,6 @@
     flex-direction: column;
     justify-content: center;
     background-color: $gray-7;
-    min-height: 0;
   }
 
   &--side-right {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -100,7 +100,7 @@
   &--cta-only {
     flex-direction: column;
     justify-content: center;
-    background: $gray-7;
+    background-color: $gray-7;
     min-height: 0;
   }
 


### PR DESCRIPTION
**Github Issue**
- [Issue XXX: Issue Title](https://issues.ama-assn.org/browse/EWL-6893)

**Jira Ticket**
- [Issue form 3: Hub page: hero image not appearing in correct dimensions](https://issues.ama-assn.org/browse/EWL-XXXX)

## Description
css rule modified so that it won't override background image properties.

## To Test
- set up d8 for local styleguide development
- in styleguide repo, pull branch and run gulp serve.
- in vagrant machine, run `drush @one.local cr`
- go to http://ama-one.local/amaone/physicians-membership
- if you can see two people in the page hero, the style applied correctly.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
<img width="1249" alt="Screen Shot 2019-10-07 at 7 46 48 PM" src="https://user-images.githubusercontent.com/10862145/66359095-4d41a200-e93b-11e9-8b11-f819990581fc.png">


## Remaining Tasks
N/A

## Additional Notes
This improves the current display, but does not fully address the issue in the ticket. A further team discussion is necessary. 

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
