### PR TITLE
EWL-8496: restored webform label font weight and size.

### DIFF
--- a/styleguide/source/assets/scss/00-base/_webforms.scss
+++ b/styleguide/source/assets/scss/00-base/_webforms.scss
@@ -134,3 +134,8 @@ a.webform-button--submit {
 .form-submit.ama__button {
   @include gutter($margin-bottom-full...);
 }
+
+.webform-options-display-buttons-label {
+  font-size: 18px;
+  font-weight: $font-weight-regular;
+}


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8496: Contact Us Form Update](https://issues.ama-assn.org/browse/EWL-8496)

## Description
restored font size and weight in the contact us form buttons

## To Test
- [ ] pull and serve branch
- [ ] visit the contact form and confirm that the buttons match the buttons on test. http://ama-one.lndo.site/form/contact-us

## Visual Regressions

See Percy build


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
