### PR TITLE
EWL-8878: Lightbox | Not working in ordered and unordered lists

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_modal.scss
+++ b/styleguide/source/assets/scss/02-molecules/_modal.scss
@@ -10,7 +10,7 @@
     height: 41px;
     width: 41px;
     display: none;
-    z-index: 10px;
+    z-index: 10;
     @include breakpoint($bp-small) {
       display:block;
     }

--- a/styleguide/source/assets/scss/02-molecules/_modal.scss
+++ b/styleguide/source/assets/scss/02-molecules/_modal.scss
@@ -10,6 +10,7 @@
     height: 41px;
     width: 41px;
     display: none;
+    z-index: 10px;
     @include breakpoint($bp-small) {
       display:block;
     }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-8878: Ticket Title](https://issues.ama-assn.org/browse/EWL-8878)

## Description
Added z-index rule to modal trigger


## To Test
- [ ] pull and serve styleguide
- [ ] verify that you can click the modal trigger whithin a listicle: 

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
