### PR TITLE
EWL-8884: subcat read more android tablet fix.

### DIFF
--- a/styleguide/source/assets/js/index-page.js
+++ b/styleguide/source/assets/js/index-page.js
@@ -21,7 +21,7 @@
           truncHeight = trunc.height() + 25
           fullHeight = full.height() + 20
         } else if (width < 900) {
-            truncHeight = trunc.height()
+            truncHeight = trunc.height() + 25
             fullHeight = full.height() + 20
         } else {
           truncHeight = trunc.height()


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8884: Subcat Video Custom Block | Read More does not show up on Android_Tablet ](https://issues.ama-assn.org/browse/EWL-8884)

## Description
Adjusted height of truncated text section for a closed 'Read More' section on tablet width Subcategory pages.


## To Test
-  Run 'lando link-styleguides' to get latest
-  Confirm 'Read More' button on Subcat pages appears on tablet sized devices (ex: http://ama-one.lndo.site/about/ama-career-opportunities)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
