### PR TITLE
EWL-7951: convert promo as inline

### DIFF
--- a/styleguide/source/assets/scss/00-base/_colors.scss
+++ b/styleguide/source/assets/scss/00-base/_colors.scss
@@ -14,6 +14,10 @@ $hoverBlack: #333333;
 $hoverRed: #d81735; // JAMA red
 $hoverComplementary: #ffd8a3;
 
+//BG Colors
+$bg-purple: #ece7f0;
+$bg-gray: #f4f4f4;
+
 //Grayscale
 $black: #000000;
 $gray-64: #5C5C5C;

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -94,6 +94,7 @@
       @include breakpoint($bp-xs) {
         grid-column: 1/5;
         justify-content: center;
+        width: auto;
       }
       @include breakpoint($bp-small) {
         justify-content: left;
@@ -101,10 +102,14 @@
       @include breakpoint($bp-large) {
         grid-column: 3/5;
         justify-content: center;
+        margin-left: 14px;
+        .ama__button {
+          width: 100%;
+        }
       }
-    }
-    .ama__button {
-      min-width: 33%;
+      .ama__button {
+        min-width: 33%;
+      }
     }
     &.promo-as-inline-gray {
       background-color: $bg-gray;

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -108,6 +108,8 @@
       }
       .ama__button {
         min-width: 33%;
+        @include gutter($padding-right-full...);
+        @include gutter($padding-left-full...);
       }
     }
     &.promo-as-inline-gray {

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -32,15 +32,14 @@
     display: grid;
     grid-template-rows: auto auto auto;
     grid-template-columns: 1fr 6fr 2.5fr;
-    grid-auto-flow: dense;
 
     &.align-right,
     &.align-left,
     &.align-center {
-      float:none;
+      float: none;
       width: 100%;
-      margin-left:0;
-      margin-right:0;
+      margin-left: 0;
+      margin-right: 0;
     }
 
     .heading-left {

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -20,28 +20,100 @@
   }
 
   &--inline {
-    @extend .col-xs-12;
-    @extend .col-sm-4;
     @include gutter($padding-top-full...);
     @include gutter($padding-right-full...);
+    @include gutter($padding-left-full...);
     @include gutter($padding-bottom-full...);
     @include gutter($margin-right-full...);
     @include gutter($margin-bottom-full...);
     @include list($left-justified-w-padding, $two-levels);
-    @include breakpoint($bp-small) {
-      float: left;
-    }
     z-index: 500;
-    .ama__button {
-      z-index: 500;
+    width: 100%;
+    display: grid;
+    grid-template-rows: auto auto auto;
+    grid-template-columns: 1fr 6fr 2.5fr;
+    grid-auto-flow: dense;
+
+    &.align-right,
+    &.align-left,
+    &.align-center {
+      float:none;
+      width: 100%;
+      margin-left:0;
+      margin-right:0;
     }
 
-    border-top: solid 1px $gray-50;
-    border-bottom: solid 1px $gray-50;
-    padding-left: 0;
+    .heading-left {
+      @include breakpoint($bp-xs) {
+        grid-column: 1/5;
+      }
+      @include breakpoint($bp-med) {
+        grid-column: 1/3;
+      }
+    }
 
     &.listicle-margin {
       margin-right: 60px;
+    }
+
+    h2 {
+      grid-row: auto / span 1;
+      order: 1;
+      margin-bottom: 0;
+      @include breakpoint($bp-xs) {
+        grid-column: 1/5;
+      }
+      @include breakpoint($bp-large) {
+        grid-column: 1/3;
+      }
+    }
+
+    & > div {
+      grid-row: auto / span 1;
+      order: 2;
+      p {
+        font-size: 20px;
+      }
+      @include gutter($padding-top-half...);
+      @include breakpoint($bp-xs) {
+        grid-column: 1/5;
+        @include gutter($padding-bottom-half...);
+      }
+      @include breakpoint($bp-large) {
+        grid-column: 1/3;
+        padding-bottom: 0;
+      }
+    }
+    .inline-cta {
+      grid-row: auto / span 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      order: 3;
+      padding: 0;
+      @include breakpoint($bp-xs) {
+        grid-column: 1/5;
+        justify-content: center;
+      }
+      @include breakpoint($bp-small) {
+        justify-content: left;
+      }
+      @include breakpoint($bp-large) {
+        grid-column: 3/5;
+        justify-content: center;
+      }
+    }
+    .ama__button {
+      min-width: 33%;
+    }
+    &.promo-as-inline-gray {
+      background-color: $bg-gray;
+      .ama__button {
+        @extend .ama__button--complementary-secondary;
+      }
+    }
+    &.promo-as-inline-purple {
+      background-color: $bg-purple;
     }
   }
 
@@ -54,10 +126,6 @@
   .ama__image img {
     max-width: 100%;
     height: auto;
-  }
-
-  .ama__button--secondary {
-    width: 100%;
   }
 
   &--inline-banner {

--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -27,6 +27,9 @@
         padding-top: 25px;
       }
     }
+    &__sidebar--secondary {
+      padding-top:0;
+    }
   }
 
   .ama__news-heading {


### PR DESCRIPTION
## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
- [EWL-7951: Convert promo-as-inline content blocks to full-width](https://issues.ama-assn.org/browse/EWL-7951)

## Description
styles for inline promos


## To Test
- [ ] set up d8 for local styleguide development
- [ ] pull and serve branch
- [ ] see further testing instructions in d8 PR https://github.com/AmericanMedicalAssociation/ama-d8/pull/2058

## Visual Regressions

N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
