### PR TITLE
EWL-8400: EWL-8400: updated twig to show block only once, and to be able to deal with mor

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -28,16 +28,27 @@
       @include gutter($margin-left-full...);
       @include gutter($margin-bottom-full...);
       width: 47%;
+      &.five-up {
+        width: 30%;
+      }
     }
 
     @include breakpoint($bp-med min-width) {
       @include gutter($margin-left-full...);
       width: 25%;
-    }
-
-    @include breakpoint($bp-med max-width) {
       &:nth-of-type(3) {
         margin-left: 0;
+        &.five-up {
+          margin-left: $gutter*.75;
+        }
+      }
+      &.five-up {
+        width: 33%;
+      }
+    }
+    @include breakpoint($bp-large min-width) {
+      &.five-up {
+        width: 32%;
       }
     }
   }
@@ -49,4 +60,21 @@
   .ama__article-stub__copy {
     padding: 0;
   }
+  .grid-container {
+    &:last-child {
+      .seven-up {
+        width: auto;
+        @include breakpoint($bp-small min-width) {
+          width: 47%;
+        }
+        @include breakpoint($bp-med min-width) {
+          width: auto;
+        }
+      }
+    }
+  }
+}
+
+.ama__category__article-stub-three-up {
+  margin-bottom: $gutter;
 }

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -37,7 +37,6 @@
       @include gutter($margin-left-full...);
       width: 25%;
       &:nth-of-type(3) {
-        margin-left: 0;
         &.five-up {
           margin-left: $gutter*.75;
         }

--- a/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_four-up-teaser.scss
@@ -8,16 +8,21 @@
     flex-direction: row;
     flex-wrap: wrap;
   }
-
+  h3 {
+    margin-bottom: 0;
+  }
   @include breakpoint($bp-med) {
     flex-wrap: nowrap;
   }
 
   .ama__article-stub {
     @include gutter($margin-bottom-full...);
+    @include breakpoint($bp-small) {
+      margin-bottom: 0;
+    }
     flex-grow: 1;
     flex-basis: 0;
-    
+
     &__copy > h2 {
       @extend %ama__type--small;
     }

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -175,11 +175,10 @@
 // Masthead styling for 75% 25% two column masthead
 
 .ama__75-25__masthead {
-  display: grid;
-  grid-template-rows: auto auto auto;
-  grid-template-columns: 1fr;
-
+  display: block;
   @include breakpoint($bp-small) {
+    display: grid;
+    grid-template-rows: auto auto auto;
     grid-template-columns: 3fr 1fr;
   }
 

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -116,12 +116,11 @@
         margin-bottom: $gutter;
       }
     }
-
     @include breakpoint($bp-small) {
       .grid-container {
         @include gutter($margin-top-full...);
         display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
         -ms-grid-columns: 1fr $gutter 1fr $gutter 1fr;
         grid-gap: $gutter;
         grid-template-rows: auto auto;
@@ -144,6 +143,40 @@
         }
       }
     }
+    @include breakpoint($bp-med) {
+      .grid-container {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+    }
+  }
+
+  &__article-stub-four-up-three {
+    @include breakpoint($bp-small max-width) {
+      > * {
+        margin-bottom: $gutter;
+      }
+    }
+
+    @include breakpoint($bp-small) {
+      .grid-container {
+        @include gutter($margin-top-full...);
+        display: flex;
+        flex-wrap: wrap;
+        .ama__article-stub {
+          flex-basis: 32%;
+          &:nth-child(1), &:nth-child(2), &:nth-child(3), &:nth-child(4) {
+            flex-basis: 24%;
+          }
+          h3 {
+            padding: 0;
+          }
+          .ama__image {
+            margin-bottom: 0;
+          }
+        }
+      }
+    }
+
   }
 
   .ama__article-stub--category .ama__h5 {


### PR DESCRIPTION
**Github Issue**
https://github.com/AmericanMedicalAssociation/ama-d8/pull/2355

**Jira Ticket**
- [EWL-8400: Regression: 4-up blocks are appearing twice on cat and subcat pages.](https://issues.ama-assn.org/browse/EWL-8400)

## Description
See D8 PR for description


## To Test
- [ ] Pull and serve branch 
- [ ] See D8 PR for testing instructions. https://github.com/AmericanMedicalAssociation/ama-d8/pull/2355

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
