### PR TITLE
EWL-8739: Remove social share icons from mobile index pages.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_topic-index.scss
+++ b/styleguide/source/assets/scss/05-pages/_topic-index.scss
@@ -107,4 +107,9 @@
   .ama__topic-index__stubs .views-exposed-form .form-actions {
     margin-top: 0;
   }
+  .share-row {
+    @include breakpoint($bp-small max-width) {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8379: https://issues.ama-assn.org/browse/EWL-8739](https://issues.ama-assn.org/browse/EWL-8379)

## Description
Hide social share icons on mobile to topic (index) pages.


## To Test
- link styleguides
- navigate to topic page (/topics/vaccinations for example)
- confirm social share icons are hidden on mobile screen sizes

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
<img width="560" alt="Screen Shot 2021-04-22 at 3 19 05 PM" src="https://user-images.githubusercontent.com/67962801/115779864-1b0d5f00-a37e-11eb-80bf-4d557f1e4cb7.png">



## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
