### PR TITLE
EWL-8953: Updated styling for search bar on search page.

### DIFF
--- a/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-search-purple.twig
+++ b/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-search-purple.twig
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Icons / Search bw</title>
+    <defs>
+        <path d="M2.50000229,11.565 C2.50000229,6.46038462 6.81625623,2.30769231 12.1187611,2.30769231 C17.4237659,2.30769231 21.7387699,6.46038462 21.7387699,11.565 C21.7387699,16.6696154 17.4237659,20.8211541 12.1187611,20.8211541 C6.81625623,20.8223077 2.50000229,16.6696154 2.50000229,11.565 M29.7050272,28.0996154 L21.3837695,19.0061538 C23.1612712,16.9915385 24.2387722,14.3976923 24.2387722,11.565 C24.2387722,5.18884615 18.8012672,0 12.1187611,0 C5.43750497,0 0,5.18884615 0,11.565 C0,17.9411538 5.43750497,23.1288462 12.1187611,23.1288462 C14.9462637,23.1288462 17.541266,22.1930769 19.6050179,20.64 L27.7950254,29.5892308 C28.0425256,29.8603846 28.396276,30 28.7500263,30 C29.0362765,30 29.3237768,29.91 29.557527,29.7288462 C30.0825275,29.3157692 30.1512776,28.5865385 29.7050272,28.0996154" id="path-1"></path>
+    </defs>
+    <g id="Search-Results" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Desktop---Search-Results-" transform="translate(-960.000000, -137.000000)">
+            <g id="Search-box" transform="translate(110.000000, 95.000000)">
+                <g id="Color/greyscale/#000000" transform="translate(850.000000, 42.000000)">
+                    <mask id="mask-2" fill="white">
+                        <use xlink:href="#path-1"></use>
+                    </mask>
+                    <use id="Mask" fill="#000000" xlink:href="#path-1"></use>
+                    <g id="Group" mask="url(#mask-2)">
+                        <g transform="translate(-1.071429, 0.000000)" id="Color/greyscale/#000000">
+                            <rect id="Rectangle-Copy-19" fill="#46166B" x="0" y="0" width="32.1428571" height="30"></rect>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/styleguide/source/assets/icons/svg/icon-search-purple.svg
+++ b/styleguide/source/assets/icons/svg/icon-search-purple.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Icons / Search bw</title>
+    <defs>
+        <path d="M2.50000229,11.565 C2.50000229,6.46038462 6.81625623,2.30769231 12.1187611,2.30769231 C17.4237659,2.30769231 21.7387699,6.46038462 21.7387699,11.565 C21.7387699,16.6696154 17.4237659,20.8211541 12.1187611,20.8211541 C6.81625623,20.8223077 2.50000229,16.6696154 2.50000229,11.565 M29.7050272,28.0996154 L21.3837695,19.0061538 C23.1612712,16.9915385 24.2387722,14.3976923 24.2387722,11.565 C24.2387722,5.18884615 18.8012672,0 12.1187611,0 C5.43750497,0 0,5.18884615 0,11.565 C0,17.9411538 5.43750497,23.1288462 12.1187611,23.1288462 C14.9462637,23.1288462 17.541266,22.1930769 19.6050179,20.64 L27.7950254,29.5892308 C28.0425256,29.8603846 28.396276,30 28.7500263,30 C29.0362765,30 29.3237768,29.91 29.557527,29.7288462 C30.0825275,29.3157692 30.1512776,28.5865385 29.7050272,28.0996154" id="path-1"></path>
+    </defs>
+    <g id="Search-Results" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Desktop---Search-Results-" transform="translate(-960.000000, -137.000000)">
+            <g id="Search-box" transform="translate(110.000000, 95.000000)">
+                <g id="Color/greyscale/#000000" transform="translate(850.000000, 42.000000)">
+                    <mask id="mask-2" fill="white">
+                        <use xlink:href="#path-1"></use>
+                    </mask>
+                    <use id="Mask" fill="#000000" xlink:href="#path-1"></use>
+                    <g id="Group" mask="url(#mask-2)">
+                        <g transform="translate(-1.071429, 0.000000)" id="Color/greyscale/#000000">
+                            <rect id="Rectangle-Copy-19" fill="#46166B" x="0" y="0" width="32.1428571" height="30"></rect>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/styleguide/source/assets/scss/01-atoms/_icons.scss
+++ b/styleguide/source/assets/scss/01-atoms/_icons.scss
@@ -44,6 +44,7 @@ $icons: (
     radio,
     search,
     search-white,
+    search-purple,
     select,
     show,
     triangle,

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -31,7 +31,7 @@
   }
 
   .form-submit {
-    @extend .icon--search;
+    @extend .icon--search-purple;
     background-color: transparent;
     background-size: contain;
     background-position: 0 0;

--- a/styleguide/source/assets/scss/02-molecules/_search-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-header.scss
@@ -54,7 +54,13 @@
     }
 
     .ui-selectmenu-button {
+      padding: 9px 12px;
       margin: 0;
+
+      .ui-selectmenu-text {
+        font-size: 20px;
+        line-height: 1;
+      }
     }
 
     @include breakpoint($bp-small) {
@@ -69,11 +75,12 @@
 
   .form-actions {
     position: absolute;
-    top: 0;
-    right: $gutter;
+    top: -10px;
+    right: 10px;
 
     @include breakpoint($bp-small) {
       position: relative;
+      top: 0;
       right: 0;
       order: 2;
     }
@@ -104,10 +111,9 @@
   }
 
   &--results {
-    @include gutter($padding-top-half...);
     @include gutter($padding-bottom-half...);
-    @include gutter($margin-bottom-full...);
-    background: $gray-7;
+    margin-bottom: 21px;
+    padding-top: 33px;
 
     .ama__search-header__results-num {
       text-align: left;
@@ -124,11 +130,11 @@
     }
 
     .ama__search__field {
-      @include gutter($margin-bottom-full...);
       position: relative;
       margin-left: 0;
       width: 100%;
       flex-direction: column;
+      max-width: 1080px;
 
       @include breakpoint($bp-small) {
         flex-direction: row;
@@ -147,6 +153,12 @@
           border: none;
           border-bottom: 1px solid $hoverBlue;
         }
+      }
+
+      input[type="text"] {
+        border: none;
+        border-bottom: 2px solid $gray-40;
+        padding: 7px 2px;
       }
     }
 
@@ -170,7 +182,7 @@
       overflow: hidden;
 
       .ama__search-header__options {
-        max-width: 250px;
+        max-width: 180px;
         margin-top: 0;
         float: right;
       }

--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -74,8 +74,25 @@
     }
   } // end aside.secondary
 }
+//Search page style overrides
 body.search-results {
   .ama__layout--two-column--left__page-content {
     padding-top: 0;
+    #block-ama-one-content {
+      border-top: 1px solid $gray-20;
+      @include breakpoint($bp-small max-width) {
+        padding-top: 10px;
+      }
+    }
+  }
+  .ama__layout--two-column--left__sidebar--primary {
+    padding-top: 0;
+    padding-left: 0;
+    .ama__filter {
+      border-top: 1px solid $gray-20;
+      @include breakpoint($bp-small max-width) {
+        padding-top: 10px;
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8953: Search box / top of page redesign](https://issues.ama-assn.org/browse/EWL-8953)

## Description
Updated styling of search bar on search page.


## To Test
- Import latest styles locally with 'lando link-styleguides'
- Confirm styling of search bar and icon matches the following [Zeplin](https://zpl.io/25jw1yQ)

NOTE: This ticket only covers the styling changes to the search bar and icon sections, full acceptance criteria from ticket:
Acceptance Criteria:

Remove the gray outline from behind the search field and relevance dropdowns.
Remove the main page search box and put a line rule beneath the search field in its place.

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-09-17 at 11 30 58 AM](https://user-images.githubusercontent.com/67962801/133823217-040e213f-abb5-44ca-a969-31548fc71482.png)


## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
