### PR TITLE
changed default width of 50/50 text panel

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -227,7 +227,7 @@
       text-align: left;
 
       @include breakpoint($bp-small) {
-        width: 50%;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
N/A

**Jira Ticket**
- [50/50 Hub Page cards are now displaying 65/35 image to card text](https://issues.ama-assn.org/browse/EWL-7854)

## Description
Width 50% was squeezing the text panel in 50/50 hub cards. Changed to 100%


## To Test
- [ ] set up d8 for local styleguide development
- [ ] pull branch and run `gulp serve`
- [ ] check http://ama-one.local/amaone/ama-ambassador-program and make sure the 50/50 blocks are 50/50

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
