### PR TITLE
EWL-8123: Index Page Redesign_Description Mobile Fix

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_topic-index.scss
+++ b/styleguide/source/assets/scss/05-pages/_topic-index.scss
@@ -1,6 +1,9 @@
 .description {
   position: relative;
   margin-bottom: $gutter / 2;
+  @include breakpoint($bp-small max-width) {
+    margin-bottom: 21px;
+  }
   .desc-display {
     position: relative;
     overflow: hidden;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8123: Index Page Redesign_Description Copy](https://issues.ama-assn.org/browse/EWL-8123)

## Description
Addresses UAT FAIL feedback on Index page description block; mobile breakpoint now has 21px bottom margin as opposed to Desktop/Tablet 14px bottom margin.


## To Test
- [ ] Pull branch
- [ ] Set up local env to use local SG
- [ ] Navigate to an Index Page with a description long enough to enable the Read More functionality. Verify that the bottom margin for this area is 21px on mobile, and remains 14px for desktop/tablet.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
