### PR TITLE
made submit button absolute and pinned to bottom of form, repositione…

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -158,16 +158,29 @@
 .ama__layout--two-col-right--75-25__right {
   form.webform-submission-email-subscription-form {
     position: relative;
+    padding-bottom: 63px;
     .form-item-us-citizen {
-      position: absolute;
-      top: 30px;
       width: 100%;
     }
     .form-actions {
-      margin-top: 60px;
-
+      position: absolute;
+      text-align: center;
+      bottom: 14px;
+      left: 0;
+      right: 0;
+      margin: auto;
+      .ajax-progress-throbber {
+        position:absolute;
+        top: 8px;
+        right: 0;
+      }
       @media only screen and (min-width: 601px) and (max-width: 768px) {
         margin-top: 80px;
+      }
+      .webform-button--submit {
+        display:inline-block;
+        margin: 0 auto;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
…d ajax throbber

## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
N/A

## Description
errors were all displaying beneath the submit button.
reversed Chrissy's work on the citizenship positioning and made the submit button absolute.


## To Test
- [ ] set up d8 repo for local styleguide development
- [ ] Pull this branch and run `gulp serve`
- [ ] on right rail email promos, observe that the field order is email citizenship submit. Submit an incorrect submission and verify that the order is email, email error, citizenship, citizenship error, submit button

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
