### PR TITLE
EWL-8257: Adjusted styling for membership blocks to fit with new slim…

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -15,10 +15,16 @@
 
     &:not(.membership_image) {
       &:not(.ama__button) {
-        @include gutter($padding-left-full...);
-        @include gutter($padding-right-full...);
+        &:not(.ama__membership_cta_container) {
+          @include gutter($padding-left-full...);
+          @include gutter($padding-right-full...);
+        }
       }
     }
+  }
+
+  .ama__h2 {
+    margin-bottom: 0;
   }
 
   &_logo-container {
@@ -48,9 +54,13 @@
     }
   }
 
-  .ama__button {
-    @include gutter($margin-left-full...);
-    @include gutter($margin-right-full...);
+  .ama__membership_cta_container {
+    display: block;
+    margin: 0 28px;
+    .ama__button {
+      margin: 0;
+      width: 100%;
+    }
   }
   @extend .display-list;
 }
@@ -65,12 +75,19 @@ a.ama__membership {
   }
 }
 
-.subcat-membership-block {
+//Hide ama logo in membership block in all instances besides below
+.ama__membership_logo-container .logo {
+  display: none;
+}
+
+//Slim Membership Block styling
+.layout--ama-page-section-one-col .ama__membership {
   background: #ece7f0;
   width: 100%;
   height: 210px;
   margin: 0 0 35px;
   position: relative;
+  padding-bottom: 0;
   @include breakpoint($bp-small min-width) {
     height: unset;
     display: flex;
@@ -82,11 +99,30 @@ a.ama__membership {
     align-items: center;
   }
 
+  // Remove margins on child elements so that we can set consistent spacing elsewhere.
+  & > * {
+    margin-bottom: 0;
+
+    &:not(.membership_image) {
+      &:not(.ama__button) {
+        &:not(.ama__membership_cta_container) {
+          padding: unset;
+        }
+      }
+    }
+  }
+
+  //hide description
+  .membership-body {
+    display: none;
+  }
+
   .ama__membership_logo-container {
     display: block;
     width: 100%;
     height: 40px;
     position: relative;
+    padding: 0;
     @include breakpoint($bp-small min-width) {
       width: 102px;
       height: 44px;
@@ -97,6 +133,7 @@ a.ama__membership {
     }
 
     .logo {
+      display: block;
       height: 31px;
       width: 76px;
       position: absolute;
@@ -172,7 +209,7 @@ a.ama__membership {
       flex-grow: 2;
     }
   }
-  h2 {
+  h2.ama__h2 {
     margin-top: 14px;
     margin-bottom: 0;
     padding-left: 16%;
@@ -193,6 +230,7 @@ a.ama__membership {
     height: 50px;
     line-height: 50px;
     font-size: 20px;
+    width: unset;
     @include breakpoint($bp-small min-width) {
       display: inline-block;
       margin: 0;

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -57,6 +57,9 @@
   .ama__membership_cta_container {
     display: block;
     margin: 0 28px;
+    @include breakpoint($bp-med min-width) {
+      margin-top: 14px;
+    }
     .ama__button {
       margin: 0;
       width: 100%;
@@ -172,10 +175,7 @@ a.ama__membership {
       -webkit-box-flex: 2;
       -ms-flex: 2;
       flex: 2.28;
-      flex-grow: 4;
-    }
-    @include breakpoint($bp-med min-width) {
-      flex-grow: 4;
+      flex-grow: 6;
     }
   }
   .ama__membership_cta_container {
@@ -202,7 +202,6 @@ a.ama__membership {
       bottom: 0;
     }
     @include breakpoint($bp-med min-width) {
-      text-align: center;
       flex-grow: 3;
     }
     @include breakpoint($bp-large min-width) {
@@ -215,7 +214,7 @@ a.ama__membership {
     padding-left: 16%;
     padding-right: 16%;
     text-align: center;
-    font-size: 20px;
+    font-size: 26px;
     @include breakpoint($bp-small min-width) {
       margin-top: 0;
       padding: 0;
@@ -231,6 +230,7 @@ a.ama__membership {
     line-height: 50px;
     font-size: 20px;
     width: unset;
+    overflow: hidden;
     @include breakpoint($bp-small min-width) {
       display: inline-block;
       margin: 0;
@@ -243,6 +243,7 @@ a.ama__membership {
       font-size: 20px;
       height: 50px;
       line-height: 50px;
+      margin-right: 28px;
     }
   }
 }


### PR DESCRIPTION
… membership block placement.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-8257: Subcat | Full-Width Slim Display of Membership Custom Block](https://issues.ama-assn.org/browse/EWL-8257)

## Description
Adjusted styling to fit the simplified method of Membership block placement on subcat pages.


## To Test
- Checkout and follow instructions for the following PR: [Slim Membership Config and Template update](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2330)
- Follow instructions in ama-d8 PR to place a Membership block on a subcat page
- With latest styling synced to local, navigate to subcat page and confirm it follows the Zeplin designs below: 

[Desktop](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f062b544417237955daff6e)

[Tablet](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f3fe827e829bd331bd42fdb)

[Mobile](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f3fe82b12485e157ba260ab)

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes

**NOTE**: Provides styling for the following PR: [EWL-8257 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2330)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
