### PR TITLE
SC-30: Resource card text cut off 

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
@@ -13,8 +13,18 @@
       background-color: rgba(70, 22, 107, 0.05);
       padding: $gutter-mobile/2;
       margin: $gutter-mobile/4;
-      width: 360px;
+      width: 49vh;
       height: 190px;
+
+      @include breakpoint(359px max-width) {
+        width: 46vh;
+      }
+      @include breakpoint($bp-xs max-width) {
+        width: 47vh;
+      }
+      @include breakpoint($bp-xs min-width) {
+        width: 49vh;
+      }
       @include breakpoint($bp-med min-width) {
         width: auto;
         height: auto;
@@ -30,6 +40,10 @@
       }
       .search-result-item-subtitle {
         @include font-size($h5-font-sizes);
+        width: 85%;
+        @include breakpoint($bp-med min-width) {
+          width: auto;
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

- [SC-30: Resource card text cut off ](https://issues.ama-assn.org/browse/SC-30)

## Description
Adjust widths of Search Connector resource cards to help prevent text being cut off on mobile/tablet. There's a little bit of the next resource card showing to help/indicate users there are more results. 
<img width="353" alt="Screen Shot 2019-12-12 at 2 37 44 PM" src="https://user-images.githubusercontent.com/541745/70744138-20b95600-1cef-11ea-81f4-f1063f9c1fde.png">
<img width="334" alt="Screen Shot 2019-12-12 at 2 37 59 PM" src="https://user-images.githubusercontent.com/541745/70744139-20b95600-1cef-11ea-8619-6e7acc628971.png">
<img width="353" alt="Screen Shot 2019-12-12 at 2 38 08 PM" src="https://user-images.githubusercontent.com/541745/70744140-20b95600-1cef-11ea-8fdc-2070bcc0a73d.png">
<img width="339" alt="Screen Shot 2019-12-12 at 2 38 50 PM" src="https://user-images.githubusercontent.com/541745/70744141-20b95600-1cef-11ea-97b9-2fefd917f004.png">

## To Test
- [ ] Checkout `develop` branch on the `ama-d8`
- [ ] Enabled temporary disabled modules: `drush @one.local en ama_search_connector -y && drush @joe.local en ama_search_connector_solr -y && drush @joe.local cr && drush @one.local cr`
- [ ] Enable local styleguide 
- [ ] Navigate to http://ama-one.local/search?search=journal to test mobile treatment of resource cards (as seen above). 
- [ ] Did you test in IE 11?

## Visual Regressions
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
