### PR TITLE
EWL-8015: bugfixes modal style reworking for centered image with left justified icon, ne…

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_modal.scss
+++ b/styleguide/source/assets/scss/02-molecules/_modal.scss
@@ -27,11 +27,20 @@
   }
   &__modal-link-wrapper{
     position: absolute;
-    bottom: 0;
+    bottom: 28px;
     right: 0;
+    height: 41px;
+    width: 41px;
     display: none;
     @include breakpoint($bp-small) {
       display:block;
+    }
+    .ama-image-popup-icon {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      background: url('../images/expand.svg') no-repeat 0px 0px;
+      background-size: cover;
     }
   }
 }
@@ -44,10 +53,12 @@ div[data-entity-embed-display="view_mode:media.modal"] {
       clear: both;
       width: 100%;
     }
+    @include breakpoint($bp-med) {
+      max-width: 50%;
+    }
     @include breakpoint($bp-large) {
       width: auto;
       margin-left: $gutter;
-      max-width: 50%;
     }
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_modal.scss
+++ b/styleguide/source/assets/scss/02-molecules/_modal.scss
@@ -1,19 +1,3 @@
-// Style right floated modals differently
-div[data-entity-embed-display="view_mode:media.modal"] {
-  &.align-right {
-    max-width: auto;
-    @include breakpoint($bp-xs) {
-      clear: both;
-      width: 100%;
-    }
-    @include breakpoint($bp-large) {
-      width: auto;
-      margin-left: $gutter;
-      max-width: 50%;
-    }
-  }
-}
-
 // General
 .ama__image_popup {
   &__wrapper {
@@ -51,6 +35,45 @@ div[data-entity-embed-display="view_mode:media.modal"] {
     }
   }
 }
+
+// Style right floated modals differently
+div[data-entity-embed-display="view_mode:media.modal"] {
+  &.align-right {
+    max-width: auto;
+    @include breakpoint($bp-xs) {
+      clear: both;
+      width: 100%;
+    }
+    @include breakpoint($bp-large) {
+      width: auto;
+      margin-left: $gutter;
+      max-width: 50%;
+    }
+  }
+}
+
+// Style full width modals differently.
+div[data-entity-embed-display="view_mode:media.modal"] {
+  .ama__type--small {
+    margin-left: 14px;
+  }
+  &:not(.align-right) {
+    .ama__image_popup__wrapper {
+      @include breakpoint($bp-small) {
+        padding: $gutter 50px $gutter 23px;
+      }
+      @include breakpoint($bp-med) {
+        padding: $gutter 45px;
+      }
+      @include breakpoint($bp-large) {
+        padding: $gutter 69px;
+      }
+    }
+  }
+}
+
+
+// Modal Window
 #drupal-modal {
   overflow: initial;
   img {
@@ -106,34 +129,4 @@ div[data-entity-embed-display="view_mode:media.modal"] {
 
 .ama-image-popup-modal .ui-dialog-titlebar-close:focus {
   outline: none;
-}
-
-// Style full width modals differently.
-div[data-entity-embed-display="view_mode:media.modal"] {
-  .ama__type--small {
-    margin-left: 14px;
-  }
-  &:not(.align-right) {
-    .ama__image_popup__wrapper {
-      @include breakpoint($bp-small) {
-        padding: $gutter 50px $gutter 23px;
-      }
-      @include breakpoint($bp-med) {
-        padding: $gutter 45px;
-      }
-      @include breakpoint($bp-large) {
-        padding: $gutter 69px;
-      }
-    }
-  }
-}
-
-.ama-image-popup-icon {
-  position: absolute;
-  width: 41px;
-  height: 41px;
-  background: url('../images/expand.svg') no-repeat 0px 0px;
-  background-size: cover;
-  bottom: 33px;
-  right:0;
 }

--- a/styleguide/source/assets/scss/02-molecules/_modal.scss
+++ b/styleguide/source/assets/scss/02-molecules/_modal.scss
@@ -137,7 +137,3 @@ div[data-entity-embed-display="view_mode:media.modal"] {
   bottom: 33px;
   right:0;
 }
-.ajax-progress.ajax-progress-throbber {
-  display:none;
-  position:absolute;
-}

--- a/styleguide/source/assets/scss/02-molecules/_modal.scss
+++ b/styleguide/source/assets/scss/02-molecules/_modal.scss
@@ -1,46 +1,58 @@
+// Style right floated modals differently
+div[data-entity-embed-display="view_mode:media.modal"] {
+  &.align-right {
+    max-width: auto;
+    @include breakpoint($bp-xs) {
+      clear: both;
+      width: 100%;
+    }
+    @include breakpoint($bp-large) {
+      width: auto;
+      margin-left: $gutter;
+      max-width: 50%;
+    }
+  }
+}
+
+// General
 .ama__image_popup {
   &__wrapper {
     display: inline-flex;
+    position: relative;
     @include breakpoint($bp-xs) {
-      width:100%;
+      width: 100%;
       clear: both;
-      margin: $gutter/2 0;
+      padding: none;
     }
     @include breakpoint($bp-small) {
       clear: none;
-      width: auto;
-      margin: $gutter/2;
+      padding: $gutter 50px $gutter 0;
     }
   }
   &__image {
     @include breakpoint($bp-xs) {
       width: 100%;
+      max-width:100%;
     }
     @include breakpoint($bp-small) {
-      width: auto;
+      max-width: 100%;
     }
     img {
       margin: 0;
     }
   }
   &__modal-link-wrapper{
-    width: 79px;
-    padding: 0 0 0 0.5em;
-    position: relative;
-    display: none;
-    @include breakpoint($bp-med) {
-      display:block;
-    }
-  }
-  &__icon {
     position: absolute;
     bottom: 0;
-    margin: 0;
+    right: 0;
+    display: none;
+    @include breakpoint($bp-small) {
+      display:block;
+    }
   }
 }
 #drupal-modal {
   overflow: initial;
-
   img {
     max-height: 80vh;
     max-width: 95vw;
@@ -59,7 +71,7 @@
 }
 
 .embed-entity--caption div[data-entity-embed-display="view_mode:media.modal"] + figcaption {
-  margin: 0 14px 14px 14px;
+  margin: 0 $gutter/2 $gutter/2 $gutter/2;
 }
 
 .ama-image-popup-modal .ui-dialog-title,
@@ -87,8 +99,8 @@
   position: absolute;
   right: -20px;
   top: -10px;
-  height: 28px;
-  width: 28px;
+  height: $gutter;
+  width: $gutter;
   padding: 0;
 }
 
@@ -96,9 +108,23 @@
   outline: none;
 }
 
+// Style full width modals differently.
 div[data-entity-embed-display="view_mode:media.modal"] {
   .ama__type--small {
     margin-left: 14px;
+  }
+  &:not(.align-right) {
+    .ama__image_popup__wrapper {
+      @include breakpoint($bp-small) {
+        padding: $gutter 50px $gutter 23px;
+      }
+      @include breakpoint($bp-med) {
+        padding: $gutter 45px;
+      }
+      @include breakpoint($bp-large) {
+        padding: $gutter 69px;
+      }
+    }
   }
 }
 
@@ -108,5 +134,10 @@ div[data-entity-embed-display="view_mode:media.modal"] {
   height: 41px;
   background: url('../images/expand.svg') no-repeat 0px 0px;
   background-size: cover;
-  bottom: 5px;
+  bottom: 33px;
+  right:0;
+}
+.ajax-progress.ajax-progress-throbber {
+  display:none;
+  position:absolute;
 }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8015: modals](https://issues.ama-assn.org/browse/EWL-8015)

## Description
modal style reworking for centered image with left justified icon, new 100% width breakpoints. Modal is now present as low as 768px, new responsive margins.


## To Test
- [ ] set up d8 for local sg
- [ ] pull and serve branch
- [ ] add a right floated modal and a modal with no alignment. Experiment with very tall or wide images.
- [ ] verify that right floated modals are max 50% of width and have a good left margin. verify that the image 
- [ ] verify that the image goes 100% width on tablet, and there is no strange text wrapping. 
- [ ] verify that the modal icon disappears below 768px
- [ ] verify all these things for full-width modals minus the max-width.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
