### PR TITLE
removed position relative from listicle lis

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -7,7 +7,6 @@
   &__item {
 
     counter-increment: ama-listicle;
-    position: relative;
     margin-left: 43px;
     margin-bottom: 19px;
     @include gutter($margin-top-half...);


### PR DESCRIPTION
## Ticket(s)
N/A

## Description
listicles were overlapping modals and causing them to be unclickable
removed position: relative to fix issue


## To Test
- [ ] pull and serve branch
- [ ] make a listicle beneath a right floated modal.
- [ ] verify that the modal is clickable.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
