### PR TITLE
changed blockquote layout to use flexbox.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_block-quote.scss
+++ b/styleguide/source/assets/scss/01-atoms/_block-quote.scss
@@ -1,6 +1,14 @@
 blockquote {
+  display: flex;
+  flex-direction: column;
   position: relative;
   padding-left: 30px;
+  * {
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+  margin-bottom: 1em;
   @include breakpoint($bp-med) {
     padding-left: 13px;
   }


### PR DESCRIPTION
## Ticket(s)


**Github Issue**
N/A

**Jira Ticket**
- [Blockquote formatting conflicts with promo-as-inline positioning](https://issues.ama-assn.org/browse/EWL-7894)

## Description
left floated promo blocks were obscuring the left margin and by extension the :before element of blockquotes. Because block quotes don't need to wrap, was able to switch them to flexbox.


## To Test
- [ ] set up d8 for local styleguide development
- [ ] pull this branch and run `gulp serve`
- [ ] go to https://ama-one.local/about/awards/physicians-tomorrow-awards and confirm that the purple left border of the block quote at the top of the page is not overlapping the embedded promo block.
- [ ] add lists on other parts of the page to confirm they display correctly.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
