### PR TITLE
EWL-9116: Fixes white space issue on subcategory on-page search filters

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_subcategory.scss
+++ b/styleguide/source/assets/scss/05-pages/_subcategory.scss
@@ -31,6 +31,13 @@
       }
     }
   }
+
+  .ama__layout--two-col-right--75-25 {
+    grid-template-rows: 0fr 1fr;
+    .ama__layout--two-col-right--75-25__top {
+      margin-bottom: 0;
+    }
+  }
 }
 
 #views-exposed-form-subcategory-listing-block-with-filters-block-1 {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-9116: Subcat | Large gap between chicklets and index/results discovered](https://issues.ama-assn.org/browse/EWL-9116)

## Description
Adjusted styling to prevent whitespace when selecting certain filters within subcategory search.


## To Test
- Import latest styling with lando link-styleguides
- Navigate to subcategory page with filters (ex from ticket: /delivering-care/overdose-epidemic)
- Select the following filters: "AMA Substance Use and Pain Care Task Force," "Harm Reduction Centers," and "Overdose Epidemic Report"
- Confirm results load for each and container of filters do not display any extra whitespace

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-10-27 at 12 16 09 PM](https://user-images.githubusercontent.com/67962801/139114505-14c8b2cd-bf52-4680-a1e8-e9f9fc26e6f8.png)
![Screen Shot 2021-10-27 at 12 16 18 PM](https://user-images.githubusercontent.com/67962801/139114507-72b2cf3a-6701-4b13-a0f3-5d6ab8d6a486.png)


## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
