### PR TITLE
EWL-7955: changed additional date colors to gray-50.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_event-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_event-stub.scss
@@ -57,6 +57,7 @@
 
   &__date {
     font-style: italic;
+    color: $gray-50;
   }
 
   &__location {

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -57,7 +57,7 @@
         }
       }
     }
-    
+
     &__event__button {
       @include breakpoint($bp-med min-width) {
         width: 200px;
@@ -139,6 +139,7 @@
       @include gutter($padding-top-full...);
       grid-column: 1/3;
       grid-row: 3;
+      color: $gray-50;
     }
 
     &__share,


### PR DESCRIPTION
## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-7955: Change date display color sitewide to meet AA accessibility standard](https://issues.ama-assn.org/browse/EWL-7955)

## Description
Added the date color to Press Releases, Event Detail, News Articles and Event Listings.

## To Test
- [ ] Set up d8 for local development.
- [ ] pull branch and run `gulp serve` 
- [ ] Verify that when a date is displayed in a news article, press release, event detail and event listing, it's #767676


## Visual Regressions
Local regression tests run


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
Anything more to add? Good things to call out here are:
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
