### PR TITLE
EWL-7961: People Bio image on Author Article Index pages is too large

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
@@ -13,8 +13,8 @@
   &__image {
     min-width: 0;
     max-width: 0;
-    min-width: 280px;
-    max-width: 280px;
+    min-width: 210px;
+    max-width: 210px;
     margin: 0 auto;
 
     img {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-7961: People Bio image on Author Article Index pages is too large](https://issues.ama-assn.org/browse/EWL-7961)

## Description
Changed Bio image width from 280px -> 210px.


## To Test
- [ ] Pull branch
- [ ] Set up local env to use local styleguide
- [ ] Run `gulp serve`
- [ ] Create/view an Author Article Index page and verify that the bio photo is 210px wide as per the [Zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5e5428d76fd68073c47e03ba)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
