### PR TITLE
Adjust alert box behavior to prevent shifting of page content on load.

### DIFF
--- a/styleguide/source/assets/js/alert.js
+++ b/styleguide/source/assets/js/alert.js
@@ -12,17 +12,28 @@
      attach: function (context, settings) {
        $.cookie('ama__alert--hide');
        var alertCookie = $.cookie('ama__alert--hide');
-       
+            
        (function ($) {
          // If the 'hide cookie is not set we show the alert
          if (alertCookie !== '1') {
-           $('.ama__alert__wrap').fadeIn("slow");
+           $('.ama__alert__wrap').css({
+            "transition": "opacity 2s",
+             "opacity": "1"
+            });
+         } else {
+           $('.ama__alert__wrap').css({
+            "display": "none"
+           });
          }
 
          // Add the event that closes the popup and sets the cookie that tells us to
          // not show it again until one day has passed.
          $('.ama__alert__close').click(function() {
-           $('.ama__alert__wrap').fadeOut();
+           $('.ama__alert__wrap').css({
+            "transition": "opacity 2s",
+             "opacity": "0",
+             "display": "none"
+            });
            // set the cookie
            $.cookie('ama__alert--hide', '1', { expires: 1});
            return false;

--- a/styleguide/source/assets/scss/02-molecules/_alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_alert.scss
@@ -19,7 +19,7 @@
   }
 
   &__wrap {
-    display: none;
+    opacity: 0;
   }
 
   &__text {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- N/A

## Description
Adjusted alert banner js and styling to maintain alert banner structure while the page loads. This prevents the content on the page to shift as the banner loads in. Adjusts logic to hide banner if already viewed during current browsing session.


## To Test
- run 'lando link-styleguides'
- clear caches with 'lando drush @one.local cr'
- While logged out: go to homepage, confirm alert banner structure loads immediately and the content fades in after preventing content below banner from shifting down when banner loads
- Refresh the page, confirm on page load alert banner does not display (cookie is set after first viewing)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-06-21 at 3 45 08 PM](https://user-images.githubusercontent.com/67962801/122825933-32969480-d2a8-11eb-9b01-fc85a1080b0a.png)
![Screen Shot 2021-06-21 at 3 45 21 PM](https://user-images.githubusercontent.com/67962801/122825940-34f8ee80-d2a8-11eb-8fe3-2cb188d75db9.png)
![Screen Shot 2021-06-21 at 3 45 37 PM](https://user-images.githubusercontent.com/67962801/122825943-362a1b80-d2a8-11eb-99c2-e4e87949072e.png)

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
