### PR TITLE
Feature/ewl 7570 add images to listicle

### DIFF
--- a/styleguide/source/assets/js/listicle.js
+++ b/styleguide/source/assets/js/listicle.js
@@ -18,16 +18,25 @@
           });
         });
       }
+      //if there is an inline promo on a page with a listicle, determine if the list is close enough beneath the promo in the dom to assume it will be floated next to it. I chose within 5 siblings.
       if($('.ama__promo--inline ~ .listicle')) {
         var length = $('.ama__promo--inline').first().nextUntil('.listicle').addBack().length;
         if (length <= 5) {
           $('.ama__promo--inline').addClass('listicle-margin');
         }
       }
-      if($('.listicle__item > img')) {
-        $('.listicle__item > img').each(function() {
-
-          $(this).parent().css("background-color", "red")
+      //if the listicle item contains an image, put a clearfix div on the item so if it has a trailing image, the next item won't wrap on it.
+      //Also, determine it the image is almost 100% of the list width. if it is, add a class to remove the left margin and make the image 100% width. I chose 80%.
+      if($('.listicle__item img')) {
+        $('.listicle img').each(function () {
+          var fixedThis = this
+          var width = $('.listicle').width()
+          var imageWidth = $(this).width()
+          var clearfix = '<div class="clearfix"></div>'
+          $(this).closest('.listicle__item').once().append(clearfix)
+          if (imageWidth >= width*.8) {
+            $(this).addClass('no-margin')
+          }
         })
       }
     }

--- a/styleguide/source/assets/js/listicle.js
+++ b/styleguide/source/assets/js/listicle.js
@@ -28,14 +28,16 @@
       //if the listicle item contains an image, put a clearfix div on the item so if it has a trailing image, the next item won't wrap on it.
       //Also, determine it the image is almost 100% of the list width. if it is, add a class to remove the left margin and make the image 100% width. I chose 80%.
       if($('.listicle__item img')) {
-        $('.listicle img').each(function () {
-          var fixedThis = this
-          var width = $('.listicle').width()
+        $('.listicle__item img').each(function () {
+          var width = $(this).closest('.listicle__item').width()
+          console.log(width)
           var imageWidth = $(this).width()
+          console.log(imageWidth)
           var clearfix = '<div class="clearfix"></div>'
           $(this).closest('.listicle__item').once().append(clearfix)
-          if (imageWidth >= width*.8) {
+          if (imageWidth >= width*.7) {
             $(this).addClass('no-margin')
+            $(this).closest ('figure').addClass('no-margin')
           }
         })
       }

--- a/styleguide/source/assets/js/listicle.js
+++ b/styleguide/source/assets/js/listicle.js
@@ -24,6 +24,12 @@
           $('.ama__promo--inline').addClass('listicle-margin');
         }
       }
+      if($('.listicle__item > img')) {
+        $('.listicle__item > img').each(function() {
+
+          $(this).parent().css("background-color", "red")
+        })
+      }
     }
   };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -9,7 +9,7 @@
     counter-increment: ama-listicle;
     position: relative;
     margin-left: 43px;
-    @include gutter($margin-bottom-half...);
+    margin-bottom: 19px;
     @include gutter($margin-top-half...);
 
     &::before {
@@ -19,7 +19,7 @@
       color: $white;
       width: 30px;
       height: 30px;
-      top: 4px;
+      top: 0;
       text-align: center;
       font-size: 22px;
       font-weight: 600;

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -42,16 +42,18 @@
     figure {
       float: right;
       margin-bottom: 19px;
-      @include breakpoint($bp-xs) {
-        width: 100%;
-        margin-left: 0;
-        img {
-          width: 100%;
+      img {
+        &.no-margin {
+          margin-left: 0
         }
-      }
-      @include breakpoint($bp-med) {
-        width: auto;
-        margin-left: 1rem;
+        @include breakpoint($bp-xs) {
+          width: 100%;
+          margin-left: 0;
+        }
+        @include breakpoint($bp-med) {
+          width: auto;
+          margin-left: 1rem;
+        }
       }
     }
   }
@@ -68,5 +70,10 @@
       font-weight: inherit;
       color: inherit;
     }
+  }
+  .clearfix {
+    width: 100%;
+    height: 1px;
+    clear: both;
   }
 }

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -39,6 +39,21 @@
         @include gutter($margin-top-half...);
       }
     }
+    figure {
+      float: right;
+      margin-bottom: 19px;
+      @include breakpoint($bp-xs) {
+        width: 100%;
+        margin-left: 0;
+        img {
+          width: 100%;
+        }
+      }
+      @include breakpoint($bp-med) {
+        width: auto;
+        margin-left: 1rem;
+      }
+    }
   }
 
   &__title,

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -36,13 +36,26 @@
 
       &-item {
         @include gutter($margin-bottom-half...);
-        @include gutter($margin-top-half...);
+        margin-top: 0;
       }
     }
     figure {
       float: right;
       margin-bottom: 19px;
+      figcaption {
+        margin-left: 1rem;
+      }
+      &.no-margin {
+        float: none;
+        display: block;
+        width: 100%;
+        figcaption {
+          margin-left: 0rem;
+          display: block;
+        }
+      }
       img {
+        margin-top: 7px;
         &.no-margin {
           margin-left: 0
         }
@@ -64,6 +77,7 @@
     font-size: 22px;
     font-weight: 600;
     display: inline;
+    width: 100%;
     @include gutter($margin-bottom-full...);
 
     a {


### PR DESCRIPTION
## Ticket(s)
https://issues.ama-assn.org/browse/EWL-7570

**Jira Ticket**
- [Add image display to list component object](https://issues.ama-assn.org/browse/EWL-7570)

## Description
Added formatting for proper image display


## To Test
- [ ] Setup ama-one for local styleguide development
- [ ] pull this branch and run gulp serve
- [ ] Go to a page, [vaping crisis](http://ama-one.local/delivering-care/public-health/e-cigarettes-and-vaping-public-health-epidemic) with a list on it, and observe the spacing. Compare this to the zeppelin files attached to the ticket.
- [ ] Try adding images to different list items. Confirm that if an image protrudes from the bottom of one list item, the next item will break clear of it, rather than wrapping text around it.
- [ ] observe that the image can have a caption that stays confined within the image's left margin.

## Visual Regressions

## Relevant Screenshots/GIFs
NA
## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
