### PR TITLE
EWL-7708 increased z-index on inline promo blocks.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -29,6 +29,10 @@
     @include breakpoint($bp-small) {
       float: left;
     }
+    z-index: 500;
+    .ama__button {
+      z-index: 500;
+    }
 
     border-top: solid 1px $gray-50;
     border-bottom: solid 1px $gray-50;


### PR DESCRIPTION


## Ticket(s)
https://issues.ama-assn.org/browse/EWL-7708

**Github Issue**
N/A

**Jira Ticket**
- [Target area for CTAs in inline promos does not cover the entirety of the CTA](https://issues.ama-assn.org/browse/EWL-7708)

## Description
Increased z-index on inline promo blocks

## To Test
- [ ] set up d8 for local styleguide development
- [ ] pull this branch and serve
- [ ] visit a page with an inline promo and make sure that it's clickable and not causing any unexpected problems.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
