### PR TITLE
EWL-9166: Resets padding for podcast player elements.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-bio.scss
@@ -19,7 +19,7 @@
 
   &__text {
     @include type($myriad-pro, $font-weight-regular);
-    font-ize: 20px;
+    font-size: 20px;
     color: $black;
     display: block;
     margin-top: -4px;

--- a/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
+++ b/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
@@ -7,6 +7,7 @@
   }
   h3 {
     margin-bottom: 6px;
+    padding: 0;
   }
   @include breakpoint($bp-small max-width) {
     h4 {
@@ -19,6 +20,7 @@
     color: #a1a1a4;
     margin-bottom: 30px;
     font-size: 12px;
+    padding: 0;
     @include breakpoint($bp-small) {
       margin-bottom: 0px;
     }
@@ -38,6 +40,11 @@
 
   &__episode_info {
     flex: 1;
+    padding: 0;
+    .ama__h4--purple,
+    .podcast-container {
+      padding: 0;
+    }
   }
 }
 
@@ -46,6 +53,7 @@ ul.ama__podcast-player__links {
   justify-content: space-between;
   margin-left: 0;
   margin-bottom: 32px;
+  padding: 0;
   @include breakpoint($bp-small) {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-9166: Simplecast Embed](https://issues.ama-assn.org/browse/EWL-9166)

## Description
Adds padding resets for simplecast podcasts to prevent page shifting on load.


## To Test
- Link latest styling
- Clear caches
- Navigate to article with simplecast podcast embedded
- Confirm podcast does not shift as page loads

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
