### PR TITLE
EWL-8492: Article Page Related Content Titles Are Not Top Justified

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -43,8 +43,8 @@
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    align-items: center;
-    align-content: flex-start;
+    align-items: start;
+    align-content: start;
 
     &:last-child {
       @include ama-rules(1px, 'bottom', solid, $gray-50);


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8492: Article Page: Related Content Component(s) Titles Are Not Top Justified](https://issues.ama-assn.org/browse/EWL-8492)

## Description
[Original PR](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/990) did not apply on specific mobile devices, namely iPad Air (1 & 2) and iPad Mini (all versions). This was because the `align-content: flex-start` attribute was not being used on these devices, and the previously set `align-items: center` was taking effect. Both have been changed to `start` to ensure that whichever applies, the effect is the same. The change from `flex-start` to `start` on the `align-content` attribute was purely for browser support, as research into the issue shows that `start` is more widely supported at this point in time and the nuances between them do not apply in this instance.


## To Test
- [ ] Pull branch
- [ ] Run `lando gulp` from SG root
- [ ] Run `lando link-styleguides` to set up local AMA One SG
- [ ] Set up Browserstack local testing (https://www.browserstack.com/docs/live/local-testing) and verify that the Related Article titles are all top-aligned as per ticket requirements on all devices (iPad Mini and iPad Air especially)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
Good page to test as it was showing the misalignment in UAT testing: http://ama-one.lndo.site/health-care-advocacy/advocacy-update/dec-18-2020-advocacy-update-other-news

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
