### PR TITLE
EWL-8091: Mofiying icons for essentials tools and resources size

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_icons.scss
+++ b/styleguide/source/assets/scss/01-atoms/_icons.scss
@@ -63,7 +63,7 @@ $icons: (
   .icon--#{$name} {
     display: inline-block;
     background: url("../icons/svg/icon-" + $name + ".svg") no-repeat 0 0;
-    background-size: 40px 50px;
+    background-size: 33px 33px;
     min-height: 50px;
     min-width: 50px;
     max-height: 50px;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-8091: Change Ticket - 8028 Icons for Essential Tools & Resources Component](https://issues.ama-assn.org/browse/EWL-8091)

## Description
* Changing the background size of tools and resources component


## To Test
- [ ] Compile the styleguide assets
- [ ] Go to the following pages 
  * `http://localhost:3000/?p=pages-news`
  * `http://localhost:3000/?p=pages-category`
  * `http://localhost:3000/?p=pages-event`
  * `http://localhost:3000/?p=pages-press-release`

And ensure icons are consistent and now are displayed with the size of 33px X 33px



## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---
[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
