### PR TITLE
EWL-7141: Adjust event tab image styling.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_event-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_event-stub.scss
@@ -10,7 +10,7 @@
 
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   padding-top: $gutter-mobile/2;
   border-bottom: 1px solid $gray-50;
 
@@ -69,7 +69,7 @@
     color: $purple;
   }
 
-  .ama__image {
+  .ama__bio-image-with-body__image {
     @include gutter($margin-bottom-full...);
     width: 100%;
     min-width: 180px;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-7471: Images on Events Listing pages are being truncated on left and right sides](https://issues.ama-assn.org/browse/EWL-7471)

## Description
Adjust styling to align event stub images on event detail page.


## To Test
- Import styling
- Checkout the following [PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2447)
- Confirm truncating images documented in the following ticket are resolved. [https://issues.ama-assn.org/browse/EWL-7471](https://issues.ama-assn.org/browse/EWL-7471)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A

## Additional Notes
Created in tandem with the following ama-d8 PR: [https://issues.ama-assn.org/browse/EWL-7471](https://issues.ama-assn.org/browse/EWL-7471)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
