### PR TITLE
EWL-0: Fixes whitespace bug on homepage when critical css loads.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -183,7 +183,10 @@
   z-index: 502;
 }
 
-.sticky-wrapper.is-sticky {
-  min-height: 61px;
-  height: 61px;
+.sticky-wrapper {
+  height: 61px !important;
+  .is-sticky {
+    min-height: 61px;
+    height: 61px;
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- N/A

## Description
Fixes a display issue where the calculated height for the headers sticky nav wrapper element is created before the page content can (specifically the menu) can collapse. See attached screenshot for example


## To Test
- N/A

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-07-22 at 3 18 57 PM](https://user-images.githubusercontent.com/67962801/126704443-9059d4d2-aded-42c8-8a15-597ffb989d0a.png)



## Remaining Tasks
- N/A


## Additional Notes
- As this is needed to resolve an issue with the critical css functionality which is still under development, please merge into develop as soon as possible.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
