### PR TITLE
EWL-9235: Fixes click functionality for videos embedded within lists

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_image.scss
+++ b/styleguide/source/assets/scss/01-atoms/_image.scss
@@ -27,6 +27,11 @@
   &.align-legacy {
     &.video {
       width: 100%;
+      z-index: 999;
+      position: relative;
+      &:hover {
+        cursor: pointer;
+      }
       @include breakpoint($bp-small) {
         width: $inline-image-width;
       }


### PR DESCRIPTION
…tems in articles.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- [EWL-9235: Video in bullet points doesn't play](https://issues.ama-assn.org/browse/EWL-9235)

## Description
Adjusts styling to allow video items to still be clickable when embedded within list items on article nodes.


## To Test
- link latest styles
- Navigate to and edit an article
- Add several list items through the text editor
- within one of these list items embed a video media item
- save the node and confirm the video player can be interacted with

## Visual Regressions
- N/A


## Relevant Screenshots/GIFs
- N/A


## Remaining Tasks
- N/A

## Additional Notes
- N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
