### PR TITLE
EWL-8513: Fix mobile font size for subcategory list links on category pages.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -45,7 +45,7 @@
       text-decoration: none;
       padding: 0;
       font-weight: $font-weight-semibold;
-      font-size: 14px;
+      font-size: 18px;
       display: inline;
 
       @include breakpoint($bp-small) {
@@ -81,7 +81,7 @@
     display: none;
 
     @include breakpoint($bp-small max-width) {
-      font-size: 16px;
+      font-size: 18px;
     }
 
     @include breakpoint($bp-small) {

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -112,6 +112,9 @@
         min-width: 14px;
         max-height: 14px;
         max-width: 14px;
+        @include breakpoint($bp-small max-width) {
+          background-position: 0 5px;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8513: Category: Mobile, Topic Terms Text is too Small](https://issues.ama-assn.org/browse/EWL-8513)

## Description
Adjusted mobile styling of subcategory links displayed at the top of category pages.


## To Test
- link new styles 
- On category page (ex: /delivering-care) view on mobile screensize or device
- Confirm links and show more link display as 18px.

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-11-04 at 2 46 37 PM](https://user-images.githubusercontent.com/67962801/140411558-5fe7ecdc-576d-4fb5-88db-e93803fed2ae.png)



## Remaining Tasks
- N/A

## Additional Notes
- There is also a commit in here to fix the alignment of the show all subcategories arrow icon. This was not technically part of the ticket but it was bugging me.
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
