### PR TITLE
Set US verification checkbox label to initial capitalization

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -28,6 +28,7 @@
     }
     .us-verify {
       font-size: 10px;
+      text-transform: initial;
     }
     .ui-checkboxradio-icon {
       margin-top: 1px;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)


**Github Issue**
N/A

**Jira Ticket**
- [EWL-7818: Remove initial caps from checkbox text on Morning Rounds promos](https://issues.ama-assn.org/browse/EWL-7818)

## Description
Changed `.us-verify` class to override default label capitalization back to initial. This "fixes" the new label text _"I verify I’m in the U.S. and agree to receive communication from the AMA or third parties on behalf of AMA."_


## To Test
- [ ] Set local env to use local styleguide
- [ ] Pull branch
- [ ] Run `gulp` or `gulp serve`
- [ ] Run `drush @one.local cr`
- [ ] Verify that the Morning Rounds submission form text is capitalized as stated above in all instances on the site (full-width on homepage, footer form, sidebar forms).

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
