### PR TITLE
EWL-8885: Adjust CTA button styling in 30/70 custom block.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
+++ b/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
@@ -118,6 +118,15 @@
   }
 }
 
+.ama__news-article {
+  .hero-evergreen {
+    &__buttons .ama__button {
+      border: solid 1px #471b6d;
+      background-color: #ffffff;
+      color: #46166b;
+    }
+  }
+}
 
 .thirty-seventy-block {
   margin-bottom: $gutter * .75;

--- a/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
+++ b/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
@@ -122,8 +122,12 @@
   .hero-evergreen {
     &__buttons .ama__button {
       border: solid 1px #471b6d;
-      background-color: #ffffff;
+      background-color: $white;
       color: #46166b;
+      &:hover {
+        background-color: #46166b;
+        color: $white;
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8885: 30/70 Custom Block CTA Color Change Needed](https://issues.ama-assn.org/browse/EWL-8885)

## Description
Adjusted color of cta button within the 30/70 custom block.

## To Test
- Link latest styles with 'lando link-styleguides'
- Edit any news article and embed a 30/70 custom block within the body of the node
- Confirm CTA colors match the following criteria:
CTA text color: #46166b
CTA Background: #FFFFFF
CTA Surround box: #471b6d 

[Zeplin w/ CTA](https://zpl.io/25RPy5J )

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-06-29 at 11 17 42 AM](https://user-images.githubusercontent.com/67962801/123833388-e6f97180-d8cb-11eb-8312-b971f56ff406.png)

## Remaining Tasks
- N/A

## Additional Notes
- This fix applies to 30/70 custom blocks on News Articles only.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
