### PR TITLE
EWL-8552: Vertical trending block style adjustments.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_trending-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_trending-block.scss
@@ -123,7 +123,7 @@
       content: " ";
       position: absolute;
       right: -20px;
-      top: 10px;
+      top: 6px;
       width: 13px;
       height: 8px;
       background: url('../images/arrow-right-blue.png') no-repeat 0px 0px;

--- a/styleguide/source/assets/scss/02-molecules/_trending-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_trending-block.scss
@@ -48,7 +48,7 @@
   &__inner {
     border: solid 1px $complementary;
     border-top: none;
-    padding-top: 13px;
+    padding-top: 14px;
   }
 
   &__links {
@@ -132,8 +132,9 @@
   }
 
   .ama__trending-block__view-all {
-    margin: 11px 24px 20px 0;
+    margin: 14px 24px 14px 0;
     color: $blue;
+    line-height: 1;
   }
 
   &__horizontal {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8552: Trending module on AMAone homepage](https://issues.ama-assn.org/browse/EWL-8552)

## Description
Adjust header spacing and view all trending link styling.


## To Test
- Link styleguides locally
- If not present, follow instructions here to create/place a vertical trending block on the homepage: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/2640](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2640)
- Confirm spacing between purple header bar and first article is 14px.
- Confirm spacing above and below "View all Trending" cta is 14px.

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
