### PR TITLE
EWL-8062: Right align images

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_lists.scss
@@ -29,13 +29,11 @@ $presentation-nested: "presentation-nested";
     }
 
     @if($indent == "body-copy") {
-      left: 50px;
-      position:relative;
+
       @include gutter($margin-bottom-half...);
       li {
         @include list-style($default);
         ul {
-          left: 0;
           margin-bottom: 0;
           li {
             @include list-style($default-nested);
@@ -43,28 +41,22 @@ $presentation-nested: "presentation-nested";
         }
       }
       @media (min-width: 320px) {
-        position: static;
         margin-left: 35px;
         max-width: 100%;
         li {
           ul {
-            position:static;
-            margin-right: 10px;
-            margin-left: 0;
+            margin-left: 5px;
             max-width: 100%;
           }
         }
       }
       @media (min-width: 768px) {
         position: relative;
-        width: calc(100% - 80px);
-        margin-left: 0;
+        margin-left: 50px;
         li {
           ul {
-            position:relative;
             width: 100%;
             margin-left: 0;
-            margin-right: 0;
           }
         }
       }

--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -14,7 +14,7 @@
 
   @include breakpoint($bp-small) {
     &--left {
-      float: left;
+      float: right;
       @include gutter($margin-right-half...);
     }
 
@@ -38,7 +38,7 @@ figure.embed-entity--caption {
 }
 
 figure.embedded-entity.align-left {
-  margin-right: $gutter / 2;
+  margin-left: $gutter / 2;
   margin-bottom: $gutter / 2;
 }
 
@@ -57,13 +57,15 @@ figure.embedded-entity.align-right {
     float: right;
     width: auto;
   }
-
+//  overrides for legacy entities.
+//  Right and center aligned blocks and images have been retired, permenantly 🕶️.
   &.align-center {
-    text-align: center;
+    float: right;
   }
 
   &.align-left {
-    @include gutter($margin-right-half...);
+    float: right;
+    @include gutter($margin-left-half...);
     width: auto;
   }
 }


### PR DESCRIPTION
**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8062: Article Page Redesign - Images](https://issues.ama-assn.org/browse/EWL-8062)

## Description
Set left floated blocks to float right. Corrected formatting in lists so they display properly.


## To Test
- [ ] Pull and serve branch.
- [ ] See d8 PR for testing steps. https://github.com/AmericanMedicalAssociation/ama-d8/pull/2052

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
