### PR TITLE
EWL-8975: Fixes styling of homepage hero block when placing within layout builder.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -152,6 +152,42 @@
     }
   }
 
+  //Layout builder styling
+  &__stubs.trending.layout-builder-block {
+    @include breakpoint($bp-small) {
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      .ama__article-stub:nth-child(2) {
+        grid-column-start: 1;
+        grid-column-end: 4;
+        grid-row-start: 1;
+        margin: 0 0 21px 0;
+        padding-bottom: 21px;
+        border-bottom: 1px solid $gray-7;
+        height: unset;
+      }
+
+      .ama__article-stub:nth-child(3) {
+        grid-column: 1;
+      }
+
+      .ama__article-stub:nth-child(4) {
+        grid-column: 2;
+        justify-self: center;
+      }
+
+      .ama__article-stub:nth-child(5) {
+        grid-column: 3;
+        justify-self: end;
+      }
+    }
+
+    @include breakpoint($bp-med) {
+      .ama__article-stub:nth-child(3) {
+        height: 270px;
+      }
+    }
+  }
+
   &__trending {
     margin-bottom: 21px;
     @include breakpoint($bp-small) {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-8975: Home Page Hero](https://issues.ama-assn.org/browse/EWL-8975)

## Description
Adds styling to fix display of home page hero block within the layout builder.


## To Test
-  Link latest styling
- Navigate to homepage
- Open layout builder and place homepage hero block
- Confirm styling is consistent with what displays on the front end

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-10-26 at 11 18 13 AM](https://user-images.githubusercontent.com/67962801/138919995-db5edf2f-d9ce-472a-ae42-8096a7e07a27.png)


## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
