### PR TITLE
EWL-8007: Removing division from topic terms per business feedback.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -1,6 +1,5 @@
 .ama__tags,
 article[class*='__page-content'] .ama__tags {
-  @include ama-rules(1px, "bottom", $gray-7, solid);
   @include gutter($margin-top-full...);
   @include gutter($margin-bottom-full...);
   @include gutter($padding-top-full...);
@@ -8,6 +7,7 @@ article[class*='__page-content'] .ama__tags {
   display: flex;
   align-items: flex-start;
   flex-direction: column;
+  list-style: none;
   
   @include breakpoint($bp-small) {
     flex-direction: row;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-8007: Topic Terms business feedback](https://issues.ama-assn.org/browse/EWL-8007)

## Description
* Removing thin rule from the topic terms component.

## To Test
- [ ] Compile and go to any topic term horizontal gray line shouldn't be displayed anymore under `http://localhost:3000/?p=molecules-tags`


## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
The integration depends on this [PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2072) from AMA-D8 Repo

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
