### PR TITLE
EWL-8102: added styles to inline promo blocks. + EWL-8102

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -102,8 +102,6 @@
       }
       .ama__button {
         @extend .ama__button--complementary-secondary;
-        padding-left: 10px;
-        padding-right: 10px;
         min-width: 220px;
         max-width: 100%;
         @include breakpoint($bp-large) {

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -78,6 +78,8 @@
       @include breakpoint($bp-large) {
         grid-column: 1/3;
         padding-bottom: 0;
+        margin-right: 38px;
+        max-width: 566px;
       }
     }
     .inline-cta {
@@ -88,7 +90,7 @@
       padding: 0;
       grid-column: 1/5;
       justify-content: center;
-      width: auto;
+      margin-right: 0;
       order: 3;
       @include breakpoint($bp-small) {
         justify-content: left;
@@ -96,17 +98,19 @@
       @include breakpoint($bp-large) {
         grid-column: 3/5;
         justify-content: center;
-        margin-left: 14px;
         order: 1;
-        .ama__button {
-          width: 100%;
-        }
       }
       .ama__button {
-        min-width: 33%;
-        @include gutter($padding-right-full...);
-        @include gutter($padding-left-full...);
         @extend .ama__button--complementary-secondary;
+        padding-left: 10px;
+        padding-right: 10px;
+        min-width: 220px;
+        max-width: 100%;
+        @include breakpoint($bp-large) {
+          min-width: 0;
+          max-width: 220px;
+          width: 100%;
+        }
       }
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -14,8 +14,10 @@
     margin-bottom: 0;
 
     &:not(.membership_image) {
-      @include gutter($padding-left-full...);
-      @include gutter($padding-right-full...);
+      &:not(.ama__button) {
+        @include gutter($padding-left-full...);
+        @include gutter($padding-right-full...);
+      }
     }
   }
 


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8103: Promo-as-inline content block - Text Width, and margin between CTA](https://issues.ama-assn.org/browse/EWL-8103)
- [EWL-8102: Article Page Redesign Membership Custom Block CTA L/R Padding](https://issues.ama-assn.org/browse/EWL-8102)

## Description
Added max and min widths, changed padding values on inline promo blocks
combined with EWL-8102 due to them being related to the same sass partials.
removed padding override on membership cta blocks to make their l/r padding 10px.

## To Test
- [ ] set up d8 for local sg development. Pull and serve branch
- [ ] Add an inline promo to a news article and verify that it conforms to the specs in the ticket and zeplin. 
desktop max cta width 220px
max copy width 566px
right padding 38px
28px wrapper padding
10px padding on button L/R, 10px L/R on the membership promo CTAs as well.
button is properly responsive.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
