### PR TITLE
added unordered list styles to styleguide as pattern.

### DIFF
--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.json
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.json
@@ -1,0 +1,16 @@
+{
+  "unordered_list_presentation": [
+    {
+      "text": "Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a."
+    },
+    {
+      "text": "Praesent sapien massa, convallis a pellentesque nec, egestas non nisi."
+    },
+    {
+      "text": "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae"
+    },
+    {
+      "text": "Donec sollicitudin molestie malesuada. Proin eget tortor risus."
+    }
+  ]
+}

--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.md
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.md
@@ -1,0 +1,14 @@
+### Description
+A `<ul>`  element with its child `<li>` elements and optional nested child `<ul>` and `<li>` elements.
+
+### Variables:
+~~~
+unordered-list-presentation [{
+  text: Unordered list for Presentation
+    type: string / required
+  description (optional) [{
+    text: standard unordered list for blocks and presentation elements
+      type: string / required
+  }]
+}]
+~~~

--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.twig
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.twig
@@ -1,0 +1,20 @@
+<section class="ama__promo--inline">
+  <ul>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
+      <ul>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+      </ul>
+    </li>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
+      <ul>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+      </ul>
+    </li>
+  </ul>
+</section>

--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.twig
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list-presentation.twig
@@ -1,20 +1,13 @@
 <section class="ama__promo--inline">
   <ul>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
-      <ul>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-      </ul>
-    </li>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
-      <ul>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-      </ul>
-    </li>
+    {% for list in unordered_list_presentation %}
+      <li> {{list.text }}
+          <ul>
+            <li>
+              {{ list.text }}
+            </li>
+          </ul>
+      </li>
+    {% endfor %}
   </ul>
 </section>

--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list.json
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list.json
@@ -1,0 +1,16 @@
+{
+  "unordered_list": [
+    {
+      "text": "Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a."
+    },
+    {
+      "text": "Praesent sapien massa, convallis a pellentesque nec, egestas non nisi."
+    },
+    {
+      "text": "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae"
+    },
+    {
+      "text": "Donec sollicitudin molestie malesuada. Proin eget tortor risus."
+    }
+  ]
+}

--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list.md
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list.md
@@ -1,0 +1,14 @@
+### Description
+A `<ul>`  element with its child `<li>` elements and optional nested child `<ul>` and `<li>` elements.
+
+### Variables:
+~~~
+unordered-list [{
+  text:
+    type: string / required
+  description (optional) [{
+    text: standard unordered list for body copy
+      type: string / required
+  }]
+}]
+~~~

--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list.twig
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list.twig
@@ -1,20 +1,13 @@
 <section>
   <ul>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
-      <ul>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-      </ul>
-    </li>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
-      <ul>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
-      </ul>
-    </li>
+    {% for list in unordered_list %}
+      <li> {{list.text }}
+          <ul>
+            <li>
+              {{ list.text }}
+            </li>
+          </ul>
+      </li>
+    {% endfor %}
   </ul>
 </section>

--- a/styleguide/source/_patterns/01-atoms/lists/unordered-list.twig
+++ b/styleguide/source/_patterns/01-atoms/lists/unordered-list.twig
@@ -1,0 +1,20 @@
+<section>
+  <ul>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
+      <ul>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+      </ul>
+    </li>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+    <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.
+      <ul>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+        <li>Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</li>
+      </ul>
+    </li>
+  </ul>
+</section>


### PR DESCRIPTION
Add unordered list patterns to styleguide

## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
N/A

## Description
Added ul and ul - presentation patterns to styleguide


## To Test
- [ ] pull branch, run `gulp serve` check atoms -> lists and see that the ul patterns are present

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
