### PR TITLE
bugfix/EWL-7934: added right margin to left aligned embedded entity.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -52,14 +52,18 @@ figure.embedded-entity.align-right {
 .embedded-entity {
 
   &.align-right {
-    
+
     @include gutter($margin-left-half...);
     float: right;
-    width: auto;;
+    width: auto;
   }
 
   &.align-center {
     text-align: center;
   }
-  
+
+  &.align-left {
+    @include gutter($margin-right-half...);
+    width: auto;
+  }
 }


### PR DESCRIPTION
## Ticket(s)
[Left aligned images in body copy have no right margin](https://issues.ama-assn.org/browse/EWL-7934)

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [Left aligned images in body copy have no right margin](https://issues.ama-assn.org/browse/EWL-7934)

## Description
Added right margin to left aligned embedded images


## To Test
- [ ] Set up D8 for styleguide development
- [ ] pull branch and run `gulp serve` `drush @one.local cr`
- [ ] go to a news article and add a left aligned image. Verify that there is a right margin.
- [ ] add a list next to the left aligned image. Verify that it displays as expected.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
