### PR TITLE
EWL-8122: Index Page Redesign - Right Rail Promos

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
+++ b/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
@@ -26,9 +26,15 @@
   &__right {
     > div {
       margin-top:0;
-      margin-bottom: $gutter;
+      margin-bottom: ($gutter *2);
       &:last-child {
         margin-bottom: 0;
+      }
+      @include breakpoint($bp-med max-width) {
+        margin-bottom: $gutter;
+      }
+      @include breakpoint($bp-small max-width) {
+        margin-bottom: 21px;
       }
     }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8122: Index Page Redesign - Right Rail Promos](https://issues.ama-assn.org/browse/EWL-8122)

## Description
Added 56px bottom margins to right rail blocks on Index pages. Added $bp-med and $bp-small breakpoints with 28px and 21px bottom margins respectively as per [ticket AC](https://issues.ama-assn.org/browse/EWL-8122).


## To Test
- Pull branch
- Set up local env to use local SG
- Run `gulp`
- Navigate to an Index page with at least two promo blocks in the right rail. Verify the above margin-settings as per ticket AC.
- See D8 PR for additional testing reqs.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
[D8 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2154)
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
