### PR TITLE
EWL-8488: Global: Padding on topic term pills is incorrect

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -42,7 +42,7 @@ article[class*='__page-content'] .ama__tags {
       margin-left: 0;
       list-style: none;
       padding-bottom: 14px;
-      padding-right: 18px;
+      padding-right: 14px;
 
 
     }

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -1,7 +1,7 @@
 .ama__tags,
 article[class*='__page-content'] .ama__tags {
   @include gutter($margin-top-full...);
-  margin-bottom: $gutter;
+  margin-bottom: $gutter / 2;
   display: flex;
   align-items: flex-start;
   flex-direction: column;

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -15,7 +15,7 @@ article[class*='__page-content'] .ama__tags {
   &-text {
 
     font-weight: bold;
-    margin-right: 5px;
+    margin-right: 8px;
     @include gutter($padding-bottom-quarter...);
 
     @include breakpoint($bp-small) {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWL-8488: Global: Padding on topic term pills is incorrect](https://issues.ama-assn.org/browse/EWL-8488)
- [EWL-8489: Global: Padding on More About text in Topic Terms section is incorrect](https://issues.ama-assn.org/browse/EWL-8489)
- [EWL-8490: Global: Article page: Margins between Topic Terms and Essential Tools & Resources block is incorrect](https://issues.ama-assn.org/browse/EWL-8490)

## Description
removed 4px from right pill margin
updated padding between more text and pills
reduced bottom margin of pill section by 14px


## To Test
- [ ] set up d8 for SG development
- [ ] pull and serve
- [ ] verify that pills have 14px right margin 
- [ ] verify that the pills are 8px from the "More About" text.
- [ ] verify that the total distance between the pills and the tools & resources block is 28px (14px from the pill, 14px from the bottom of the div)

## Visual Regressions

N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
