### PR TITLE
EWL-8492: Article Page Related Content Titles Are Not Top Justified

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -44,6 +44,7 @@
     flex-wrap: wrap;
     flex-direction: row;
     align-items: center;
+    align-content: flex-start;
 
     &:last-child {
       @include ama-rules(1px, 'bottom', solid, $gray-50);


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8492: Article Page: Related Content Component(s) Titles Are Not Top Justified](https://issues.ama-assn.org/browse/EWL-8492)

## Description
Add `align-content` to related article stubs to meet requested change.


## To Test
- [ ] Pull branch
- [ ] Link local AMA SG with `lando link-styleguides`
- [ ] Run `lando gulp` from styleguide root
- [ ] Run `lando drush @one.local cr`
- [ ] Navigate to an article page with related articles of varying length (good example: http://ama-one.lndo.site/health-care-advocacy/advocacy-update/dec-18-2020-advocacy-update-other-news) and verify that the shorter titles are top justified per acceptance criteria. Reference Zeplin linked in ticket (note that it does not particularly help here though as the example titles are all the same length)

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
![Screenshot_2021-02-16 Dec 18, 2020 Advocacy Update other news](https://user-images.githubusercontent.com/57365587/108079072-01753180-7034-11eb-8659-d3086000fd6c.png)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
