### PR TITLE
EWL-9228: Adds styling for gutter between link columns.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_annual-interum-block.scss
+++ b/styleguide/source/assets/scss/03-organisms/_annual-interum-block.scss
@@ -91,6 +91,9 @@
       &.mobile {
         display: block;
       }
+      .col.col-second {
+        padding-left: 34px;
+      }
       h3 a {
         color: $purple;
         text-decoration: none;
@@ -168,6 +171,13 @@
             }
           }
         }
+      }
+    }
+
+    .active_links-mg {
+      padding-left: 0;
+      @include breakpoint($bp-large) {
+        padding-left: 34px;
       }
     }
 

--- a/styleguide/source/assets/scss/03-organisms/_annual-interum-block.scss
+++ b/styleguide/source/assets/scss/03-organisms/_annual-interum-block.scss
@@ -91,8 +91,12 @@
       &.mobile {
         display: block;
       }
+      .col.col-first {
+        flex: 1;
+      }
       .col.col-second {
         padding-left: 34px;
+        flex: 1;
       }
       h3 a {
         color: $purple;
@@ -177,7 +181,7 @@
     .active_links-mg {
       padding-left: 0;
       @include breakpoint($bp-large) {
-        padding-left: 34px;
+        padding-left: 19px;
       }
     }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-9228: Home Page Annual Interim custom block | adjust desktop gutter width](https://issues.ama-assn.org/browse/EWL-9228)

## Description
Adds styling to add gutter spacing between meeting link columns.


## To Test
- Checkout the corresponding [ama-d8 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3170)
- link styles locally
- Navigate to annual interim block on homepage
- Confirm gutter between meeting link columns exists and matches the following (only on desktop) [Zeplin](https://app.zeplin.io/project/5da0e00b85f67a23e567b630/screen/61e9d9e9930a4eb59d5f822a)

## Visual Regressions
- N/A

## Relevant Screenshots/GIFs
![Screen Shot 2022-02-08 at 11 01 57 AM](https://user-images.githubusercontent.com/67962801/153038589-ce9bc304-9c20-46bd-9382-a88f994ed87d.png)



## Remaining Tasks
- N/A


## Additional Notes
- N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
