### PR TITLE
EWL-8108: Fixing Extra space topic terms and tools and resources.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -39,25 +39,38 @@ article[class*='__page-content'] .ama__tags {
     
     
     li {
-      padding-bottom: 21px;
       margin-left: 0;
       list-style: none;
-      
+      padding-bottom: 14px;
+      padding-right: 18px;
+
+      &:nth-last-of-type(-n+3) {
+        padding-bottom: initial;
+      }
+
+      &:nth-last-of-type(2) {
+        @media only screen and (min-width: 991px) and (max-width: 1199px) {
+          padding-bottom: 14px;
+        }
+
+        @media only screen and (min-width: 768px) and (max-width: 990px) {
+          padding-bottom: 14px;
+        }
+      }
+
+      &:nth-last-of-type(-n+2) {
+        @media only screen and (min-width: 200px) and(max-width: $bp-small) {
+          padding-top: 14px;
+        }
+      }
+
       @include breakpoint($bp-small) {
         margin: initial;
-        padding-bottom: 18px;
       }
     }
-    
-    &:last-child {
-      margin-right: 0;
-    }
-  
   }
 
   .ama__tag {
-    @include gutter($margin-right-half...);
-    @include gutter($margin-bottom-half...);
     font-size: 14px;
     text-decoration: none;
     display: block;

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -2,13 +2,12 @@
 article[class*='__page-content'] .ama__tags {
   @include gutter($margin-top-full...);
   @include gutter($margin-bottom-full...);
-  @include gutter($padding-top-full...);
-  @include gutter($padding-bottom-full...);
   display: flex;
   align-items: flex-start;
   flex-direction: column;
   list-style: none;
-  
+
+ 
   @include breakpoint($bp-small) {
     flex-direction: row;
   }
@@ -40,12 +39,13 @@ article[class*='__page-content'] .ama__tags {
     
     
     li {
-      @include gutter($margin-bottom-full...);
+      padding-bottom: 21px;
       margin-left: 0;
       list-style: none;
       
       @include breakpoint($bp-small) {
         margin: initial;
+        padding-bottom: 18px;
       }
     }
     


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-8108: Article Page Redesign - Topic Terms](https://issues.ama-assn.org/browse/EWL-8108)

## Description
* Removing not needed space in Tags component

## To Test
- [ ] Compile assets `gulp serve`
- [ ] Clear Cache `drush @one.local cr`
- [ ] Go to a page that contains tags like `http://ama-one.local/residents-students/residency/without-travel-costs-residency-interviews-decline-sharply`
- [ ] Ensure that space between tags and tools and resources block are the same that the one specified in the designs.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs
![Screen Shot 2020-07-06 at 1 24 25 PM](https://user-images.githubusercontent.com/5325044/86626967-1dd4ca00-bf8d-11ea-9266-29d376c3ba1b.png)
![Screen Shot 2020-07-06 at 1 24 04 PM](https://user-images.githubusercontent.com/5325044/86626975-1f9e8d80-bf8d-11ea-93fe-867d7fd0654c.png)
![Screen Shot 2020-07-06 at 1 17 37 PM](https://user-images.githubusercontent.com/5325044/86626980-20372400-bf8d-11ea-926f-0dd929bef2ea.png)

## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
