### PR TITLE
 Move up right rail promos vertically on Subcategory pages.

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
+++ b/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
@@ -6,21 +6,32 @@
   display: grid;
   grid-template-columns: 3fr 1fr;
   grid-template-rows: auto auto auto;
+  grid-template-areas: 'content sidebar'
+                        'content_below sidebar';
 
   &__top {
     @include breakpoint($bp-small max-width) {
       padding: 0 ($gutter / 2);
       margin-bottom: 0;
+      grid-row: 1 / 2;
+      grid-column: 1 / 1;
     }
     @include gutter($margin-bottom-full...);
+    grid-area: content;
     grid-row: 1 / 1;
     grid-column: 1 / 2;
   }
 
   &__left {
+    @include breakpoint($bp-small max-width) {
+      grid-column: 1 / 1;
+      grid-row: 2 / 3;
+    }
+
     @include gutter($margin-right-half...);
     grid-column: 1 / 1;
     grid-row: 2 / 2;
+    grid-area: content_below;
   }
 
   &__right {
@@ -41,12 +52,13 @@
     @include gutter($margin-left-half...);
 
     @include breakpoint($bp-small max-width) {
-      grid-column: 1 / 1;
       grid-row: 3 / 3;
+      grid-column: 1 / 1;
       padding: 0 ($gutter / 2);
     }
 
     grid-column: 2 / 2;
     grid-row: 2 / 2;
+    grid-area: sidebar;
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_subcategory.scss
+++ b/styleguide/source/assets/scss/05-pages/_subcategory.scss
@@ -32,3 +32,9 @@
     }
   }
 }
+
+#views-exposed-form-subcategory-listing-block-with-filters-block-1 {
+  .form-item:not(.ama__radio):not(.ama__checkbox) {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8368: Move up right rail promos vertically on Subcategory pages](https://issues.ama-assn.org/browse/EWL-8368)

## Description
* Modifying the way that the layout is handled to match with designs


## To Test
- [ ] Compile assets `lando gulp serve`
- [ ] Clear cache `lando drush @one.local cr`
- [ ] Go to a page like `https://ama-one.lndo.site/delivering-care/coronavirus` the sidebar should be displayed at the top of the sidebar as described on the specs.
- Please note that right now there is no alignment between the sidebar and the content section that has the search box. That's because the search field has a `margin-top: 14 px` and `margin-bottom: 14px`

![Screen Shot 2020-11-09 at 8 08 31 PM](https://user-images.githubusercontent.com/5325044/98618743-6bf53380-22c7-11eb-93de-0569cfe353fe.png)

We must fix this probably on a separate ticket and then add to the `ama__layout--two-col-right--75-25 section` class the `margin-top: 42px` that are indicated in the zeplin designs



## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
- Create a ticket or give the green light to fix the issue with the margin in the search box component described above.
- Once fixed the margin I can add the margin to the `ama__layout--two-col-right--75-25 section` to align all together.


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
