### PR TITLE
EWL-7611 updated promo block styles to compensate for duplicate class…

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_category-index.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-index.scss
@@ -6,7 +6,7 @@
         margin-top: $gutter;
       }
 
-      margin-top: $gutter * 2;
+      margin-top: $gutter;
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -1,10 +1,14 @@
 .ama__membership {
   background: $gray-7;
-  @include gutter($padding-top-half...);
-  @include gutter($padding-right-half...);
-  @include gutter($padding-bottom-half...);
-  @include gutter($padding-left-half...);
+  @include gutter($padding-top-full...);
+  @include gutter($padding-right-full...);
+  @include gutter($padding-bottom-full...);
+  @include gutter($padding-left-full...);
   @include child-top-gutters($gutter / 2);
+
+  &.bottom-margin {
+    @include gutter($margin-bottom-full...);
+  }
 
   // Remove margins on child elements so that we can set consistent spacing elsewhere.
   & > * {

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
@@ -6,7 +6,7 @@
         margin-top: $gutter;
       }
 
-      margin-top: $gutter * 2;
+      margin-top: $gutter;
     }
   }
 


### PR DESCRIPTION
… being removed. Also added margin-bottom class for correct spacing.

**Github Issue**
related to: 

**Jira Ticket**
- [Promo blocks are conjoined when two membership promos are used on the same news article](https://issues.ama-assn.org/browse/EWL-7611)

## Description
promo blocks were getting a double `ama__membership` class that was giving blocks double padding. Because everyone is used to this, I removed the double class and doubled the padding. Also added margin bottom rule to apply to all but the last block in a multi-block display.


## To Test
- [ ] follow the instructions in the companion PR in the D8 repo https://github.com/AmericanMedicalAssociation/ama-d8/pull/1734

## Visual Regressions

N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
