### PR TITLE
EWL-8751: Fix subscribe button footer styling on mobile.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -170,10 +170,16 @@
     }
   }
   &__right {
+    .ama__subscribe-promo__form .ama__applied-filters__remove {
+      font-weight: $font-weight-semibold;
+      text-decoration: none;
+    }
+    
     @include breakpoint(max-width $bp-small){
       border-top: 1px solid $gray-50;
       padding-top: $gutter-mobile;
     }
+
     p {
       line-height: 1.25em;
     }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8751: Footer | Android and iPhone, No underline for the subscribe CTA. and Font Adjustment to Semi Bold](https://issues.ama-assn.org/browse/EWL-8751)

## Description
Fix styling of 'subscribe' button in footer for mobile devices.

## To Test
- Link latest styles with lando link-styleguides
- Confirm styling of 'Subscribe' button on mobile matches the following zeplin:
[Footer Designs](https://app.zeplin.io/project/5a8ef2508b4ec0f7321ce002/screen/5fc5143c4123b20452021bfe)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-06-09 at 2 19 26 PM](https://user-images.githubusercontent.com/67962801/121415854-c3c34e00-c92d-11eb-9d11-c5fd443eb8b8.png)

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
