### PR TITLE
EWL-6852 changed styles to display full image at all breakpoints

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -8,7 +8,7 @@
   text-decoration: none;
   min-height: 400px;
   width: 100%;
-  
+
   &__heading,
   & .ama__h2 {
     @include gutter($margin-top-full...);
@@ -99,13 +99,19 @@
   &--image-text {
     .ama__hub-card__image {
       @include breakpoint($bp-xs) {
-        max-height: 280px;
+        max-height: 400px;
+      }
+      @include breakpoint($bp-small) {
+        max-height: 240px;
       }
       @include breakpoint($bp-med) {
-        max-height: 147px;
+        max-height: 300px;
       }
       @include breakpoint($bp-large) {
-        max-height: 180px;
+        max-height: 370px;
+      }
+      @include breakpoint($bp-xl) {
+        max-height: 370px;
       }
       overflow: hidden;
     }


### PR DESCRIPTION
**Github Issue**
N/A

**Jira Ticket**
- [Issue form 49: Hub Template: Just noticed yesterday: some small card images are too rectangular](https://issues.ama-assn.org/browse/EWL-6852)

## Description
At all breakpoints, a max-height of under 300px was set with overflow hidden. Breakpoints are updated to show the full image


## To Test
- in the AMA-D8 repo, edit `provisioning/vars/local.yml` lines 84 and 86 to enable local styleguide development
- run `scripts/build` to set your local styleguide path
- in the styleguide repo check out this branch.
- in `/styleguide` run `gulp serve`
- go to a [hub page](http://ama-one.local/amaone/ama-ambassador-program) and check that the card images are not being cut off. See attached screenshots for reference

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
Card images should look like this:
![Screen Shot 2019-10-15 at 5 16 36 PM](https://user-images.githubusercontent.com/10862145/66874069-b9418d00-ef6f-11e9-99ad-ffe043a1676d.png)

As opposed to this:
![Screen Shot 2019-10-15 at 5 16 53 PM](https://user-images.githubusercontent.com/10862145/66874084-c5c5e580-ef6f-11e9-8e9f-b12242217d08.png)



## Remaining Tasks
N/A


## Additional Notes
This ticket should fix this particular issue, but I would recommend doing a full rewrite of this card style in the future, as it is not set up in a very straightforward or dependable way. For instance, overflow: hidden should not be used.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
