### PR TITLE
EWL-9082: fixed incorrect icon positioning.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_select-menu.scss
+++ b/styleguide/source/assets/scss/01-atoms/_select-menu.scss
@@ -35,7 +35,7 @@
 
   .ui-icon {
     position: absolute;
-    top: 20px;
+    top: 16px;
     right: 15px;
     width: 0;
     height: 0;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-9082: Relevance dropdown arrow not vertically centered on Search page](https://issues.ama-assn.org/browse/EWL-9082)

## Description
moved dropdown menu carat


## To Test
- [ ] pull and serve sg
- [ ] set up d8 for styleguide development `lando link-styleguides && lando drush @one.local cr`
- [ ] go to the search page and verify that the downwards arrow on the "relevance" dropdown is centered vertically.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
