### PR TITLE
EWL-8555: Hide trending tag on articles if skip promotion is checked.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -52,6 +52,15 @@
   }
 }
 
+//Rule to hide trending article tag if Skip Promotion field is selected
+.no-trending {
+  .ama__news {
+    .trending-icon {
+      display: none;
+    }
+  }
+}
+
 //Rules for embedded Article Stub Lists
 .ama__article-stub-list--inline {
   margin-top: $gutter;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8555: Trending notifications on Article pages](https://issues.ama-assn.org/browse/EWL-8555)

## Description
Adds styling to hide trending article tag on news articles if skip promotion field is checked.

## To Test

- Checkout corresponding PR: [EWL-8555](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2666) 
- Open any current trending article
- Edit article and select "Skip Promotion" field in the right hand dropdown menu
- Save article and confirm Trending Tag is no longer displaying.

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
