### PR TITLE
Bugfix/ewl 7855 unsupported list not supported in all custom block types

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -22,7 +22,7 @@
       &:before {
         content: "";
         position: absolute;
-        background-color: $black;
+        background-color: currentColor;
         border-radius: 100%;
         width: 8px;
         height: 8px;
@@ -40,7 +40,7 @@
           padding-left: 16px;
           &:before {
             content: "";
-            border:1px solid $black;
+            border:1px solid currentColor;
             position: absolute;
             background-color: transparent;
             border-radius: 100%;

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -53,6 +53,20 @@
       }
     }
   }
+  .contextual,
+  .contextual-region,
+  .contextual-links,
+  ul.contextual-links {
+    ul {
+      width: 100%;
+      left:0;
+      list-style-type: none;
+      li:before {
+        height: 0px;
+        width: 0px;
+      }
+    }
+  }
 }
 
 @mixin left-justified-list-w-padding() {

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -4,6 +4,7 @@
 
   &__text {
     padding: $gutter / 2;
+    @include left-justified-list();
   }
 
   &__heading {
@@ -23,8 +24,8 @@
     color: $gray-64;
 
     // Right now the style guide uses `buttons`, but eventually we want to switch these to `a` elements.
-    a, 
-    button, 
+    a,
+    button,
     .ama__button {
       @include gutter($margin-top-full...);
       @include gutter($margin-right-half...);

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -10,6 +10,7 @@
   }
 
   &__text {
+    @include left-justified-list();
     &__header {
       @include gutter($margin-bottom-half...);
     }

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -4,6 +4,7 @@
   @include gutter($padding-bottom-half...);
   @include gutter($padding-left-half...);
   @include child-top-gutters($gutter / 2);
+  @include left-justified-list();
   display: block;
   font-weight: $font-weight-semibold;
   text-decoration: none;

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -3,6 +3,7 @@
   padding: $gutter / 2;
   color: $white;
   background: $purple;
+  @include left-justified-list();
 
   &__subject-title {
     @extend .ama__h4--white;

--- a/styleguide/source/assets/scss/04-templates/_one_column.scss
+++ b/styleguide/source/assets/scss/04-templates/_one_column.scss
@@ -29,5 +29,6 @@
     @include gutter($padding-top-double...);
     @include gutter($padding-bottom-full...);
     border-top: solid 1px $black;
+    @include left-justified-list();
   }
 }// end article


### PR DESCRIPTION
## Ticket(s)
[Unordered lists not supported in all Custom Block types](https://issues.ama-assn.org/browse/EWL-7855?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

**Github Issue**
N/A

**Jira Ticket**
- [Unordered lists not supported in all Custom Block types](https://issues.ama-assn.org/browse/EWL-7855?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

## Description
Added new list styles to select custom blocks


## To Test
- [ ] pul the companion PR for D8. 
- [ ] set up d8 for local styleguide development.
- [ ] follow the testing steps in the d8 PR https://github.com/AmericanMedicalAssociation/ama-d8/pull/1863

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
