### PR TITLE
removed closeIcon var that was throwing GulpUglify error.

### DIFF
--- a/styleguide/source/assets/js/modal.js
+++ b/styleguide/source/assets/js/modal.js
@@ -76,9 +76,8 @@
 	}
 
 	function closeModal (context) {
-		let closeIcon = '.ui-icon-closethick';
-		$(closeIcon).unbind('click.close');
-		$(closeIcon).trigger('click');
+		$('.ui-icon-closethick').unbind('click.close');
+		$('.ui-icon-closethick').trigger('click');
 	}
 
 	Drupal.behaviors.ama_image_popup = {


### PR DESCRIPTION
**Jira Ticket**
N/A

## Description
GulpUglify was erroring on js minify due to a variable. The variable was barely used, so I switched back to a basic selector.

## To Test
- [ ] run gulp release
- [ ] verify that the release finishes successfully

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
