### PR TITLE
EWL-8507 Footer Subscribe Button iOS Issues

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
@@ -3,6 +3,7 @@
   @include font-size($p-font-sizes);
   @include gutter-all($padding-all-half...);
   border-radius: 0;
+  appearance: none;
   border: 1px solid $purple;
   cursor: pointer;
   display: inline-block;

--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -52,6 +52,8 @@
   @else if($style == "subscribe") {
     background-color: $orange-medium !important;
     color: $black !important;
+    padding-bottom: 12.5px;
+    right: 2px;
 
     &:hover {
       border-color: transparent !important;

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -200,6 +200,7 @@
         input {
           background-color: $white;
           text-decoration: none;
+          font-weight: 600;
           &.error {
             background-image: none;
           }

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -199,6 +199,7 @@
       .ama__subscribe-promo--wide .ama__subscribe-promo__form {
         input {
           background-color: $white;
+          text-decoration: none;
           &.error {
             background-image: none;
           }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
N/A

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8507: Footer / Global: Subscribe button on Tablet and Mobile incorrect design](https://issues.ama-assn.org/browse/EWL-8507)

## Description
iOS applies its own "native" styling to inputs that needs the `appearance` CSS attribute set to `none` to override. There were also flaws with the sizing and positioning of this button leaving it shorter than the email input next to it (see screencap below) and leaving a space in between the button and input on mobile devices.


## To Test
- [ ] Pull branch
- [ ] Run `gulp` from styleguide root
- [ ] Link local ama-one styleguide (`link-styleguides`)
- [ ] Verify on your local machine that the height of the button now aligns with the email input (see description above and screencap below)
- [ ] Set up Browserstack local testing (https://www.browserstack.com/docs/live/local-testing) and verify that the button is now the correct style on iOS (iPad and iPhone, various versions and browsers) and no longer has a 2px gap between the button and email input.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
Height issue before change
![Screenshot_2021-02-19 American Medical Association AMA](https://user-images.githubusercontent.com/57365587/108508281-2f9b8100-7281-11eb-8342-7aad268a1f48.png)



## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
