### PR TITLE
EWL-7493: Remove extra whitespace within travel tab on Event Detail p…

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_info-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/_info-card.scss
@@ -54,6 +54,10 @@
   }
 
   &--location {
+    //Unset container height to prevent extra spacing
+    .layout__region--main {
+      min-height: unset !important;
+    }
     .ama__info-card__wrap {
       @include breakpoint($bp-small) {
         display: flex;


### PR DESCRIPTION
…ages.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-7493: Extra white space displaying in Travel Info page for Event Details](https://issues.ama-assn.org/browse/EWL-7493)

## Description
Added rule to remove minimum height for layout region main within event detail info cards.


## To Test
- Link latest styles
- Navigate to Event Detail page with location info (ex: house-delegates/interim-meeting/2019-ama-hod-interim-meeting)
- Confirm extra whitespace documented in the following ticket is resolved: [https://issues.ama-assn.org/browse/EWL-7493](https://issues.ama-assn.org/browse/EWL-7493)

## Visual Regressions
- N/A


## Relevant Screenshots/GIFs
- N/A


## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
