### PR TITLE
EWL-9201: Update alert banner styling for mobile.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_alert.scss
@@ -1,25 +1,23 @@
 .ama__alert {
-  display: none;
+  display: flex;
   background-color: $homepagePurple;
   padding: $gutter / 2;
   color: $white;
   width: 100%;
   align-items: center;
   flex-direction: column;
+  background-image: url('../icons/svg/icon-homepage-alert.svg');
+  background-repeat: no-repeat;
+  background-position: 20px 50%;
+  position: relative;
 
   @include breakpoint($bp-small) {
-    display: flex;
-  }
-
-  @include breakpoint($bp-med) {
-    background-image: url('../icons/svg/icon-homepage-alert.svg');
-    background-repeat: no-repeat;
-    background-position: 20px 50%;
     flex-direction: row;
   }
 
   &__wrap {
     opacity: 0;
+    min-height: unset;
   }
 
   &__text {
@@ -27,20 +25,41 @@
     margin-bottom: 0;
     margin-right: 25px;
 
+    &.mobile {
+      padding-left: 40px;
+      a {
+        color: $white;
+      }
+    }
+
     @include breakpoint($bp-med) {
       margin-right: 0;
       margin-left: 50px;
       flex: 1;
+
+      &.mobile {
+        display: none;
+      }
+    }
+
+    @include breakpoint($bp-med max-width) {
+      &.desktop {
+        display: none
+      }
     }
   }
 
-  button {
+  .ama__button {
     text-transform: uppercase;
     font-weight: $font-weight-bold;
     margin: 0 auto;
 
     @include breakpoint($bp-med) {
       align-self: flex-end;
+    }
+
+    @include breakpoint($bp-med max-width) {
+      display: none;
     }
   }
 
@@ -60,6 +79,10 @@
 
     @include breakpoint($bp-med) {
       position: static;
+    }
+
+    @include breakpoint($bp-med max-width) {
+      top: 35%;
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

## JIRA Ticket(s)
- [EWL-9201: Homepage alert banner for mobile viewport](https://issues.ama-assn.org/browse/EWL-9201)


## Description:
Adjusts alert banner template to allow for mobile styling.


## To Test
- link styleguide locally
- Load homepage, if no alert banner set, create one, clear caches and reload page
- confirm styling of alert banner on mobile viewports matches the following zeplin: [https://app.zeplin.io/project/61ba3a074b0a235e235ffdd6/dashboard](https://app.zeplin.io/project/61ba3a074b0a235e235ffdd6/dashboard)

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs


## Remaining Tasks
- n/a

## Additional Notes
- n/a
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
