### PR TITLE
EWL-9006: Fixes button functionality on header nav when sticky class is applied.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -189,4 +189,8 @@
     min-height: 61px;
     height: 61px;
   }
+
+  &.is-sticky .ama__main-navigation {
+    z-index: 502 !important;
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-9006: Subcat | Purple ribbon mostly inactive once Social Sticky Nav becomes vertical](https://issues.ama-assn.org/browse/EWL-9006)

## Description
Added style rule to increase z-index of nav bar when sticky class is applied. This prevents the invisible wrapper for the social share buttons from overlapping and preventing selection of buttons in the nav.


## To Test
- Compile styles from PR and run 'lando link-styleguides' to link to local
- In an incognito window or while signed out, navigate to any page with social share buttons (example from ticket: /delivering-care/public-health)
- Scroll until sticky nav is applied
- Confirm menu, AMA logo, Join/Renew and the Search field are clickable/actionable
- Scroll back up to the top of the page and confirm same functionality as above

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-08-19 at 1 56 22 PM](https://user-images.githubusercontent.com/67962801/130128830-8b305dca-cf2f-4588-b969-40f30660d9a4.png)


## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
