### PR TITLE
EWL-7569 added more bottom margin between list elements. Normalized h…

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -9,7 +9,7 @@
     counter-increment: ama-listicle;
     position: relative;
     margin-left: 43px;
-    @include gutter($margin-bottom-half...);
+    margin-bottom: 19px;
     @include gutter($margin-top-half...);
 
     &::before {
@@ -19,7 +19,7 @@
       color: $white;
       width: 30px;
       height: 30px;
-      top: 4px;
+      top: 0;
       text-align: center;
       font-size: 22px;
       font-weight: 600;


### PR DESCRIPTION
## Ticket(s)
https://issues.ama-assn.org/browse/EWL-7569

**Jira Ticket**
- [Fix padding around list numbering in List Object component](https://issues.ama-assn.org/browse/EWL-7569)

## Description
cleaned up list number padding and padding around items.


## To Test
- [ ] Setup ama-one for local styleguide development
- [ ] pull this branch and run gulp serve
- [ ] Go to a page, [vaping crisis](http://ama-one.local/delivering-care/public-health/e-cigarettes-and-vaping-public-health-epidemic) with a list on it, and observe the spacing. Compare this to the zeppelin files attached to the ticket.
- [ ] Observe the vertical positioning of the numbers
the distance between the numbers if there is only a headline and no text
the distance between the bottom of the previous list item and the top of the next
etc

## Visual Regressions

## Relevant Screenshots/GIFs
NA
## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
