### PR TITLE
Bugfix/ewl 7853 topic tags incorrectly placed

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -22,7 +22,7 @@
       &:before {
         content: "";
         position: absolute;
-        background-color: $black;
+        background-color: currentColor;
         border-radius: 100%;
         width: 8px;
         height: 8px;
@@ -40,7 +40,7 @@
           padding-left: 16px;
           &:before {
             content: "";
-            border:1px solid $black;
+            border:1px solid currentColor;
             position: absolute;
             background-color: transparent;
             border-radius: 100%;

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -53,6 +53,20 @@
       }
     }
   }
+  .contextual,
+  .contextual-region,
+  .contextual-links,
+  ul.contextual-links {
+    ul {
+      width: 100%;
+      left:0;
+      list-style-type: none;
+      li:before {
+        height: 0px;
+        width: 0px;
+      }
+    }
+  }
 }
 
 @mixin left-justified-list-w-padding() {

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -4,6 +4,7 @@
 
   &__text {
     padding: $gutter / 2;
+    @include left-justified-list();
   }
 
   &__heading {
@@ -23,8 +24,8 @@
     color: $gray-64;
 
     // Right now the style guide uses `buttons`, but eventually we want to switch these to `a` elements.
-    a, 
-    button, 
+    a,
+    button,
     .ama__button {
       @include gutter($margin-top-full...);
       @include gutter($margin-right-half...);

--- a/styleguide/source/assets/scss/02-molecules/_product.scss
+++ b/styleguide/source/assets/scss/02-molecules/_product.scss
@@ -10,6 +10,7 @@
   }
 
   &__text {
+    @include left-justified-list();
     &__header {
       @include gutter($margin-bottom-half...);
     }

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -4,6 +4,7 @@
   @include gutter($padding-bottom-half...);
   @include gutter($padding-left-half...);
   @include child-top-gutters($gutter / 2);
+  @include left-justified-list();
   display: block;
   font-weight: $font-weight-semibold;
   text-decoration: none;

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -3,6 +3,7 @@
   padding: $gutter / 2;
   color: $white;
   background: $purple;
+  @include left-justified-list();
 
   &__subject-title {
     @extend .ama__h4--white;

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -10,6 +10,8 @@ article[class*='__page-content'] .ama__tags {
   display: flex;
   flex-wrap: wrap;
   flex: 1;
+  left:0;
+  width:100%;
 
   li {
     margin-left: 0;

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -225,9 +225,8 @@
       display: flex;
       flex-direction: column;
       text-align: left;
-
       @include breakpoint($bp-small) {
-        width: 50%;
+        width: 100%;
       }
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -226,7 +226,7 @@
       flex-direction: column;
       text-align: left;
       @include breakpoint($bp-small) {
-        width: 100%;
+        width: 50%;
       }
     }
   }

--- a/styleguide/source/assets/scss/04-templates/_one_column.scss
+++ b/styleguide/source/assets/scss/04-templates/_one_column.scss
@@ -29,5 +29,6 @@
     @include gutter($padding-top-double...);
     @include gutter($padding-bottom-full...);
     border-top: solid 1px $black;
+    @include left-justified-list();
   }
 }// end article


### PR DESCRIPTION
**NOTE: this PR is based off of https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/757 review and merge that PR first to prevent merge issues.**

## Ticket(s)
https://issues.ama-assn.org/browse/EWL-7855?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

**Github Issue**

**Jira Ticket**
- [Work on unordered lists has shifted the placement of topic tags and the lines that separate them from body text](https://issues.ama-assn.org/browse/EWL-7853)

## Description
Excluded tag lists from ul formatting


## To Test
- [ ] set up d8 for local styleguide development.
- [ ] pull branch and run gulp serve.
- [ ] visit a page and confirm that tags are flush left and the borders run 100% width of the page content area.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
