### PR TITLE
EWL-7532: Adding same space for ordered lists in the styleguide.

### DIFF
--- a/styleguide/source/_patterns/01-atoms/lists/ordered-list.json
+++ b/styleguide/source/_patterns/01-atoms/lists/ordered-list.json
@@ -1,0 +1,16 @@
+{
+  "ordered_list": [
+    {
+      "text": "Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a."
+    },
+    {
+      "text": "Praesent sapien massa, convallis a pellentesque nec, egestas non nisi."
+    },
+    {
+      "text": "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae"
+    },
+    {
+      "text": "Donec sollicitudin molestie malesuada. Proin eget tortor risus."
+    }
+  ]
+}

--- a/styleguide/source/_patterns/01-atoms/lists/ordered-list.twig
+++ b/styleguide/source/_patterns/01-atoms/lists/ordered-list.twig
@@ -1,0 +1,7 @@
+<section>
+  <ol>
+    {% for list in ordered_list %}
+    <li> {{list.text }}</li>
+    {% endfor %}
+  </ol>
+</section>

--- a/styleguide/source/assets/scss/01-atoms/_ordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_ordered-list.scss
@@ -1,0 +1,4 @@
+section ol, 
+article ol {
+  @include gutter($margin-bottom-half...);
+}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-7532: Spacing beneath ordered list element and H2 needs to be increased](https://issues.ama-assn.org/browse/EWL-7532)

## Description
Adding same spacing on ordered lists than in the unordered lists to match the margin bottom.


## To Test
- [ ] Compile the styles `gulp serve`
- [ ] Clear the cache `drush @one.local cr`
- [ ] Create any content of any type and add an unodered list and an ordered list and add an h2 once the list for each one ends in the body field
- [ ] Look that the margin bottom for each one of the lists matches


## Visual Regressions
N/A

## Relevant Screenshots/GIFs

![Selection_013](https://user-images.githubusercontent.com/5325044/68325566-4c617480-008f-11ea-980c-fd06048d05b7.png)


## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
