### PR TITLE
EWL-8085: Solve issue on hub cards IE div empty.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -109,10 +109,6 @@
 
   //IE11 hack becaue IE does not understand object-fit
   @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    // Select only first child div without any classes.
-    > div:not([class]) {
-      flex-shrink: 0;
-    }
 
     //This targets all hub cards in IE11
     &__image {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8127: Member Benefits Plus page layout broken in IE](https://issues.ama-assn.org/browse/EWL-8127)

## Description
* Removing wrong rule on IE for `flex-shrink` to allow container display columns properly


## To Test
- [ ] Go to a page like `amaone/ama-member-benefits-plus`
- [ ] Open it on IE and all other browsers
- [ ] Hub card should be displayed consistently on all browsers.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![Screen Shot 2020-07-28 at 3 49 18 PM](https://user-images.githubusercontent.com/5325044/88720444-7a3d8c00-d0ea-11ea-92d2-112bf574c73a.png)


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
