### PR TITLE
EWL-8512: Full Width Index Page Membership Promos

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -264,8 +264,11 @@ a.ama__membership {
 }
 
 @include breakpoint(max-width $bp-small) {
-  .contextual-region.container.index-page .ama__layout--two-col-right--75-25__right {
-    margin: 0 -15px;
-    padding: 0;
+  .ama__category-index, .ama__subcategory-index {
+    .ama__membership {
+      position: relative;
+      right: 5.5px;
+      margin: 0px -34px;
+    }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -263,7 +263,7 @@ a.ama__membership {
   }
 }
 
-@include breakpoint(max-width $bp-small) {
+@include breakpoint($bp-small max-width) {
   .ama__category-index, .ama__subcategory-index {
     .ama__membership {
       position: relative;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
- [EWL-8512: Index: Mobile, Membership Custom Block - Make Full Width](https://issues.ama-assn.org/browse/EWL-8512)

## Description
Added index-page specific change to membership promo blocks to remove padding and margins (making them full width) in accordance to [Zeplin](https://zpl.io/anqwggn) and acceptance criteria.

**Broke out the parent selectors and re-targeted based on "category" and "subcategory" index template selectors to address inconsistency in QA testing.**


## To Test
- [ ] Pull branch
- [ ] Link styleguide (run `lando link-styleguides`
- [ ] Run `lando gulp` from `styleguide`
- [ ] Navigate to an Index page and verify that the membership promo block is now full width. Compare and critique with [Zeplin](https://zpl.io/anqwggn).

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![Screenshot_2021-02-11 Access to Health Care Coverage](https://user-images.githubusercontent.com/57365587/107666383-162c8080-6c54-11eb-8741-98c713bc1c8e.png)

## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
