### PR TITLE
Ewl 7172 add second cta button to all cards in hub template

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card-row.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card-row.scss
@@ -3,4 +3,53 @@
   display: flex;
   flex-wrap: wrap;
   width: 100%;
+  &.twoCards {
+    .ama__hub-card {
+      &__button-container {
+        &.text-only {
+          width: 100%;
+        }
+      }
+    }
+  }
+  &.manyCards {
+    .ama__hub-card {
+      &:nth-child(3):nth-last-child(1) {
+        @include breakpoint($bp-small $bp-med) {
+          .ama__hub-card__button-container {
+            &.ama__hub-card__button-flex.text-only {
+              &.text-only {
+                flex-direction: row;
+                display: flex;
+                a {
+                  width: 48%;
+                  margin-bottom: 0;
+                }
+                a:nth-child(2) {
+                  margin: 0 0 0 16px;
+                }
+              }
+            }
+          }
+        }
+      }
+      &__button-flex {
+        padding: 0;
+        flex-direction: column;
+      &.text-only {
+          width: 100%;
+          a {
+            width: 100%;
+            margin-bottom: 15px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+          }
+          a:nth-child(2) {
+            margin: 0;
+          }
+        }
+      }
+    }
+  }
 }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -8,7 +8,7 @@
   text-decoration: none;
   min-height: 400px;
   width: 100%;
-  
+
   &__heading,
   & .ama__h2 {
     @include gutter($margin-top-full...);
@@ -36,6 +36,40 @@
 
     a:nth-child(2) {
       margin-left: 16px;
+    }
+    &.text-only {
+      @include breakpoint($bp-xs) {
+        width: 100%;
+      }
+      @include breakpoint($bp-med) {
+        width: 50%;
+      }
+      margin-right: auto;
+      margin-left: auto;
+    }
+  }
+
+  &__button-flex {
+    @include breakpoint($bp-xs) {
+      flex-direction: column;
+      a {
+        width: 100%;
+        margin-bottom: 15px;
+      }
+      a:nth-child(2) {
+        margin: 0;
+      }
+    }
+    @include breakpoint($bp-med) {
+      display: flex;
+      flex-direction: row;
+      a {
+        width: 49%;
+        margin-bottom: 0;
+      }
+      a:nth-child(2) {
+        margin: 0 0 0 16px;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -28,6 +28,9 @@
 
     .ama__button--secondary {
       @extend %ama__button--secondary;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
 
     a {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -26,8 +26,16 @@
     @include gutter-all($padding-all-full...);
     text-align: center;
 
+    .ama__button--secondary {
+      @extend %ama__button--secondary;
+    }
+
     a {
       @extend %ama__button;
+    }
+
+    a:nth-child(2) {
+      margin-left: 16px;
     }
   }
 

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -55,6 +55,9 @@
       a {
         width: 100%;
         margin-bottom: 15px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
       a:nth-child(2) {
         margin: 0;


### PR DESCRIPTION
## Ticket(s)
https://issues.ama-assn.org/browse/EWL-7172

**Github Issue**
N/A

**Jira Ticket**
- [Add second CTA button to all cards in Hub template](https://issues.ama-assn.org/browse/EWL-7172)

## Description
Added classes for a secondary button style, and responsive behavior.


## To Test
- requires PR from D8 repo to test. Instructions can be found there : https://github.com/AmericanMedicalAssociation/ama-d8/pull/1638

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
