### PR TITLE
EWL-8008: Article Page Redesign Essential Tools and Services

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_tools.scss
+++ b/styleguide/source/assets/scss/03-organisms/_tools.scss
@@ -18,6 +18,7 @@
     @include gutter($padding-top-full...);
     @include gutter($padding-left-full...);
     @include gutter($padding-right-full...);
+    @include gutter($margin-bottom-full...);
     display: flex;
     flex-wrap: wrap;
     background: #F4F3F1;

--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -87,7 +87,7 @@
     @include breakpoint($bp-med min-width) {
       @include gutter($padding-left-full...);
       grid-column: 3;
-      grid-row: 2 / 4;
+      grid-row: 2 / auto;
     }
   } // end aside.secondary
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8008: Article Page Redesign Essential Tools and Services](https://issues.ama-assn.org/browse/EWL-8008)

## Description:
Moved Tools and Resources block from content region to main region on Event Detail pages to escape it from being processed as a additional accordion object. Added standard margin to bottom of Tools and Resources block to address spacing issues on Evergreen and Event Detail pages.


## To Test:
- Pull branch
- Pull [accompanying D8 branch](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2063)
- Configure local env to use local SG
- Run `drush @one.local cim -y && drush @one.local cr`
- Navigate to an Event Detail page and verify that the Tools and Resources section on each tab is rendering correctly in accordance to the Zeplin. See screenshot below for reported issue being addressed.
- Navigate to an Event Detail or Evergreen page and verify that when the Tools and Resources section is the last block on the page, there is a standard 28px margin between the bottom of the block and the footer.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
<img width="707" alt="thumbnail_image001" src="https://user-images.githubusercontent.com/57365587/85415409-ea2c8580-b532-11ea-9bf2-d28c088af09f.png">


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
