### PR TITLE
Feature/ewl 7791 sitewide unordered list styling

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_gutter_mixin.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_gutter_mixin.scss
@@ -15,6 +15,10 @@ $margin-top-half-negative: margin, top, -$gutter / 2, -$gutter-mobile / 2;
 $margin-top-full-negative: margin, top, -$gutter, -$gutter-mobile;
 $margin-left-full-negative: margin, left, -$gutter, -$gutter-mobile;
 
+// list margins
+$margin-left-list: margin, left, $gutter * 1.786, $gutter-mobile * 1.6;
+$margin-left-nested-list: margin, left, $gutter /1.3, $gutter-mobile * 1.1;
+
 $padding-top-quarter: padding, top, $gutter / 4, $gutter-mobile / 4;
 $padding-top-full: padding, top, $gutter, $gutter-mobile;
 $padding-top-double: padding, top, $gutter * 2, $gutter-mobile * 2;

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -1,0 +1,86 @@
+/**
+* List mixins for none node-body lists.
+*/
+
+@mixin list() {
+  ul {
+    position:relative;
+    width: calc(100% - 50px);
+    @include breakpoint($bp-small) {
+      font-size: 20px;
+    }
+    @include breakpoint($bp-med) {
+      font-size: 18px;
+    }
+    li {
+      list-style-type: none;
+      width: 100%;
+      clear: both;
+      position: relative;
+      padding-left: 18px;
+      &:before {
+        content: "";
+        position: absolute;
+        background-color: $black;
+        border-radius: 100%;
+        width: 8px;
+        height: 8px;
+        left: 1px;
+        top: 9px;
+      }
+      ul {
+        left: 0;
+        width: calc(100% - 71px);
+        li {
+          list-style-type: none;
+          position: relative;
+          left: 0;
+          padding-left: 16px;
+          &:before {
+            content: "";
+            border:1px solid $black;
+            position: absolute;
+            background-color: transparent;
+            border-radius: 100%;
+            width: 6px;
+            height: 6px;
+            left: 1px;
+            top: 9px;
+          }
+        }
+      }
+    }
+  }
+}
+
+@mixin left-justified-list-w-padding() {
+  @include list();
+  ul {
+    left: 0;
+    width: 100%;
+    li {
+      line-height: 1.3em;
+      margin-bottom: 13px;
+      ul {
+        left: 0;
+      }
+    }
+  }
+}
+@mixin left-justified-list() {
+  @include list();
+  ul {
+    left: 0;
+  }
+}
+@mixin indented-list {
+  @include list();
+  ul {
+    left: 30px;
+    li {
+      ul {
+        left: 0;
+      }
+    }
+  }
+}

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -6,6 +6,7 @@
   ul {
     position:relative;
     width: calc(100% - 50px);
+    @include gutter($margin-bottom-half...);
     @include breakpoint($bp-small) {
       font-size: 20px;
     }
@@ -29,6 +30,7 @@
         top: 9px;
       }
       ul {
+        margin-bottom: 0;
         left: 0;
         width: calc(100% - 71px);
         li {
@@ -58,6 +60,7 @@
   ul {
     left: 0;
     width: 100%;
+    margin-bottom: 0;
     li {
       line-height: 1.3em;
       margin-bottom: 13px;
@@ -76,6 +79,7 @@
 @mixin indented-list {
   @include list();
   ul {
+    margin-bottom: 0;
     left: 30px;
     li {
       ul {

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -1,41 +1,19 @@
 section ul,
 article ul,
+.text-body ul,
 .ama__list {
-  @include gutter($margin-bottom-half...);
+  position:relative;
+  left:50px;
+  width: calc(100% - 50px);
   li {
-    padding: 0;
-    list-style: disc;
+    list-style: outside disc;
     ul {
-      @include gutter($margin-left-full...);
-      list-style-position: outside;
-    }
-  }
-  ul {
-    @include gutter($margin-left-full...);
-    list-style: none;
-  }
-}
-article {
-  .text-body {
-    ul {
-      @include gutter($margin-left-list...);
+      left: 0;
+      width: calc(100% - 71px);
       li {
-        list-style: outside disc;
+        list-style: outside circle;
         position: relative;
-        padding-right: 1em;
-        &:before {
-          padding-left: 0;
-        }
-        ul {
-          @include gutter($margin-left-nested-list...);
-          li {
-            list-style: outside circle;
-            line-height: 25px;
-            &:before {
-              padding-left: 0;
-            }
-          }
-        }
+        left: 21px;
       }
     }
   }

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -2,34 +2,41 @@ section ul,
 article ul,
 .ama__list {
   @include gutter($margin-bottom-half...);
-
   li {
-    @include gutter($margin-left-full...);
     padding: 0;
     list-style: disc;
-
     ul {
       @include gutter($margin-left-full...);
       list-style-position: outside;
     }
   }
-
   ul {
     @include gutter($margin-left-full...);
     list-style: none;
   }
 }
 article {
-    .text-body {
+  .text-body {
+    ul {
+      @include gutter($margin-left-list...);
+      li {
+        list-style: outside disc;
+        position: relative;
+        padding-right: 1em;
+        &:before {
+          padding-left: 0;
+        }
         ul {
-            list-style: outside disc;
-            margin-left: 1.2em;
+          @include gutter($margin-left-nested-list...);
+          li {
+            list-style: outside circle;
+            line-height: 25px;
+            &:before {
+              padding-left: 0;
+            }
+          }
         }
-        ul li {
-            position: relative;
-            left: 1em;
-            padding-right: 1em;
-            margin-left: -1em;
-        }
+      }
     }
+  }
 }

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -5,11 +5,13 @@ article ul,
   position:relative;
   left:50px;
   width: calc(100% - 50px);
+  @include gutter($margin-bottom-half...);
   li {
     list-style: outside disc;
     ul {
       left: 0;
       width: calc(100% - 71px);
+      margin-bottom: 0;
       li {
         list-style: outside circle;
         position: relative;

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -26,6 +26,7 @@
     @include gutter($padding-bottom-full...);
     @include gutter($margin-right-full...);
     @include gutter($margin-bottom-full...);
+    @include left-justified-list-w-padding();
     @include breakpoint($bp-small) {
       float: left;
     }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -88,6 +88,7 @@
     margin: 0;
     max-width: none;
     width: auto;
+    @include indented-list();
   }
 
   &__button-container {
@@ -234,5 +235,11 @@
       flex-direction: row-reverse;
     }
   }
+}
 
+/**
+* WYSIWYG Hub card styles.
+*/
+.paragraph--type--wysiwyg {
+  @include indented-list();
 }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -18,28 +18,7 @@
   .ama__button {
     width: 100%;
   }
-
-  ul {
-    left: 0;
-    width: 100%;
-    margin-left: 20px;
-    @include breakpoint($bp-small) {
-      font-size: 20px;
-    }
-    @include breakpoint($bp-med) {
-      font-size: 18px;
-    }
-    li {
-      list-style: outside disc;
-      width: 100%;
-      margin-bottom: 13px;
-      clear: both;
-      position: relative;
-      &:last-child {
-        margin-bottom: 0;
-      }
-    }
-  }
+  @include left-justified-list-w-padding();
 }
 
 a.ama__membership {

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -20,6 +20,9 @@
   }
 
   ul {
+    left: 0;
+    width: 100%;
+    margin-left: 20px;
     @include breakpoint($bp-small) {
       font-size: 20px;
     }
@@ -27,24 +30,13 @@
       font-size: 18px;
     }
     li {
-      list-style: outside none;
+      list-style: outside disc;
       width: 100%;
       margin-bottom: 13px;
       clear: both;
       position: relative;
-      padding-left: 15px;
       &:last-child {
         margin-bottom: 0;
-      }
-      &:before {
-        content: "";
-        position: absolute;
-        background-color: $black;
-        border-radius: 100%;
-        width: 8px;
-        height: 8px;
-        left: 1px;
-        top: 10px;
       }
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -20,8 +20,33 @@
   }
 
   ul {
-    list-style-position: outside;
-    @include gutter($margin-left-full...);
+    @include breakpoint($bp-small) {
+      font-size: 20px;
+    }
+    @include breakpoint($bp-med) {
+      font-size: 18px;
+    }
+    li {
+      list-style: outside none;
+      width: 100%;
+      margin-bottom: 13px;
+      clear: both;
+      position: relative;
+      padding-left: 15px;
+      &:last-child {
+        margin-bottom: 0;
+      }
+      &:before {
+        content: "";
+        position: absolute;
+        background-color: $black;
+        border-radius: 100%;
+        width: 8px;
+        height: 8px;
+        left: 1px;
+        top: 10px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Ticket(s)


**Github Issue**
- [Feature/ewl 7791 sitewide unordered list styling #1853
](https://github.com/AmericanMedicalAssociation/ama-d8/pull/1853)

**Jira Ticket**
- [Implement sitewide styles for use of unordered lists through D8 WYSIWYGs](https://issues.ama-assn.org/browse/EWL-7791)

## Description
A list mixin was added for lists outside of main body copy.
Lists in main body copy were reworked
styles were added to the ckeditor to control list display.

## To Test
- [ ] Pull complimentary d8 branch (only affects list display in wysiwyg)
- [ ] Pull this branch and set up site for local development.
- [ ] run `drush @one.local cr`
- [ ] verify that, in body copy, bullets are indented 30px from left margin. Verify that sublist bullets in body copy are flush left to the copy of the parent list and are rings.
 - [ ] Verify that if a list and a nested list are placed next to an inline promo block, they still appear correctly.
 -  [ ] verify on blocks such as "membership moves medicine" the list is as it appears in the zeppelin designs and is flush left with the headline. Hub pages, in the 50/50 split card and wysiwyg cards the bulleted lists are indented by 30px and the bullets are slightly larger than the copy bullets, and the copy is closer to the bullets, in line with the zeppelin designs on the jira ticket

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
 - due to the promo block issue with floated left content, we had a compromise with the business that lists and sublists in content will have smaller bullets and more space between the bullet and the copy. Lists elsewhere, in blocks and hub pages, will appear as they're shown in the zeppelin designs.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
