### PR TITLE
EWL-8731: Fixes social icon cut off on people bio pages.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_people_bio.scss
+++ b/styleguide/source/assets/scss/05-pages/_people_bio.scss
@@ -39,4 +39,10 @@
       }
     }
   }
+
+  .ama__masthead__content__share-wrapper {
+    @include breakpoint($bp-med) {
+      display: block;
+    }
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-8731: People Bio Template | Social Icons are slightly cut off at the top of page](https://issues.ama-assn.org/browse/EWL-8731)

## Description
Added styling to prevent social icons from cutting off on desktop within people bio pages.


## To Test
- Link latest styling
- Clear caches
- Navigate to people bio page and confirm social icons appear with not pixels cut off
Example paths:
/member-groups-sections/organized-medical-staff/nancy-r-church-md
/about/board-trustees/susan-r-bailey-md

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
- N/A

## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
