### PR TITLE
EWL-8284: Add styling to account for on-page anchor link offset when opening in…

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_table-of-contents.scss
+++ b/styleguide/source/assets/scss/02-molecules/_table-of-contents.scss
@@ -45,3 +45,15 @@
     display: none;
   }
 }
+.ama-toc-link {
+  position: relative;
+  .dupe {
+    visibility: hidden;
+    position: absolute;
+    left: 0px;
+    top: -60px;
+  }
+}
+body.toolbar-horizontal .ama-toc-link .dupe {
+  top: -140px;
+}


### PR DESCRIPTION
… new tab or window

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-8284: External TOC Anchor Links Set Page Scroll Before Menu Ribbon Loads](https://issues.ama-assn.org/browse/EWL-8284)

## Description
Adds styling to account for sticky nav offset on on-page anchor links open into new tabs or windows.


## To Test
- Sync styling and view with PR: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2313](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2313). Confirm on page anchor links opening in new tab or window 'scrolls to' the correct header and is not covered by the navigation bar.

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes

Checkout and view in tandem with the following PR: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2313](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2313)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
