### PR TITLE
EWL-8730: Subcat | Page Grouper: Bottom Margin should be 35 px and not 28px

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -2,11 +2,11 @@
   background-color: $pg-lt-blue;
   min-height: 271px;
   display: flex;
-  margin: 0 15px $gutter;
+  margin: 0 15px 35px;
   padding: 0;
   @include breakpoint($bp-small) {
     padding: 0 25% 0 calc(25% - 21px);
-    margin: 0 0 $gutter 0;
+    margin: 0 0 35px 0;
   }
   @include breakpoint($bp-med) {
     padding: 0 8%;


### PR DESCRIPTION
## Ticket(s)
*Jira Ticket**
- [EWL-8730: Subcat | Page Grouper: Bottom Margin should be 35 px and not 28px](https://issues.ama-assn.org/browse/EWL-8730)

## Description
Increased page grouping block bottom margin to 35px

## To Test
- [ ] set up d8 for local development
- [ ] pull and serve branch
- [ ] verify that page grouping blocks have a 35px bottom margin on subcat pages.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
