### PR TITLE
EWL-8376: Adding marging to the bottom of custom video block according specs

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_video-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_video-block.scss
@@ -6,10 +6,12 @@
   margin: $gutter/3 15px;
   justify-content: center;
   align-items: stretch;
+  margin-bottom: 35px;
   @include breakpoint($bp-small) {
     flex-direction: row;
     margin: $gutter/3 0;
     padding: $gutter/2 7%;
+    margin-bottom: 42px;
   }
   @include breakpoint($bp-large) {
     padding: $gutter/4*3 7%;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8376: Adjust bottom padding of Video Card custom block in Layout Builder](https://issues.ama-assn.org/browse/EWL-8376)

## Description
* Adding right margin bottom to the video block component.


## To Test
- [ ] Add to a page or visit one that contains a custom video block
- [ ] Ensure that video wrapper matches margin on mobile (35px) and desktop (42px)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
