### PR TITLE
restricted UL styles. Rolled back previous work to deal with regressi…

### DIFF
--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -125,12 +125,6 @@ p {
   @include gutter($margin-bottom-half...);
 }
 
-ul {
-  @include type($myriad-pro, $font-weight-regular);
-  @include font-size($p-font-sizes);
-  @include gutter($margin-bottom-half...);
-}
-
 small,
 .ama__type--small,
 %ama__type--small {

--- a/styleguide/source/assets/scss/01-atoms/_tabs.scss
+++ b/styleguide/source/assets/scss/01-atoms/_tabs.scss
@@ -1,4 +1,4 @@
-.ama__tabs {
+.ama__tabs{
   border: none !important;
   border-radius: 0;
   padding: 0;
@@ -10,21 +10,11 @@
     margin: 0;
     border-radius: 0;
     display: none;
-
-    ul {
-      position: static;
-      width: 100%;
-
-      li {
-        position: static;
-        width: 100%;
-      }
-    }
     @include breakpoint($bp-small) {
       display: block;
     }
 
-    .ui-tabs-tab {
+    .ui-tabs-tab{
       background: $white;
       border: none;
     }

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -22,7 +22,7 @@ ul.ul-standard {
   }
 }
 
-.ama__homepage__navs ul,
+.ama__org-nav ul,
 .ama__list {
   @include gutter($margin-bottom-half...);
 
@@ -41,4 +41,7 @@ ul.ul-standard {
     @include gutter($margin-left-full...);
     list-style: none;
   }
+}
+.ama__category-nav ul {
+  margin-bottom: 14px;
 }

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -22,7 +22,7 @@ ul.ul-standard {
   }
 }
 
-.ama__org-nav ul,
+.ama__homepage__navs ul,
 .ama__list {
   @include gutter($margin-bottom-half...);
 

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -21,3 +21,24 @@ ul.ul-standard {
     width: 0;
   }
 }
+
+nav ul,
+.ama__list {
+  @include gutter($margin-bottom-half...);
+
+  li {
+    @include gutter($margin-left-full...);
+    padding: 0;
+    list-style: disc;
+
+    ul {
+      @include gutter($margin-left-full...);
+      list-style-position: outside;
+    }
+  }
+
+  ul {
+    @include gutter($margin-left-full...);
+    list-style: none;
+  }
+}

--- a/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
+++ b/styleguide/source/assets/scss/01-atoms/_unordered-list.scss
@@ -22,7 +22,7 @@ ul.ul-standard {
   }
 }
 
-nav ul,
+.ama__org-nav ul,
 .ama__list {
   @include gutter($margin-bottom-half...);
 

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -10,8 +10,6 @@ article[class*='__page-content'] .ama__tags {
   display: flex;
   flex-wrap: wrap;
   flex: 1;
-  left:0;
-  width:100%;
 
   li {
     margin-left: 0;

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -56,9 +56,6 @@
     padding-bottom: $gutter-mobile;
     margin-bottom: $gutter-mobile;
     border-bottom: 1px solid $gray-50;
-    ul {
-      margin-bottom: 0;
-    }
 
     a {
       text-decoration: none;
@@ -68,24 +65,15 @@
       }
     }
 
-    @include breakpoint($bp-xs) {
-      ul {
-        font-size: 1em;
-        line-height: 1.25;
-      }
-    }
     @include breakpoint($bp-small) {
       border: none;
-      padding-bottom: 8px;
     }
+
     @include breakpoint($bp-large) {
       display: flex;
-      border: none;
-      padding-bottom: 20px;
+
       ul {
         width: 50%;
-        font-size: 1em;
-        line-height: 1.667;
       }
     }
   }
@@ -139,12 +127,6 @@
     text-transform: uppercase;
     text-align: center;
     border-top: 1px solid $gray-50;
-    ul {
-      list-style-type: none;
-      margin-bottom: 0;
-      line-height: 1.05em;
-      font-size: 1em;
-    }
 
     li {
       display: inline-block;
@@ -154,23 +136,10 @@
         padding: 0 7px;
       }
     }
-    @include breakpoint($bp-xs) {
-      ul {
-        font-size: 1em;
-        line-height: 1.5em;
-      }
-    }
-    @include breakpoint($bp-small) {
-      ul {
-        font-size: 1em;
-        line-height: 1.25;
-      }
-    }
+
     @include breakpoint($bp-large) {
-      ul {
-        font-size: 1.111em;
-        line-height: 1em;
-      }
+      font-size: 1.111em;
+      line-height: 1em;
     }
   }
 
@@ -181,24 +150,10 @@
     background: $purple;
     border-top: 1px solid $gray-50;
     color: $white;
-    ul {
-      list-style-type: none;
-      margin-bottom: 0;
-      line-height: 1.05em;
-      font-size: 1em;
-    }
-    @include breakpoint($bp-xs) {
-      ul {
-        font-size: 1em;
-        line-height: 1.5em;
-      }
-    }
+
     @include breakpoint($bp-large) {
       padding: 0;
-      ul {
-        font-size: 1em;
-        line-height: 1.056em;
-      }
+
       > .container {
         display: flex;
         align-items: center;


### PR DESCRIPTION
…ons.


## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
N/A

## Description
UL styles were being broadly applied by a rule in _typography.scss
Removed this rule. Rolled back previous work to deal with regressions this caused.


## To Test
- [x] set up d8 for local styleguide development
- [x] pull branch and run `gulp serve`
- [x] put your local browser next to the prod site
- [x] confirm that the admin toolbar is the correct size.
- [x] confirm that the footer is in sync with prod
- [x] when moving back and forth between local and prod, ensure that things generally match.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
