### PR TITLE
EWL-6868: Issue form 61 Membership promo not displaying correctly

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -267,12 +267,23 @@ section#schedules {
   border-bottom: solid 1px $gray-50;
 }
 
-section#related_links ul {
-  list-style: none;
-
-  li {
+section#related_links {
+  ul {
     list-style: none;
-    margin: 0;
+
+    li {
+      list-style: none;
+      margin: 0;
+    }
+  }
+
+  .ama__membership ul {
+    list-style: initial;
+
+    li {
+      list-style: initial;
+      margin-left: 28px;
+    }
   }
 }
 

--- a/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_resource-tabs.scss
@@ -282,7 +282,8 @@ section#related_links {
 
     li {
       list-style: initial;
-      margin-left: 28px;
+      list-style-position: inside;
+      padding: 0;
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-6868: Issue form 61 Membership promo not displaying correctly](https://issues.ama-assn.org/browse/EWL-6868)

## Description
The Membership promo ( Physicians membership promo (16) ) displayed inside the _Related Links_ tab of a resource page was losing its `link-style` and `margin-left`. The SCSS nesting for this element has been updated to handle this special case while also leaving the general `ul` and `li` styling for _Related Links_ tabs in place.

There is a separate issue for the _Media_ tab where the Membership promo was displaying an older version. "Editing" this block without making changes and saving the page updates it to the latest version. Detailed instructions have been listed below as well as on the JIRA ticket.


## To Test
- [ ] Ensure you are using your local styleguide resource
- [ ] Run `gulp`/`gulp-serve` to build latest CSS files
- [ ] Navigate to a resource page with the Membership promo in tabs, e.g. /delivering-care/public-health/about-improving-health-outcomes
- [ ] Verify that the Membership promo ("Membership Moves Medicine") block on each of the three tabs (_Media_,_Downloads_,_Related Links_) is identical in content and style.

_NOTE:_ If the _Media_ tab is displaying a different set of content for the Membership promo (a paragraph instead of a bulleted list, see "Relevant Screenshots" section below) this appears to be a cached version. To resolve:
- [ ] Navigate to the page editor /node/23401/edit
- [ ] In the _Media Tab_ content area, select the "Edit" button
- [ ] Scroll down the _Membership Block_ item at the end and select "Edit"
- [ ] Make no change, but navigate back to the top of the _Media Tab_ content area and select "Collapse".
- [ ] Save the page and view. The _Media_ tab should now be displaying the latest version of the Membership promo block.

_These instructions have been included as a comment on the JIRA ticket as well._

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
Screenshot of the old Membership promo content as mentioned above: https://issues.ama-assn.org/secure/attachment/52200/52200_image1-17.png


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
