### PR TITLE
EWL-8144: Add rule to divide bio and index items on People Bio template

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -1,7 +1,7 @@
 .ama__tags,
 article[class*='__page-content'] .ama__tags {
   @include gutter($margin-top-full...);
-  margin-bottom: $gutter / 2;
+  margin-bottom: $gutter;
   display: flex;
   align-items: flex-start;
   flex-direction: column;

--- a/styleguide/source/assets/scss/03-organisms/_user-article-listing.scss
+++ b/styleguide/source/assets/scss/03-organisms/_user-article-listing.scss
@@ -1,7 +1,7 @@
 .ama__user-article-listing {
   border-bottom: 1px solid #ededed;
   display: flex;
-  padding: 30px 0;
+  padding: $gutter 0;
   flex-direction: column-reverse;
 
   @include breakpoint($bp-small) {

--- a/styleguide/source/assets/scss/05-pages/_people_bio.scss
+++ b/styleguide/source/assets/scss/05-pages/_people_bio.scss
@@ -26,10 +26,20 @@
     @include gutter($margin-bottom-full...);
   }
   .user-article-listing-view {
+    border-top: solid 2px #ededed;
     > ul > li {
       display: flex;
       justify-content: center;
       padding-top: 60px;
+    }
+    .article-listing__link:first-of-type > .ama__user-article-listing {
+      //Spacing override for horizontal rule line above
+      @include breakpoint($bp-large max-width) {
+        padding-top: 37px;
+      }
+      @include breakpoint($bp-med max-width) {
+        padding-top: 36px;
+      }
     }
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_people_bio.scss
+++ b/styleguide/source/assets/scss/05-pages/_people_bio.scss
@@ -33,12 +33,9 @@
       padding-top: 60px;
     }
     .article-listing__link:first-of-type > .ama__user-article-listing {
-      //Spacing override for horizontal rule line above
-      @include breakpoint($bp-large max-width) {
-        padding-top: 37px;
-      }
-      @include breakpoint($bp-med max-width) {
-        padding-top: 36px;
+      padding-top: 36px;
+      @include breakpoint($bp-small) {
+        padding-top: $gutter;
       }
     }
   }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-8144: Add rule to divide bio and index items on People Bio template](https://issues.ama-assn.org/browse/EWL-8144)

## Description
Added border top property to create horizontal rule line in people bio scss file.


## To Test
- Navigate to People Bio template (Ex: /news-leadership-viewpoints/authors-news-leadership-viewpoints/sara-berg) and confirm rule line conforms with the styling in the following Zeplins:

[Desktop](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5e4accbd13889ea8a35d642e)

[Tablet](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5e4accbd603637ab964bcedb)

[Mobile](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5e4accbd465f0cab81aae69e)

**NOTE**: The spacing above the line is supposed to be 28px across screen sizes, this is tricky to confirm since the spacing above is created by the ama__tags elements. But from what I can tell, the bottom padding from the container and first list item adds up to the required space.

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
