### PR TITLE
EWL-8357: Restore dates to Article pages in Mobile responsive view

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
@@ -1,6 +1,8 @@
 .ama__inline-bio {
   @include gutter($padding-top-half...);
-  @include gutter($padding-bottom-half...);
+  @include breakpoint($bp-small) {
+    @include gutter($padding-bottom-half...);
+  }
   &__image {
     display: none;
     margin-bottom:35px;

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -225,33 +225,23 @@
     .share-row {
       display: flex;
       flex-direction: column;
-      visibility: hidden;
-      height: 0;
+
       @include breakpoint($bp-small) {
         flex-direction: row;
-        visibility:visible;
         height: auto;
       }
       .share-region {
-        visibility: hidden;
-        height: 0;
-        grid-column: none;
-        grid-row: none;
+        height: auto;
+        margin-left: auto;
         display: flex;
         justify-content: left;
         align-items: left;
         min-width: 50px;
-        @include breakpoint($bp-small) {
-          visibility: visible;
-          height: auto;
-          margin-left: auto;
-        }
       }
       .date-region {
         .date {
           @include breakpoint($bp-xs) {
             padding-top:0;
-            padding-bottom: 10px;
           }
           @include breakpoint($bp-small) {
             @include gutter($padding-top-half...);
@@ -259,6 +249,12 @@
           color: $gray-50;
           .date-block {
             font-weight: $font-weight-regular;
+          }
+          .date-block {
+            margin-bottom: 0 !important;
+            @include breakpoint($bp-small) {
+              margin-bottom: $gutter /2;
+            }
           }
         }
       }
@@ -295,8 +291,6 @@
   }
 }
 
-
-
 // Exceptions for social share icons
 .ama__news-article, .ama__resource-page {
   .ama__masthead__content__share {
@@ -319,3 +313,4 @@ article.ama__people-bio {
     padding-bottom: 0;
   }
 }
+


### PR DESCRIPTION
**Jira Ticket**
- [EWL-XXXX: Restore dates to Article pages in Mobile responsive view](https://issues.ama-assn.org/browse/EWL-8357)

## Description
Added padding and visibility rules to date in mobile view


## To Test
- [ ] pull and serve branch
- [ ] `lando link-styleguides && lando drush @one.local cr`
- [ ] verify that the date displays according the the zeplin in the ticket in mobile view

## Visual Regressions
See Percy


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
