### PR TITLE
EWL-8516: Adjust styling for blocks in right rail of category pages o…

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -102,9 +102,7 @@
   .ama__tools {
     padding: 0;
   }
-  .ama__membership {
-    margin: 0 0 $gutter;
-  }
+
   .ama__layout--split__right .ama__article-stub--category {
     padding: 0 ($gutter / 2);
   }


### PR DESCRIPTION
…n desktop.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-8516: Category | Desktop, Incorrect Bottom Margin below RR Membership Custom Block](https://issues.ama-assn.org/browse/EWL-8516)

## Description
- Adjusted styling so blocks in the right hand rail on category pages follow designs.


## To Test
- Link latest styles
- navigate to top level category page (ex: /about)
- confirm margin between blocks on lower right hand rail are 56 px on desktop
- Spacing should match: https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5e54329d0c608264b3764742


## Visual Regressions

- N/A

## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
