### PR TITLE
EWL-7782: Videos do not display on the Hub page template in mobile

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -52,6 +52,7 @@
     align-items: center;
     padding: 0;
     height: 100%;
+    width: 100%;
 
     @include breakpoint($bp-small) {
       flex-basis: 50%;

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -11,6 +11,10 @@
   background-repeat: no-repeat;
   min-height: 350px;
 
+  & > div:first-child {
+    width: 100%;
+  }
+
   @include breakpoint($bp-small) {
     background-position: center;
     background-size: cover;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-7782: Videos do not display on the Hub page template in mobile](https://issues.ama-assn.org/browse/EWL-7782)

## Description
Added explicit width setting for hub video containers to resolve them not appearing in mobile breakpoints.


## To Test
- [ ] Pull branch
- [ ] Set local env to use local styleguide
- [ ] Run `gulp` or `gulp serve`
- [ ] Run `drush @one.local cr`
- [ ] Verify that hub page video elements are visible across all breakpoints. Ex. http://ama-one.local/amaone/ama-group-spotlight

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
