### PR TITLE
EWL-8975: Fixes styling of article stub in hero section of homepage hero module.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -76,7 +76,7 @@
   &__video {
     display: flex;
     flex-basis: 100%;
-    align-items: center;
+    align-items: flex-start;
     height: 100%;
     margin-bottom: 14px;
 

--- a/styleguide/source/assets/scss/03-organisms/_home-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_home-page-hero.scss
@@ -8,9 +8,9 @@
         justify-content: flex-end;
       }
   
-      .ama__hero-video-info {
+      .ama__hero-video-info,
+      > .ama__article-stub__copy {
         @include breakpoint($bp-large) {
-  
           margin-right: 20px;
         }
   
@@ -30,7 +30,8 @@
           font-size: 14px;
         }
       }
-      .ama__video__container {
+      .ama__video__container,
+      > .ama__image {
         .series-icon {
           display: none;
         }
@@ -40,6 +41,21 @@
           padding-top: 26%;
           margin: 0;
         }
+      }
+
+      //Related article stub styling here
+      > .ama__article-stub__copy {
+        h3.ama__h3 {
+          font-size: 28px;
+          line-height: 32px;
+          @include breakpoint($bp-small) {
+            font-size: 38px;
+            line-height: 42px;
+          }
+        }
+      }
+      > .ama__image {
+        padding-top: 0;
       }
     }
   }

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -211,7 +211,8 @@
         margin-left: 20px;
       }
       grid-template-columns: 285px 285px 285px 285px;
-      .ama__hero-video-info {
+      .ama__hero-video-info,
+      .ama__hero-video .ama__article-stub__copy {
         max-width: 280px;
         width: 31%;
       }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8975: Homepage Hero Module](https://issues.ama-assn.org/browse/EWL-8975)

## Description
Adjusted styling to allow fo manually created article stub to display in the top hero spot in the homepage hero custom block.


## To Test
- Link latest styleguide
- Create or edit a Homepage Hero custom block with a 'Related Article' in the top spot
- Save and place on homepage using layout
- Confirm styling matches the following Zeplins:
- [Desktop](https://zpl.io/bJqpz7J)
- [Tablet](https://zpl.io/bLOW9eB)
- [Mobile](https://zpl.io/bzx5lEz)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-10-25 at 3 29 27 PM](https://user-images.githubusercontent.com/67962801/138766143-81c1afb9-f52b-414c-b2c4-164b860c3363.png)

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
