### PR TITLE
SC-24: Mobile scroll bug

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
@@ -58,8 +58,9 @@
     display: flex;
     align-items: center;
     width: 100%;
-    overflow: scroll;
+    overflow-x: scroll;
     @include breakpoint($bp-med min-width) {
+      overflow-x: hidden;
       float: none;
       display: block;
     }

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
@@ -58,7 +58,7 @@
     display: flex;
     align-items: center;
     width: 100%;
-    overflow: hidden;
+    overflow: scroll;
     @include breakpoint($bp-med min-width) {
       float: none;
       display: block;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [SC-24: Mobile scroll bug](https://issues.ama-assn.org/browse/SC-24)

## Description
Allows for search connector results to be swiped (left/right) using mobile to view hidden results.


## To Test
- [ ] Checkout `feature/search-connector` branch from `ama-d8` repo and enable local style guide development mode. 
- Import and clear cache: `drush @one.local cim -y && drush @one.local cr`
- [ ] Using browser inspect element or browserstack to emulate mobile devices touch, navigate to search page and search for term, ie: http://ama-one.local/search?search=journals
- [ ] Scroll to the bottom and ensure hidden search results for search connector can be viewed when swipe right/left.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs
![RwyHIjDr1T](https://user-images.githubusercontent.com/541745/69654362-a7f5a100-1042-11ea-9ea6-fe96785e9058.gif)



## Remaining Tasks
N/A


## Additional Notes
N/A


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
