### PR TITLE
EWL-6782 added default padding beneath our lowest breakpoint

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_block-quote.scss
+++ b/styleguide/source/assets/scss/01-atoms/_block-quote.scss
@@ -19,7 +19,8 @@ blockquote {
     text-align: left;
   }
   ol {
-    margin-left: 20px;
+    list-style-position: inside;
+    margin-left: 0px;
     @include breakpoint($bp-xs) {
       margin-left: 4px;
     }

--- a/styleguide/source/assets/scss/01-atoms/_block-quote.scss
+++ b/styleguide/source/assets/scss/01-atoms/_block-quote.scss
@@ -1,8 +1,6 @@
 blockquote {
   position: relative;
-  @include breakpoint($bp-xs) {
-    padding-left: 30px;
-  }
+  padding-left: 30px;
   @include breakpoint($bp-med) {
     padding-left: 13px;
   }


### PR DESCRIPTION

## Ticket(s)


**Github Issue**

**Jira Ticket**
- [EWL-XXXX: Ticket Title](https://issues.ama-assn.org/browse/EWL-XXXX)

## Description
Added default left padding to blockquotes to display beneath our lowest breakpoint, 400px


## To Test
- [ ] pull branch
- [ ] enable local styleguide development
- [ ] make a node with a blockquote
- [ ] verify that it displays correctly on mobile

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
