### PR TITLE
EWL-8118 Address UAT Fail Feedback (Remove extra Related Topics whitespace)

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_topic-index.scss
+++ b/styleguide/source/assets/scss/05-pages/_topic-index.scss
@@ -56,7 +56,7 @@
   }
 
   a {
-    margin: 0 8px 0 0;
+    margin: 0;
     font-size:18px;
     outline: 0;
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8118: Index Page Redesign_Related Topics](https://issues.ama-assn.org/browse/EWL-8118)

## Description
Removed extra margin creating undesired space between Related Topics listings on Index page; this addresses UAT FAIL feedback from 8/18/20.


## To Test
- [ ] Pull branch
- [ ] Configure local env to use local SG
- [ ] Navigate to an Index page that has more than one Related Topic item and verify that there is no extra whitespace in between items. See ticket UAT feedback comment and attacked 8118.docx example for more details.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
