### PR TITLE
EWL-8813: Home Page | 14 px bottom margin added below Video Inserts and Subcat title

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -78,6 +78,7 @@
     flex-basis: 100%;
     align-items: center;
     height: 100%;
+    margin-bottom: 14px;
 
     .ama__video {
       height: 100%;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8813: Home Page | 14 px bottom margin added below Video Inserts and Subcat title](https://issues.ama-assn.org/browse/EWL-8813)

## Description
Added 14px to bottom of homepage video blocks


## To Test
- [ ] pull branch, serve and link styleguides
- [ ] refresh the homepage and verify that videos in the top block area have a 14px bottom margin between the video and the subtitle. Screenshots in ticket.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
