### PR TITLE
corrected nested list margin regression.

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -41,11 +41,6 @@ $presentation-nested: "presentation-nested";
           margin-bottom: 0;
           li {
             @include list-style($default-nested);
-            ul {
-              li {
-                @include list-style($default-nested);
-              }
-            }
           }
         }
       }
@@ -109,11 +104,10 @@ $presentation-nested: "presentation-nested";
           @include list-style($default-nested);
           li {
             position: relative;
-            left: 41px;
-            margin-left: -20px;
+            left: 21px;
             ul {
               li {
-                left: 2px;
+                left: 0;
               }
             }
           }
@@ -130,7 +124,6 @@ $presentation-nested: "presentation-nested";
       li {
         width: 100%;
         position: relative;
-        padding-left: 18px;
       }
     }
   }

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -125,6 +125,10 @@ p {
   @include gutter($margin-bottom-half...);
 }
 
+ul {
+  @include type($myriad-pro, $font-weight-regular);
+}
+
 small,
 .ama__type--small,
 %ama__type--small {


### PR DESCRIPTION
## Ticket(s)
N/A


**Jira Ticket**
- [Second-level unordered list bullet margins are too wide](https://issues.ama-assn.org/browse/EWL-7879)

## Description
Removed nested issue pushing the text further from the bullets.
Removed regression where lists use Arial in event nodes


## To Test
- [ ] set up d8 for local styleguide development
- [ ] pull branch and run `gulp serve`
- [ ] go to a news article and add a ul with a nested ul
- [ ] check to be sure the space between the bullet and text in the nested list is the same distance as it is on the top level list.
- [ ] add a list to an event node. Verify that the list is using myriad-pro and not Arial.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
