### PR TITLE
EWL-6782: Adding Correct Rule to Properly Display Blockquote before to the left

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_block-quote.scss
+++ b/styleguide/source/assets/scss/01-atoms/_block-quote.scss
@@ -7,6 +7,7 @@ blockquote,
   &:before {
     content: '';
     height: 100%;
+    left: 0;
     background-color: $purple;
     position: absolute;
     width: 5px;

--- a/styleguide/source/assets/scss/01-atoms/_block-quote.scss
+++ b/styleguide/source/assets/scss/01-atoms/_block-quote.scss
@@ -1,7 +1,6 @@
 blockquote,
 .blockquote {
   position: relative;
-  margin-left: 9.2%;
   @include gutter($margin-bottom-half...);
   @include gutter($margin-top-half...);
   &:before {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-6782: Formatting blockquotes](https://issues.ama-assn.org/browse/EWL-6782)

## Description
Adding rule to display properly blockquote `before` to the left

## To Test
* Add a Blockquote throught the ckeditor
* Ensure it is displaying correctly on the ckeditor and when save content it is displaying correctly according the Zeplin designs.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
This PR depends as well of the [PR 1653](https://github.com/AmericanMedicalAssociation/ama-d8/pull/1653)


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
