### PR TITLE
EWL-8791: Set YPS subcat section on category pages to accommodate 4 l…

### DIFF
--- a/styleguide/source/assets/js/subcategory-exploration.js
+++ b/styleguide/source/assets/js/subcategory-exploration.js
@@ -21,9 +21,8 @@
       // Determine when to show link based on window size.
       $(document).ready(function () {
         function showHideMoreLink () {
-          // Set intial window width to 1024 pixel.
-          // @todo: Check if this is an issue to set 1024 width limit.
-          if ($initialWindowWidth <= 1024) {
+          // Set intial window width to 900 pixel.
+          if ($initialWindowWidth <= 900) {
             // If the unordered list outerHeight is greater than the parent container then show the show more link,
             // hide otherwise.
             if ($subcategoryList.outerHeight() > $subcategoryListContainerHeight) {
@@ -54,16 +53,18 @@
         e.stopPropagation();
         e.preventDefault();
 
-        // Checks to see if the container has been expand or not by comparing initial outerHeight to current outerHeight
-        if($subcategoryListContainer.outerHeight() > $subcategoryListContainerHeight) {
+        // Checks to see if the container has been expanded or not by checking the class
+        if($subcategoryListContainer.hasClass('ama__subcategory-exploration__list--expanded')) {
           $subcategoryListContainer.removeClass('ama__subcategory-exploration__list--expanded');
           $(this).removeClass('ama__subcategory-exploration__show-more--expanded');
           $subcategoryListLinkText.text('View all subcategories');
+          console.log('explore hidden');
         }
         else {
           $subcategoryListContainer.addClass('ama__subcategory-exploration__list--expanded');
           $(this).addClass('ama__subcategory-exploration__show-more--expanded');
           $subcategoryListLinkText.text('View fewer subcategories');
+          console.log('explore shown');
         }
       });
     }

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -15,6 +15,10 @@
       height: 95px;
     }
 
+    @include breakpoint($bp-med) {
+      height: auto;
+    }
+
     &--expanded {
       height: auto;
     }


### PR DESCRIPTION
…ines of content.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-8791: Category | YPS section Subcat no longer displaying on Member Sections](https://issues.ama-assn.org/browse/EWL-8791)

## Description
Adjust section styling to accommodate for 4 lines of content in subcat section for category pages.


## To Test
- link styles locally
- Navigate to /member-groups-sections category page (this seems to be one of the only instance of 4 lines in section)
- Confirm at desktop size all subcategories appear

## Visual Regressions
- N/A


## Relevant Screenshots/GIFs
<img width="1248" alt="Screen Shot 2021-04-21 at 1 01 10 PM" src="https://user-images.githubusercontent.com/67962801/115599873-ae249700-a2a1-11eb-9284-09a970acb342.png">



## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
