### PR TITLE
EWL-8512: Index Mobile Membership Block Full Width

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -257,7 +257,7 @@ a.ama__membership {
     @include breakpoint($bp-large min-width) {
       margin-bottom: 56px;
       &:last-of-type {
-	margin-bottom: 0;
+        margin-bottom: 0;
       }
     }
   }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -256,9 +256,15 @@ a.ama__membership {
     }
     @include breakpoint($bp-large min-width) {
       margin-bottom: 56px;
-      &:last-of-type {
-        margin-bottom: 0;
+      &:last-of-type { margin-bottom: 0;
       }
     }
+  }
+}
+
+@include breakpoint(max-width $bp-small) {
+  .contextual-region.container.index-page .ama__layout--two-col-right--75-25__right {
+    margin: 0 -15px;
+    padding: 0;
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -256,7 +256,8 @@ a.ama__membership {
     }
     @include breakpoint($bp-large min-width) {
       margin-bottom: 56px;
-      &:last-of-type { margin-bottom: 0;
+      &:last-of-type {
+	margin-bottom: 0;
       }
     }
   }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8512: Index: Mobile, Membership Custom Block - Make Full Width](https://issues.ama-assn.org/browse/EWL-8512)

## Description
Added index-page specific change to membership promo blocks to remove padding and margins (making them full width) in accordance to [Zeplin](https://zpl.io/anqwggn) and acceptance criteria.


## To Test
- [ ] Pull branch
- [ ] Link styleguide (run `lando link-styleguides`
- [ ] Run `lando gulp` from `styleguide`
- [ ] Navigate to an Index page and verify that the membership promo block is now full width. Compare and critique with [Zeplin](https://zpl.io/anqwggn).

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![Screenshot_2021-02-11 Access to Health Care Coverage](https://user-images.githubusercontent.com/57365587/107666383-162c8080-6c54-11eb-8741-98c713bc1c8e.png)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
