### PR TITLE
EWL-8454: Padding Missing from Explore Topics in Subcategory

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_subcategory-explore-topics.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-explore-topics.scss
@@ -1,5 +1,6 @@
 .ama__subcategory-explore-topics {
-  display: inline;
+  display: inline-block;
+  padding: 21px 0px $gutter;
 
   @include breakpoint($bp-small) {
     display: flex;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8454: Drupal 8.9 Bottom padding missing from Explore Topics in Subcategory](https://issues.ama-assn.org/browse/EWL-8454)

## Description
Added padding as specified in [Zeplins](https://issues.ama-assn.org/browse/EWL-8454) for all viewports.

## To Test
- [ ] Pull branch
- [ ] Run `lando link-styleguides`
- [ ] Run `lando gulp` from `styleguides/ama-style-guide-2/styleguide` dir
- [ ] Create new Subcat page with default layout and verify that Explore Topics padding now matches [Zeplins](https://issues.ama-assn.org/browse/EWL-8454) (see [ticket](https://issues.ama-assn.org/browse/EWL-8454) for example of original issue)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
