### PR TITLE
EWL-7596: Bullets display incorrectly when positioned next to a promo box

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -20,3 +20,22 @@ article ul,
     list-style: none;
   }
 }
+article {
+    .text-body {
+        ul li {
+            display: flex;
+            margin: 0;
+
+            &:before {
+                 display: inline-block;
+                 content: "•";
+                 width: 8px;
+                 margin-right: 15px;
+                 font-size: 31px;
+                 line-height: 18px;
+                 align-self: baseline;
+                 margin-top: 3px;
+             }
+        }
+    }
+}

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -7,7 +7,6 @@ article ul,
     @include gutter($margin-left-full...);
     padding: 0;
     list-style: disc;
-    list-style-position: inside;
 
     ul {
       @include gutter($margin-left-full...);

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -2,12 +2,12 @@ section ul,
 article ul,
 .ama__list {
   @include gutter($margin-bottom-half...);
-  display: table;
 
   li {
     @include gutter($margin-left-full...);
     padding: 0;
     list-style: disc;
+    list-style-position: inside;
 
     ul {
       @include gutter($margin-left-full...);
@@ -20,4 +20,3 @@ article ul,
     list-style: none;
   }
 }
-

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -2,6 +2,7 @@ section ul,
 article ul,
 .ama__list {
   @include gutter($margin-bottom-half...);
+  display: table;
 
   li {
     @include gutter($margin-left-full...);

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -1,6 +1,6 @@
 .ama__main-navigation {
   border-bottom: 1px solid $gray-50;
-  background-color: red;
+  background-color: $purple;
   color: $white;
   position: relative;
   z-index: 501;

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -1,6 +1,6 @@
 .ama__main-navigation {
   border-bottom: 1px solid $gray-50;
-  background-color: $purple;
+  background-color: red;
   color: $white;
   position: relative;
   z-index: 501;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [EWL-7596: Bullets display incorrectly when positioned next to a promo box](https://issues.ama-assn.org/browse/EWL-7596)

## Description
- Makes `ul` elements consistent using `display:table`property. 
- Fixes `ul` position when next to inline promo, reported in EWL-7596 (http://ama-one.local/practice-management/sustainability/emergency-departments-save-25000-lives-55-million-here-s-how)

## To Test
- [ ] Enable local styleguide development mode
- [ ] See the UL elements listed on this page: http://localhost:3000/?p=pages-news. Verify `ul` positioning or listing is not affected.
- Test the following browsers using this page: http://ama-one.local/practice-management/sustainability/emergency-departments-save-25000-lives-55-million-here-s-how 
  - [ ] Test `ul` elements using IE 11 
  - [ ] Test `ul` elements using Safari
  - [ ] Test `ul` elements using FF
  - [ ] Test `ul` elements using Chrome 

## Visual Regressions



A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/697/html_report/index.html).


## Relevant Screenshots/GIFs
### Before
![Screen Shot 2019-11-05 at 11 39 31 AM](https://user-images.githubusercontent.com/541745/68227813-55d0db00-ffc2-11e9-9b99-1ecae848c8d1.png)

### After
![Screen Shot 2019-11-05 at 11 42 05 AM](https://user-images.githubusercontent.com/541745/68227815-55d0db00-ffc2-11e9-8dc9-96a2e8545909.png)



---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
