### PR TITLE
EWL-8503: Fix color of border line on events page search fields.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -16,7 +16,7 @@
   &__input[type="text"] {
     font-style: italic;
     border: 0;
-    border-bottom: 1px solid $light-blue;
+    border-bottom: 1px solid $pg-blue;
     color: $gray-50;
     line-height: 1.2;
     padding: 1em 28px 3px 0;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8503: Event Listing: Search fields' rule color adjustment](https://issues.ama-assn.org/browse/EWL-8503)

## Description
Adjusted color of search field bottom borders on events page.


## To Test
-  link latest styles
- Navigate to /events page
- Confirm bottom border on both main and sidebar search field are 1px and have the color #02AAEC

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2021-11-04 at 4 35 36 PM](https://user-images.githubusercontent.com/67962801/140423489-9d5ccd00-a111-418c-a55e-cc8102b98db4.png)


## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
