### PR TITLE
EWL-7877: limited layout builder rows to 100% width

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -35,6 +35,7 @@
   &__row {
     padding: $gutter 0;
     border-top: solid 2px $gray-50;
+    max-width: 100%;
 
     .container {
       padding: 0;


### PR DESCRIPTION
## Ticket(s)
- [EWL-7877: Subcat cannot be built without overriding the layout](https://issues.ama-assn.org/browse/EWL-7877)

**Github Issue**
N/A

**Jira Ticket**
- - [EWL-7877: Subcat cannot be built without overriding the layout](https://issues.ama-assn.org/browse/EWL-7877)

## Description
confined ama layout builder rows to 100% width.


## To Test
- [ ] pull branch
- [ ] Set up d8 for local styleguide development
- [ ] go to a category page and verify that the bottom rule of the subcat list at the top of the page does not run past the right margin.
It should look like the attached screenshot

## Visual Regressions

N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
