### PR TITLE
EWL-8370: Allowing tags to be rendered properly on subtitle full text and trimmed text.

### DIFF
--- a/styleguide/source/assets/js/index-page.js
+++ b/styleguide/source/assets/js/index-page.js
@@ -5,8 +5,8 @@
       var full = $('.fulltext')
       var trunc = $('.truncated')
       var desc = $('.desc-display')
-      var fullText = $('.fulltext').html()
-      var truncated = $('.truncated').html()
+      var fullText = $.parseHTML($('.fulltext').html())[0]['data']
+      var truncated = $.parseHTML($('.truncated').html())[0]['data']
       var fullHeight = ''
       var truncHeight = ''
       var moreHtml = '<a href="#" class="more"> ...Read More</a>'


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8370: Formatting changes on subtitle text when user toggles between Read More and Hide Content](https://issues.ama-assn.org/browse/EWL-8370)

## Description
* Adding the ability to parse HTML to `fullText` and `truncated` since backend is safetly providing HTML tags to be rendered on the fly when `...Read more` or `Hide Content` is clicked.


## To Test
- [ ] Once this [PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2342) from the ama-d8 repo is merged compile assets and go to a page like `https://ama-one.lndo.site/councils/council-ethical-judicial-affairs`
- [ ] Click on `...Read More`
- [ ] Click on `Hide Content`
- [ ] If content contains HTML like `<em><strong><u><s>` Should be displayed properly

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
- This [PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2342) should be merged and tested directly on Drupal
- I noticed that content provided from the editor in the ckeditor contains lot of `<spans>` but are ignored. For now I just add the basic tags to be rendered like italics, bold, underline and strikethrough


---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
