### PR TITLE
temporary list style rollback

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -19,27 +19,27 @@ article ul,
     list-style: none;
   }
 }
-article {
-    .text-body {
-        ul {
-            width: 100%;
-        }
-        ul li {
-            display: flex;
-            flex-wrap: wrap;
-            margin: 0;
-            width: 100%;
-
-            &:before {
-                 display: inline-block;
-                 content: "•";
-                 width: 8px;
-                 margin-right: 15px;
-                 font-size: 31px;
-                 line-height: 18px;
-                 align-self: baseline;
-                 margin-top: 3px;
-             }
-        }
-    }
-}
+// article {
+//     .text-body {
+//         ul {
+//             width: 100%;
+//         }
+//         ul li {
+//             display: flex;
+//             flex-wrap: wrap;
+//             margin: 0;
+//             width: 100%;
+//
+//             &:before {
+//                  display: inline-block;
+//                  content: "•";
+//                  width: 8px;
+//                  margin-right: 15px;
+//                  font-size: 31px;
+//                  line-height: 18px;
+//                  align-self: baseline;
+//                  margin-top: 3px;
+//              }
+//         }
+//     }
+// }


### PR DESCRIPTION
## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
N/A

## Description
Quick rollback of bullet fix while we evaluate the issue


## To Test
- [ ] pull branch, set up styleguide for local development and run gulp serve
- [ ] check that the lists on this page look more or less correct http://ama-one.local/member-groups-sections/academic-physicians/aps-interim-meeting-agenda-resources

## Visual Regressions
list bullets next to a floatd element will push past the left margin of the text

## Relevant Screenshots/GIFs
http://ama-one.local/member-groups-sections/academic-physicians/aps-interim-meeting-agenda-resources


## Remaining Tasks
http://ama-one.local/member-groups-sections/academic-physicians/aps-interim-meeting-agenda-resources

## Additional Notes
http://ama-one.local/member-groups-sections/academic-physicians/aps-interim-meeting-agenda-resources

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
