### PR TITLE
Removed top gray border above AMA Tags section

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -1,6 +1,5 @@
 .ama__tags,
 article[class*='__page-content'] .ama__tags {
-  @include ama-rules(1px, "", $gray-7, solid);
   @include ama-rules(1px, "bottom", $gray-7, solid);
   @include gutter($margin-top-full...);
   @include gutter($margin-bottom-full...);


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
- [EWL-7962: Remove top border between bio and topic tag on Author Article Index page](https://issues.ama-assn.org/browse/EWL-7962)

## Description
Remove top border CSS above AMA Tags section.


## To Test
- [ ] Pull branch
- [ ] Set up local env to use local SG2
- [ ] Run `gulp serve`
- [ ] Create/view Author Article Index page and verify that the top border is now removed for the Tags section as per the [Zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5e5428d76fd68073c47e03ba)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
