### PR TITLE
EWL-7594: Adding Styles for Inline Images Alignment.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -46,3 +46,20 @@ figure.embedded-entity.align-right {
   margin-left: $gutter / 2;
   margin-bottom: $gutter / 2;
 }
+
+// Inline Images using ckeditor.
+
+.embedded-entity {
+
+  &.align-right {
+    
+    @include gutter($margin-left-half...);
+    float: right;
+    width: auto;;
+  }
+
+  &.align-center {
+    text-align: center;
+  }
+  
+}


### PR DESCRIPTION
## Ticket(s)
**Jira Ticket**
- [EWL-7594: Text not wrapping around images in News Article template](https://issues.ama-assn.org/browse/EWL-7594)

## Description
Adding Styles to align inline images in ckeditor


## To Test
- Same as https://github.com/AmericanMedicalAssociation/ama-d8/pull/1678

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
This PR is related and depends of https://github.com/AmericanMedicalAssociation/ama-d8/pull/1678
