### PR TITLE
EWL-8846: Fixes series tags in article stubs when no image present.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_series-tag.scss
+++ b/styleguide/source/assets/scss/02-molecules/_series-tag.scss
@@ -56,4 +56,8 @@
     height: 28px;
     padding: 7px 0;
   }
+  .no-image {
+    position: relative;
+    height: 42px;
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8846: Apply Series flag to Article Stub List Custom Block](https://issues.ama-assn.org/browse/EWL-8846)

## Description
Fixes overlapping of series tag and article stub content when no image is present.


## To Test
- Checkout and follow instructions in [ama-d8 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/2825)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-07-14 at 4 15 32 PM](https://user-images.githubusercontent.com/67962801/125694470-5aa1dcef-5d98-4cdc-af50-142b27080585.png)


## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
