### PR TITLE
set h2 and uls to myriad-pro.

### DIFF
--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -30,7 +30,8 @@ h1,
   }
 }
 
-h2.news,
+h2,
+.news,
 .ama__h2,
 %ama__h2 {
   @include type($myriad-pro, $font-weight-semibold);
@@ -119,6 +120,12 @@ h5,
 }
 
 p {
+  @include type($myriad-pro, $font-weight-regular);
+  @include font-size($p-font-sizes);
+  @include gutter($margin-bottom-half...);
+}
+
+ul {
   @include type($myriad-pro, $font-weight-regular);
   @include font-size($p-font-sizes);
   @include gutter($margin-bottom-half...);

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -31,7 +31,7 @@ h1,
 }
 
 h2,
-.news,
+h2.news,
 .ama__h2,
 %ama__h2 {
   @include type($myriad-pro, $font-weight-semibold);


### PR DESCRIPTION
N/A

## Ticket(s)


**Github Issue**
N/A

**Jira Ticket**
- [Event Detail nodes are using Arial for headlines and lists.](https://issues.ama-assn.org/browse/EWL-7847)

## Description
On event detail nodes, h2s and uls had Arial as a font. Change selector rules to include h2s and uls.


## To Test
- [ ] set up styleguide for local development.
- [ ] pull branch and inspect h2s and uls on event detail pages. Confirm that they are myriad-pro

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
