### PR TITLE
EWL-8058: Global Change to margins of blockquote.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_block-quote.scss
+++ b/styleguide/source/assets/scss/02-molecules/_block-quote.scss
@@ -2,18 +2,18 @@ blockquote {
   display: flex;
   flex-direction: column;
   position: relative;
-  padding-left: 30px;
+  padding-left: 26px;
+  margin-left: initial;
+ 
   * {
     &:last-child {
       margin-bottom: 0;
     }
   }
   margin-bottom: 1em;
-  @include breakpoint($bp-med) {
-    padding-left: 13px;
-  }
-  @include breakpoint($bp-large) {
-    padding-left: 26px;
+  @include breakpoint($bp-small) {
+    margin-left: 30px;
+    padding-left: 30px;
   }
   p,
   a,

--- a/styleguide/source/assets/scss/02-molecules/_block-quote.scss
+++ b/styleguide/source/assets/scss/02-molecules/_block-quote.scss
@@ -12,8 +12,8 @@ blockquote {
   }
   margin-bottom: 1em;
   @include breakpoint($bp-small) {
-    margin-left: 30px;
-    padding-left: 30px;
+    padding-left: 26px;
+    margin: 0 30px;
   }
   p,
   a,

--- a/styleguide/source/assets/scss/02-molecules/_block-quote.scss
+++ b/styleguide/source/assets/scss/02-molecules/_block-quote.scss
@@ -12,8 +12,8 @@ blockquote {
   }
   margin-bottom: 1em;
   @include breakpoint($bp-small) {
-    padding-left: 26px;
-    margin: 0 30px;
+    margin-right: 30px;
+    margin-left: 30px;
   }
   p,
   a,


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-8058: Global Change_Block Quote](https://issues.ama-assn.org/browse/EWL-8058)

## Description
* Change of the margins of the component changing the molecule related to it.


## To Test
- [ ] Generate the styleguide assets
- [ ] Go to molecules / blockquote
- [ ] Ensure that component display with the margins in the right and left specified in the ticket and in Zeplin designs.


## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![Screen Shot 2020-07-01 at 7 40 51 PM](https://user-images.githubusercontent.com/5325044/86303960-07b4bb80-bbd3-11ea-9476-0b0fe288fd99.png)
![Screen Shot 2020-07-01 at 7 40 56 PM](https://user-images.githubusercontent.com/5325044/86303961-08e5e880-bbd3-11ea-8434-8b55b0d4898b.png)
![Screen Shot 2020-07-01 at 7 41 04 PM](https://user-images.githubusercontent.com/5325044/86303963-097e7f00-bbd3-11ea-91b5-5e3408864431.png)
![Screen Shot 2020-07-01 at 7 41 12 PM](https://user-images.githubusercontent.com/5325044/86303964-0a171580-bbd3-11ea-84e8-ac3c15a0edf5.png)


## Remaining Tasks
N/A

## Additional Notes
The integration of this component depends of this PR sent in [here](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2088) from ama-d8 repo
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
