### PR TITLE
EWL-8487: Adjust styling of video component in articles and category pages.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_video-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_video-block.scss
@@ -2,11 +2,10 @@
   display:flex;
   flex-wrap: wrap;
   flex-direction: column-reverse;
-  padding: $gutter/4*3 0;
-  margin: $gutter/3 15px;
+  padding: 21px 0;
+  margin: 0 15px;
   justify-content: center;
   align-items: stretch;
-  margin-bottom: 35px;
   @include breakpoint($bp-small) {
     flex-direction: row;
     margin: $gutter/3 0;
@@ -14,7 +13,8 @@
     margin-bottom: 42px;
   }
   @include breakpoint($bp-large) {
-    padding: $gutter/4*3 7%;
+    padding: 28px 7%;
+    margin: 0;
   }
   &.left {
     @include breakpoint($bp-small) {
@@ -75,5 +75,13 @@
       padding-bottom: 0;
       padding-top: 0;
     }
+  }
+}
+
+//Spacing for video block wrapper on category pages
+.layout--ama-page-section-one-col .video-block-wrapper + .ama__membership {
+  margin-top: 21px;
+  @include breakpoint($bp-small) {
+    margin-top: 28px;
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -41,6 +41,19 @@
       padding-bottom: 0;
     }
   }
+  
+  //video component styling
+  .embedded-entity.media {
+    padding-top: 14px;
+
+    + .ama-toc-link {
+      padding-top: 14px;
+    }
+
+    + br {
+      display: none;
+    }
+  }
 }
 
 //Rule to hide mobile toc if add toc field isnt selected


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8487: inconsistent margins before and after Video component](https://issues.ama-assn.org/browse/EWL-8487)

## Description
Adjust stylings and config to create consistent top and bottom margins for video components in articles and category pages.


## To Test
- Checkout import changes in the following PR: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/3051](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3051)
- confirm on desktop and tablet: total 28px between the margins of items before and after the Video Card component
-confirm on mobile: total 21px between the margins of items before and after the Video Card component
- Repeat above for both articles and category pages
- ex: category (/education/accelerating-change-medical-education)
- ex: articles (/practice-management/physician-health/pandemic-s-end-not-sight-8-ways-deal-stress)

## Visual Regressions
- N/A


## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
