### PR TITLE
fixed regression with lists next to floated elements.

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -5,15 +5,17 @@
 //nesting levels
 $one-level: "one-level";
 $two-levels: "two-levels";
+$two-levels-body: "two-levels-body";
 //list style
+$body-copy: "body-copy";
 $left-justified: "left-justified";
 $left-justified-w-padding: "left-justified-w-padding";
 $indented: "indented";
-$body-copy: "body-copy";
 //Bullet Styles
 $default: "default";
+$default-nested: "default-nested";
 $presentation: "presentation";
-$sublist: "sublist";
+$presentation-nested: "presentation-nested";
 
 @mixin list($indent: "", $depth: "") {
   ul {
@@ -38,12 +40,10 @@ $sublist: "sublist";
           width: calc(100% - 71px);
           margin-bottom: 0;
           li {
-            @include list-style($sublist);
-            position: relative;
-            left: 21px;
+            @include list-style($default-nested);
             ul {
               li {
-                left: 0;
+                @include list-style($default-nested);
               }
             }
           }
@@ -93,11 +93,27 @@ $sublist: "sublist";
           margin-bottom: 0;
           left: 0;
           width: calc(100% - 71px);
-          @include list-style(sublist);
+          @include list-style($presentation-nested);
           li {
             ul {
               li {
                 left: -16px;
+              }
+            }
+          }
+        }
+      }
+      @if($depth == "two-levels-body") {
+        ul {
+
+          @include list-style($default-nested);
+          li {
+            position: relative;
+            left: 41px;
+            margin-left: -20px;
+            ul {
+              li {
+                left: 2px;
               }
             }
           }
@@ -110,12 +126,17 @@ $sublist: "sublist";
 @mixin list-style($style: "") {
   @if($style == "default") {
     ul {
-      list-style: outside disc;
+      list-style: inside disc;
       li {
         width: 100%;
         position: relative;
         padding-left: 18px;
       }
+    }
+  }
+  @if($style == "default-nested") {
+    li {
+      list-style: outside circle;
     }
   }
   @if($style == "presentation") {
@@ -137,7 +158,7 @@ $sublist: "sublist";
       }
     }
   }
-  @if($style == "sublist") {
+  @if($style == "presentation-nested") {
     li {
       list-style-type: none;
       left: 0;

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -4,7 +4,7 @@
 */
 .ama__list,
 .text-body {
-  @include list($body-copy, $two-levels);
+  @include list($body-copy, $two-levels-body);
 }
 /**
 * Exclusion list.


### PR DESCRIPTION
N/A

## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
- [Unordered lists support more than two levels of indent](https://issues.ama-assn.org/browse/EWL-7856)

## Description
Fixed regression where nested lists next to floated blocks were not properly formatted.


## To Test
- [ ] set up d8 for local styleguide development and pull this branch
- [ ] run `gulp serve`
- [ ] on a news article, add a multi level nested list immediately after an embedded promo block.
- [ ] confirm that 2nd 3rd level nested lists look indistinguishable from the 1st level nested list. Confirm that the list items wrap properly around the block and maintain their left margin.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![Screen Shot 2020-02-20 at 1 04 54 PM](https://user-images.githubusercontent.com/10862145/74969165-a63d3e80-53e1-11ea-807d-53822200b756.png)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
