### PR TITLE
inline-promo style change.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -27,7 +27,7 @@
     @include gutter($padding-bottom-full...);
     @include gutter($margin-right-full...);
     @include gutter($margin-bottom-full...);
-    @include list($left-justified-w-padding, $two-levels);
+    @include list($left-justified-w-padding, $one-level);
     @include breakpoint($bp-small) {
       float: left;
     }


### PR DESCRIPTION
## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
N/A

## Description
inline-promo blocks had incorrect list display.


## To Test
- [ ] set up d8 for local styleguide development
- [ ] pull branch and run `gulp serve`
- [ ] see that inline promos on news articles have bullets and are left aligned.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
