### PR TITLE
EWL-8510/8511: Mobile Social Share Icons Bottom Margin

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_social-share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_social-share.scss
@@ -67,6 +67,10 @@ footer {
   padding: 0;
   min-height: 20px;
 
+  @include breakpoint(max-width $bp-small) {
+    margin-bottom: $gutter / 2;
+  }
+
   li {
     list-style: none;
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8510: Basic: Mobile, Space Below Social Icons to Rule Line Too Small](https://issues.ama-assn.org/browse/EWL-8510)
- [EWL-8511: Category: Mobile, Space Below Social Icons to Rule Line Too Small](https://issues.ama-assn.org/browse/EWL-8510)

## Description
Added mobile breakpoint bottom margin to the social share icons to resolve the reported spacing issue with the rule line below it.


## To Test
- [ ] Pull branch
- [ ] Link local styleguide
- [ ] Run `lando gulp` from `styleguide`
- [ ] Navigate to any Category or Basic Page and verify that on mobile there is now a 14px space below the social share icons. Verify that this new additional margin is not present on tablet or desktop views.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
![Screenshot_2021-02-11 Delivering Care](https://user-images.githubusercontent.com/57365587/107658697-0315b280-6c4c-11eb-9210-92f25cec7ff0.png)

## Remaining Tasks
N/A

## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
