### PR TITLE
EWL-7986: Centered people_bio profile image.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bio-image-with-body.scss
@@ -5,35 +5,21 @@
   justify-content: center;
   text-align: center;
 
-  .ama__link--icon svg {
-    max-height: 45px;
-    max-width: 45px;
-  }
-
-  &__image {
-
-    img {
-      border-radius: 50%;
-    }
-  }
-
-  &__copy {
-    flex-grow: 1;
-  }
-
-  dt, dd {
-    display: block;
-    width: 100%;
-  }
-
-  @include breakpoint($bp-small) {
-    flex-direction: row;
+  @include breakpoint($bp-xs) {
+    flex-direction: column;
     flex-wrap: no-wrap;
     justify-content: center;
     text-align: center;
+    align-items: center;
 
     &__image {
-      margin: 0 15px 0 0;
+      margin: 0;
+      align-self: center;
+    }
+
+    dt, dd {
+      display: block;
+      width: 100%;
     }
   }
 
@@ -50,16 +36,25 @@
     &__image {
       width: auto;
       min-width: 0;
-      max-width: 210px;
       margin: 0 15px 0 0;
     }
   }
-}
-.ama__people-bio {
-  .ama__bio-image-with-body {
-    &__image {
-      min-width: 0;
-      max-width: 210px;
+
+  .ama__link--icon svg {
+    max-height: 45px;
+    max-width: 45px;
+  }
+
+  &__image {
+    min-width: 0;
+    max-width: 210px;
+    align-self: center;
+    img {
+      border-radius: 50%;
     }
+  }
+
+  &__copy {
+    flex-grow: 1;
   }
 }


### PR DESCRIPTION
**Github Issue**
N/A

**Jira Ticket**
- [EWL-7986: Bio images not centered on Mobile and Tablet](https://issues.ama-assn.org/browse/EWL-7986)

## Description
reorganized some of the people bio styles and removed some redundancy. Centered the item with flex-box.


## To Test
- [ ] prepare D8 repo for local styleguide development.
- [ ] pull branch and run `gulp serve`
- [ ] go to a people bio http://ama-local/news-leadership-viewpoints/authors-news-leadership-viewpoints/sara-berg
- [ ] Confirm that the bio image is center aligned on mobile.
- [ ] inspect the page for any visual regressions

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
