### PR TITLE
excluded share list from UL rules.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_social-share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_social-share.scss
@@ -48,6 +48,8 @@ $social-icons: (
   margin: 0;
   padding: 0;
   min-height: 38px;
+  left:0;
+  width:100%;
 
   li {
     list-style: none;


### PR DESCRIPTION
## Ticket(s)

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [Share icons are pushing past the right page margin](https://issues.ama-assn.org/browse/EWL-7844)

## Description
excluded share list from select ul styles


## To Test
- [ ] pull branch and set up d8 for local styleguide development
- [ ] check that the share icons are flush with the right edge of the page.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
