### PR TITLE
EWL-8258: Add styling for article stub list header including layout builder.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
+++ b/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
@@ -5,3 +5,20 @@
   font-weight: $font-weight-regular;
   padding: ($gutter / 4) $gutter ($gutter / 4) ($gutter / 2);
 }
+
+//Subcat specific header styling
+.js-layout-builder-block.ama__category-page-article-stub .ama_article-stub-header,
+.ama__subcategory-index .ama_article-stub-header {
+  display: block;
+  background: none;
+  color: black;
+  padding: 0;
+  font-weight: $font-weight-semibold;
+  font-size: 26px;
+  line-height: 31px;
+  text-transform: uppercase;
+  margin-bottom: 21px;
+  @include breakpoint($bp-med min-width) {
+    margin-bottom: 28px;
+  }
+}

--- a/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
+++ b/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
@@ -22,3 +22,12 @@
     margin-bottom: 28px;
   }
 }
+
+//Remove mobile top padding from first article stub item
+.ama__category__article-stub-three-up .grid-container {
+  .ama__article-stub:first-of-type {
+    @include breakpoint($bp-med max-width) {
+      padding-top: 0;
+    }
+  }
+}


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-8258: Subcat | Change Style of Article Stub List Title in Layout Builder](https://issues.ama-assn.org/browse/EWL-8258)

## Description
Added styling for Article stub headers on Subcategory pages and on subcat layout builder.


## To Test
- Checkout the ama-d8 PR here to pull in a new class: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2303](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2303)
- Navigate to subcategory page with an article stub list block that has a header or create one. Example can be found here: /delivering-care/public-health.
- Confirm header text of article stub list matches the following zeplins, on the page and the layout builder.

[Zeplin Desktop](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f062b544417237955daff6e)

[Zeplin Tablet](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f3fe827e829bd331bd42fdb)

[Zeplin Mobile](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f3fe82b12485e157ba260ab)

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- View with the ama-d8 PR here to ensure the proper classes are present. [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2303](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2303)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
