### PR TITLE
EWL-9162: Adjust spacing between image and text in series index artic…

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_series.scss
+++ b/styleguide/source/assets/scss/05-pages/_series.scss
@@ -133,7 +133,7 @@
     padding-left: 0;
     padding-right: 0;
     @include breakpoint($bp-small) {
-      padding-right: 20px;
+      padding-right: 19px;
     }
   }
 

--- a/styleguide/source/assets/scss/05-pages/_series.scss
+++ b/styleguide/source/assets/scss/05-pages/_series.scss
@@ -26,10 +26,6 @@
 
   .subscribe-series {
     display: none;
-    // Undo this when its time to implement this functionality
-    // @include breakpoint($bp-med) {
-    //   display: inline-block;
-    // }
     position: relative;
     top: -30px;
     @include type($myriad-pro, $font-weight-regular);
@@ -136,6 +132,9 @@
   .ama__subcategory-page-article-stub__text {
     padding-left: 0;
     padding-right: 0;
+    @include breakpoint($bp-small) {
+      padding-right: 20px;
+    }
   }
 
   .ama__layout--two-col-right--75-25__left {


### PR DESCRIPTION
…le stubs.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-9162: Series Index | Spacing between copy and image on swimlanes is not to spec](https://issues.ama-assn.org/browse/EWL-9162)

## Description
Adjust spacing between image and text within article stubs on series index pages.


## To Test
- Link styleguides locally
- Navigate to series index page (ex: /series/what-doctors-wish-patients-knew)
- Confirm spacing between images and text within in article stubs matches the following: [Zeplin](/series/what-doctors-wish-patients-knew)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
<img width="1100" alt="Screen Shot 2022-01-18 at 4 55 03 PM" src="https://user-images.githubusercontent.com/67962801/150031941-6eefe0a7-e098-4ab0-a669-e5c68d8b72c8.png">


## Remaining Tasks
- N/A

## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
