### PR TITLE
set max-width on 3:2 term images.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_event-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_event-stub.scss
@@ -72,7 +72,7 @@
   .ama__bio-image-with-body__image {
     @include gutter($margin-bottom-full...);
     width: 100%;
-    min-width: 180px;
+    max-width: 180px;
     height: auto;
     @include breakpoint($bp-small) {
       @include gutter($margin-right-full...);

--- a/styleguide/source/assets/scss/02-molecules/_event-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_event-stub.scss
@@ -81,6 +81,10 @@
       margin-bottom: 0;
     }
   }
+  .ama__image {
+    max-width: 180px;
+    margin-right: $gutter;
+  }
 
   .ama__rule {
     flex: 1 100%;

--- a/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
@@ -13,7 +13,7 @@
       .ama__bio-image-with-body__image {
         max-width: 100%;
         max-height: unset;
-      } 
+      }
     }
   }
 
@@ -61,7 +61,7 @@ div.ama__category-index a.ama__subcategory-page-article-stub.ama__subcategory-pa
   }
   .ama__subcategory-page-article-stub__image {
     display: block;
-    min-width: 180px;
+    max-width: 180px;
   }
 
   .ama__bio-image-with-body__image {


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-9045: Images | 3:2 Aspect Ratio Locations](https://issues.ama-assn.org/browse/EWL-9045)


## Description:
Changed several view modes to make images display in 3:2 ratio


## To Test:
- pull branch and cim
- Verify that the display ratio has been changed in the following content, view, paragraph and block types:


- Indexes on taxonomy term pages
- Event overview page: https://www.ama-assn.org/events
- Lightbox images in article template
- Best bets
- Page Grouping custom block
- Promo Group custom block



## Automated Test:
See Percy


## Style Guide:
N/A


N/A


## Additional Notes:
Anything more to add?


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
