### PR TITLE
EWL-8111: Removing Extra Space in Featured Stories to match Zepling Designs

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -200,6 +200,10 @@
       font-size: 22px;
     }
   }
+
+  .ama__four-up-teaser {
+    margin: initial;
+  }
 }
 
 .ama__column-teaser {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-8111: Article Page Redesign - Featured Stories Extra Space below Headline](https://issues.ama-assn.org/browse/EWL-8111)

## Description
* Remove extra not needed margin on featured stories article stub

## To Test
- [ ] Just Compile assets `gulp serve`
- [ ] Clear cache `drush @one.local cr`
- [ ] Go to a page like `http://ama-one.local/residents-students/residency/without-travel-costs-residency-interviews-decline-sharply`
- [ ] Ensure no extra margin is displayed below the heading of `Featured Stories`

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
