### PR TITLE
EWL-8504: added 7px to mobile breakpoint.

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -80,11 +80,12 @@
   } // end aside.primary
 
   &--secondary {
-    @include gutter($padding-top-full...);
+    padding-top: $gutter;
     grid-column: 1 / 5;
     grid-row: 3 / 4;
 
     @include breakpoint($bp-med min-width) {
+      @include gutter($padding-top-full...);
       @include gutter($padding-left-full...);
       grid-column: 3;
       grid-row: 2 / auto;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8504: Article & Press Release: Tablet Padding Below Featured Stories expanded to 28 px](https://issues.ama-assn.org/browse/EWL-8504)

## Description
Added 7px to the padding below featured stories on mobile

## To Test
- [ ] pull and serve branch. Set up D8 for SG development
- [ ] verify that on News articles and press releases there is 28px of padding below featured stories on mobile.

## Visual Regressions
See Percy


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
