### PR TITLE
EWL-8259: Fix explore topic section styling for mobile and manual ent…

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_subcategory-explore-topics.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-explore-topics.scss
@@ -44,10 +44,10 @@
   }
 }
 
-.ama__subcategory-explore-topic-section {
-  padding: 0 15px;
+.layout--ama-page-section-one-col .ama__subcategory-explore-topics {
+  padding: 21px 15px 28px;;
   @include breakpoint($bp-small) {
-    padding: 0;
+    padding: 21px 0px 28px;
   }
 }
 

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-explore-topics.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-explore-topics.scss
@@ -44,4 +44,11 @@
   }
 }
 
+.ama__subcategory-explore-topic-section {
+  padding: 0 15px;
+  @include breakpoint($bp-small) {
+    padding: 0;
+  }
+}
+
 

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-index.scss
@@ -62,7 +62,7 @@
   }
 
   .views-field-field-featured-topics {
-    margin: 21px 10px 28px;
+    margin: 21px 15px 28px;
     display: block;
     list-style: none;
     clear: both;


### PR DESCRIPTION
…ries

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8529: Subcat | Explore Topics content positioned incorrectly in Default view / on mobile](https://issues.ama-assn.org/browse/EWL-8529)

## Description
- Adjusts styling for explore topics sections on desktop and mobile to fix padding/alignment issues on subcategory pages.


## To Test
- Checkout the corresponding PR: [EWL-8529](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2559)

For desktop:
- Navigate to subcat with a column (explore topics section for this example) placed manually
- ex: https://wwwdev.ama-assn.org/practice-management/scope-practice 
- confirm padding on left aligns with content above and below

For mobile: 
- Navigate to subcat with explore topics placed automatically 
- ex: https://wwwdev.ama-assn.org/practice-management/sustainability
- conform padding on left aligns with content above and below

## Visual Regressions

- N/A

## Relevant Screenshots/GIFs
- N/A


## Remaining Tasks
- N/A


## Additional Notes
- As noted above this ticket is meant to be viewed with the following PR: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2559](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2559)

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
