### PR TITLE
converted gray-50 to accessibility compliant color. Switched date dis…

### DIFF
--- a/styleguide/source/assets/scss/00-base/_colors.scss
+++ b/styleguide/source/assets/scss/00-base/_colors.scss
@@ -14,7 +14,7 @@ $hoverRed: #d81735; // JAMA red
 //Grayscale
 $black: #000000;
 $gray-64: #5C5C5C;
-$gray-50: #7F7F7F;
+$gray-50: #767676;
 $gray-20: #CBCBCB;
 $gray-7: #EDEDED;
 $white: #ffffff;

--- a/styleguide/source/assets/scss/02-molecules/_article-stub-metadata.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub-metadata.scss
@@ -1,6 +1,6 @@
 .ama__article-stub__metadata {
   @extend .ama__type--small;
-  color: $gray-64;
+  color: $gray-50;
   display: block;
   font-size: 12px;
   text-transform: uppercase;

--- a/styleguide/source/assets/scss/02-molecules/_forum-comments.scss
+++ b/styleguide/source/assets/scss/02-molecules/_forum-comments.scss
@@ -34,7 +34,7 @@ section.ama__forum_comments, section.ama__forum_comments .indented,
             }
 
             &-date {
-              color: $gray-64;
+              color: $gray-50;
               margin-right: 30px;
             }
           }

--- a/styleguide/source/assets/scss/02-molecules/_forum-topic.scss
+++ b/styleguide/source/assets/scss/02-molecules/_forum-topic.scss
@@ -39,7 +39,7 @@
     }
   }
   &-date {
-    color: $gray-64;
+    color: $gray-50;
   }
   &-print {
     margin-left: auto;

--- a/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
@@ -25,7 +25,7 @@
       @include type($myriad-pro, $font-weight-regular);
       text-transform: uppercase;
       display: block;
-      color: $gray-64;
+      color: $gray-50;
       line-height:.9em;
       padding-bottom: ($gutter / 2.5);
     }


### PR DESCRIPTION
…plays from gray-64 to gray-50

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-7955: Change date display color sitewide to meet AA accessibility standard](https://issues.ama-assn.org/browse/EWL-7955)

## Description
converted gray-50 to accessibility compliant color. Switched date displays from gray-64 to gray-50

## To Test
- [ ] Set up d8 for local development.
- [ ] pull branch and run `gulp serve` 
- [ ] check the date displays on the homepage as well as the entities listed on the ticket
NOTE: most of the entities on this list don't have a gray date display. Extensive testing is unnecessary. 

listed entities:
Search Engine Results Page
Home Page
Category Taxonomy Term Page
Subcategory Taxonomy Term Page
Index Taxonomy Term Page
Basic Page Template
Event Detail Template
Event Listing Hard Coded Page
Evergreen Page Template
Hub Page Template
News Article Page Template
People Bio Page Template
People Listing Page Template
Press Release Page Template
Resource Page Template
Sales Landing Page Template

## Visual Regressions
Local regression tests run


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
Anything more to add? Good things to call out here are:
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
