### PR TITLE
EWL-8499: Site 404 Page CTAs Misaligned

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -19,6 +19,10 @@
     border: solid 1px $gray-50;
   }
 
+  &--stub-body {
+    min-height: 210px;
+  }
+
   &--inline {
     @include gutter($padding-top-full...);
     @include gutter($padding-right-full...);
@@ -183,4 +187,9 @@ a.ama__promo { // styling for when this pattern renders as a link.
       color: black;
     }
   }
+}
+
+.paragraph--type--promo-stub.paragraph--view-mode--default {
+  display: flex;
+  flex-direction: column;
 }


### PR DESCRIPTION

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8499: Site 404 page: CTAs misaligned](https://issues.ama-assn.org/browse/EWL-8499)

## Description
Added Twig template to give class to 404 promo card body. Set consistent height for body and set container to Flex, which restores the desired layout/design. See D8 PR for template.


## To Test
- [ ] Pull branch
- [ ] Pull [accompanying D8 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2492) and run `lando link-styleguides` from `styleguides/ama-style-guide-2/styleguide`
- [ ] Navigate to a [404 page](http://ama-one.lndo.site/nothingtoseehere)
- [ ] Verify that the promo cards are displaying as desired (see [ticket](https://issues.ama-assn.org/browse/EWL-8499) acceptance criteria for attached screencaps)

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
[Accompanying D8 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2492)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
