### PR TITLE
EWL-8424: Article Page Grouping block: Extra pipe displays in active state display of last page

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -136,6 +136,7 @@
     .link-list {
       list-style-type: none;
       .ama_page_grouping_link {
+
         line-height: 1.3;
         display:inline-block;
         text-transform: uppercase;
@@ -183,6 +184,11 @@
         }
 
         &:last-child {
+          &.active {
+            &::after {
+              content: "";
+            }
+          }
           a {
             padding-right: 0;
             &::after {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8424: Ticket Title](https://issues.ama-assn.org/browse/EWL-8424)

## Description
removed right pipe from rightmost active link


## To Test
- [ ] pull and serve branch.
- [ ] see further instructions in the d8 PR https://github.com/AmericanMedicalAssociation/ama-d8/pull/2462

## Visual Regressions
See Percy Build


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
