### PR TITLE
EWL-8257: Styling for slim subcategory membership block

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -64,3 +64,129 @@ a.ama__membership {
     background: darken(#DAD5DE, 8%);
   }
 }
+
+.ama__membership.subcat-membership-block {
+  height: 210px;
+  width: 320px;
+  margin: 0 auto;
+  position: relative;
+  @include breakpoint($bp-small min-width) {
+    height: unset;
+    width: unset;
+    margin: 0;
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+  padding-bottom: 0;
+  .ama__membership_logo-container {
+    display: block;
+    width: 100%;
+    height: 40px;
+    @include breakpoint($bp-small min-width) {
+      width: 102px;
+      height: 44px;
+    }
+    @include breakpoint($bp-large min-width) {
+      width: 200px;
+      height: 70px; 
+    }
+    padding: 0;
+    &+ div {
+      display: block;
+      padding-left: 0;
+      padding-right: 0;
+      margin-top: 14px;
+      @include breakpoint($bp-small min-width) {
+        width: 90%;
+        -webkit-box-orient: horizontal;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        position: relative;
+        -webkit-box-flex: 1;
+        -ms-flex: 1;
+        flex: 1;
+        margin-top: 7px;
+      }
+      @include breakpoint($bp-large min-width) {
+        margin-top: 20px;
+        padding-right: 28px;
+      }
+    }
+    .ama__site-logo {
+      display: block;
+      position: relative;
+      height: 44px;
+      @include breakpoint($bp-large min-width) {
+        height: 70px;
+      }
+      .logo {
+        height: 31px;
+        width: 76px;
+        position: absolute;
+        top: 15%;
+        left: 2.3%;
+        @include breakpoint($bp-small min-width) {
+          left: 12%;
+        }
+        @include breakpoint($bp-large min-width) {
+          top: 20%;
+          left: 25%;
+          height: 42px;
+          width: 105px;
+        }
+      }
+    }
+  }
+  h2 {
+    margin-bottom: 0;
+    padding-left: 0;
+    text-align: center;
+    @include breakpoint($bp-small min-width) {
+      padding-left: 6.65%;
+      text-align: left;
+    }
+    @include breakpoint($bp-med min-width) {
+      padding-left: 8%;
+    }
+    @include breakpoint($bp-large min-width) {
+      padding-left: 17%;
+    }
+    //Hide description/block content
+    &+ div {
+      display: none;
+    }
+  }
+  a.ama__button {
+    padding: 7px 22px;
+    font-size: 18px;
+    margin: 0 auto;
+    display: block;
+    width: 224px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 21px;
+    @include breakpoint($bp-small min-width) {
+      display: inline-block;
+      width: unset;
+      margin: 0;
+      right: 0px;
+      top: -7px;
+      left: unset;
+      bottom: unset;
+      padding: 8.5px 22px;
+      height: 44px;
+    }
+    @include breakpoint($bp-large min-width) {
+      margin-right: 2.6%;
+      font-size: 20px;
+      top: -10px;
+      padding: 10.5px 35px;
+      height: unset;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -93,6 +93,7 @@ a.ama__membership {
       width: 200px;
       height: 70px; 
     }
+
     &+ div {
       display: block;
       padding-left: 0;
@@ -115,6 +116,7 @@ a.ama__membership {
         padding-right: 28px;
       }
     }
+
     .logo {
       height: 31px;
       width: 76px;
@@ -131,6 +133,7 @@ a.ama__membership {
         width: 105px;
       }
     }
+
     .ama__site-logo {
       display: block;
       position: relative;

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -69,7 +69,7 @@ a.ama__membership {
   background: #ece7f0;
   width: 100%;
   height: 210px;
-  margin: 0 0 21px;
+  margin: 0 0 35px;
   position: relative;
   @include breakpoint($bp-small min-width) {
     height: unset;
@@ -78,6 +78,8 @@ a.ama__membership {
     -webkit-box-direction: normal;
     -ms-flex-direction: row;
     flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
   }
 
   .ama__membership_logo-container {
@@ -89,32 +91,9 @@ a.ama__membership {
       width: 102px;
       height: 44px;
     }
-    @include breakpoint($bp-large min-width) {
+    @include breakpoint($bp-med min-width) {
       width: 200px;
       height: 70px; 
-    }
-
-    &+ div {
-      display: block;
-      padding-left: 0;
-      padding-right: 0;
-      margin-top: 14px;
-      @include breakpoint($bp-small min-width) {
-        width: 90%;
-        -webkit-box-orient: horizontal;
-        -webkit-box-direction: normal;
-        -ms-flex-direction: row;
-        flex-direction: row;
-        position: relative;
-        -webkit-box-flex: 1;
-        -ms-flex: 1;
-        flex: 1;
-        margin-top: 7px;
-      }
-      @include breakpoint($bp-large min-width) {
-        margin-top: 20px;
-        padding-right: 28px;
-      }
     }
 
     .logo {
@@ -126,7 +105,7 @@ a.ama__membership {
       @include breakpoint($bp-small min-width) {
         left: 12%;
       }
-      @include breakpoint($bp-large min-width) {
+      @include breakpoint($bp-med min-width) {
         top: 20%;
         left: 25%;
         height: 42px;
@@ -138,9 +117,59 @@ a.ama__membership {
       display: block;
       position: relative;
       height: 44px;
-      @include breakpoint($bp-large min-width) {
+      @include breakpoint($bp-med min-width) {
         height: 70px;
       }
+    }
+  }
+  .ama__membership_title_container {
+    display: block;
+    padding-left: 0;
+    padding-right: 0;
+    margin: 0;
+    @include breakpoint($bp-small min-width) {
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      -webkit-box-flex: 2;
+      -ms-flex: 2;
+      flex: 2.28;
+      flex-grow: 4;
+    }
+    @include breakpoint($bp-med min-width) {
+      flex-grow: 4;
+    }
+  }
+  .ama__membership_cta_container {
+    margin: 0 auto;
+    display: block;
+    max-width: 75%; 
+    text-align: center;
+    position: absolute;
+    bottom: 21px;
+    left: 0;
+    right: 0;
+    @include breakpoint($bp-small min-width) {
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      position: relative;
+      -webkit-box-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      flex-grow: 2.28;
+      text-align: right;
+      position: relative;
+      bottom: 0;
+    }
+    @include breakpoint($bp-med min-width) {
+      text-align: center;
+      flex-grow: 3;
+    }
+    @include breakpoint($bp-large min-width) {
+      flex-grow: 2;
     }
   }
   h2 {
@@ -149,53 +178,31 @@ a.ama__membership {
     padding-left: 16%;
     padding-right: 16%;
     text-align: center;
+    font-size: 20px;
     @include breakpoint($bp-small min-width) {
       margin-top: 0;
-      padding-left: 6.65%;
-      text-align: left;
-      line-height: 44px;
+      padding: 0;
     }
     @include breakpoint($bp-med min-width) {
-      padding-left: 8%;
-    }
-    @include breakpoint($bp-large min-width) {
-      padding-left: 17%;
-      line-height: 70px;
-    }
-    //Hide description/block content
-    &+ div {
-      display: none;
+      font-size: 1.444em;
     }
   }
   a.ama__button {
     padding: 0 22px;
     font-size: 18px;
-    margin: 0 auto;
-    display: block;
-    width: 224px;
     height: 50px;
     line-height: 50px;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 21px;
+    font-size: 20px;
     @include breakpoint($bp-small min-width) {
       display: inline-block;
-      width: unset;
       margin: 0;
-      right: 0px;
-      top: 0px;
-      left: unset;
-      bottom: unset;
-      padding: 0 22px;
+      padding: 0 12px;
       height: 44px;
       line-height: 44px;
+      font-size: 15px;
     }
-    @include breakpoint($bp-large min-width) {
-      margin-right: 2.6%;
+    @include breakpoint($bp-med min-width) {
       font-size: 20px;
-      top: 10px;
-      padding: 0 35px;
       height: 50px;
       line-height: 50px;
     }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -66,14 +66,14 @@ a.ama__membership {
 }
 
 .ama__membership.subcat-membership-block {
+  width: 100%;
   height: 210px;
-  width: 320px;
-  margin: 0 auto;
+  margin: 0 auto 21px;
   position: relative;
   @include breakpoint($bp-small min-width) {
-    height: unset;
     width: unset;
-    margin: 0;
+    height: unset;
+    margin: 0 0 21px;
     display: flex;
     -webkit-box-orient: horizontal;
     -webkit-box-direction: normal;
@@ -85,6 +85,7 @@ a.ama__membership {
     display: block;
     width: 100%;
     height: 40px;
+    position: relative;
     @include breakpoint($bp-small min-width) {
       width: 102px;
       height: 44px;
@@ -116,6 +117,22 @@ a.ama__membership {
         padding-right: 28px;
       }
     }
+    .logo {
+      height: 31px;
+      width: 76px;
+      position: absolute;
+      top: 15%;
+      left: 2.3%;
+      @include breakpoint($bp-small min-width) {
+        left: 12%;
+      }
+      @include breakpoint($bp-large min-width) {
+        top: 20%;
+        left: 25%;
+        height: 42px;
+        width: 105px;
+      }
+    }
     .ama__site-logo {
       display: block;
       position: relative;
@@ -123,27 +140,11 @@ a.ama__membership {
       @include breakpoint($bp-large min-width) {
         height: 70px;
       }
-      .logo {
-        height: 31px;
-        width: 76px;
-        position: absolute;
-        top: 15%;
-        left: 2.3%;
-        @include breakpoint($bp-small min-width) {
-          left: 12%;
-        }
-        @include breakpoint($bp-large min-width) {
-          top: 20%;
-          left: 25%;
-          height: 42px;
-          width: 105px;
-        }
-      }
     }
   }
   h2 {
-    margin-bottom: 0;
-    padding-left: 0;
+    margin: 0;
+    padding: 0 16%;
     text-align: center;
     @include breakpoint($bp-small min-width) {
       padding-left: 6.65%;

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -65,22 +65,21 @@ a.ama__membership {
   }
 }
 
-.ama__membership.subcat-membership-block {
+.subcat-membership-block {
+  background: #ece7f0;
   width: 100%;
   height: 210px;
-  margin: 0 auto 21px;
+  margin: 0 0 21px;
   position: relative;
   @include breakpoint($bp-small min-width) {
-    width: unset;
     height: unset;
-    margin: 0 0 21px;
     display: flex;
     -webkit-box-orient: horizontal;
     -webkit-box-direction: normal;
     -ms-flex-direction: row;
     flex-direction: row;
   }
-  padding-bottom: 0;
+
   .ama__membership_logo-container {
     display: block;
     width: 100%;
@@ -94,7 +93,6 @@ a.ama__membership {
       width: 200px;
       height: 70px; 
     }
-    padding: 0;
     &+ div {
       display: block;
       padding-left: 0;
@@ -143,18 +141,23 @@ a.ama__membership {
     }
   }
   h2 {
-    margin: 0;
-    padding: 0 16%;
+    margin-top: 14px;
+    margin-bottom: 0;
+    padding-left: 16%;
+    padding-right: 16%;
     text-align: center;
     @include breakpoint($bp-small min-width) {
+      margin-top: 0;
       padding-left: 6.65%;
       text-align: left;
+      line-height: 44px;
     }
     @include breakpoint($bp-med min-width) {
       padding-left: 8%;
     }
     @include breakpoint($bp-large min-width) {
       padding-left: 17%;
+      line-height: 70px;
     }
     //Hide description/block content
     &+ div {
@@ -162,11 +165,13 @@ a.ama__membership {
     }
   }
   a.ama__button {
-    padding: 7px 22px;
+    padding: 0 22px;
     font-size: 18px;
     margin: 0 auto;
     display: block;
     width: 224px;
+    height: 50px;
+    line-height: 50px;
     position: absolute;
     left: 0;
     right: 0;
@@ -176,18 +181,20 @@ a.ama__membership {
       width: unset;
       margin: 0;
       right: 0px;
-      top: -7px;
+      top: 0px;
       left: unset;
       bottom: unset;
-      padding: 8.5px 22px;
+      padding: 0 22px;
       height: 44px;
+      line-height: 44px;
     }
     @include breakpoint($bp-large min-width) {
       margin-right: 2.6%;
       font-size: 20px;
-      top: -10px;
-      padding: 10.5px 35px;
-      height: unset;
+      top: 10px;
+      padding: 0 35px;
+      height: 50px;
+      line-height: 50px;
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
@@ -10,6 +10,13 @@
     margin-top: $gutter;
   }
 
+  .ama__category-page-article-stub {
+    padding: 0 15px;
+    @include breakpoint($bp-small) {
+      padding: 0;
+    }
+
+  }
   .ama__subcategory-page-article-stub {
 
     &:nth-child(n+7) {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-8257: Subcat | Full-Width Slim Display of Membership Custom Block](https://issues.ama-assn.org/browse/EWL-8257)

## Description
Added styling for subcategory slim membership block.


## To Test
- Checkout and follow instructions within the following AMA PR: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2319](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2319)
- Confirm styling follows the attached Zeplin designs below:

[Desktop](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f062b544417237955daff6e)

[Tablet](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f3fe827e829bd331bd42fdb)

[Mobile](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f3fe82b12485e157ba260ab)

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:

- Relevant PR here with code for membership block: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2319](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2319)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
