### PR TITLE
Additional search fixes

### DIFF
--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -209,7 +209,7 @@
           var searchInput = $(this).find("input[name*='search']");
 
           //Trim and check if search input has any value
-          if ($.trim(searchInput.val()).length < 2) {
+          if ($.trim(searchInput.val()).length < 1) {
             e.preventDefault();
             console.log('No search term entered');
             location.reload();

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -17,8 +17,9 @@
     }
   }
 
-  &__image {
+  &__image img {
     max-width: 280px;
+    max-height: 186px;
   }
 
   &__text {

--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -80,6 +80,7 @@ body.search-results {
     padding-top: 0;
     @include breakpoint($bp-large) {
       min-width: 880px;
+      padding-right: 0;
     }
     #block-ama-one-content {
       border-top: 1px solid $gray-20;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
-n/a

**Jira Ticket**
- n/a

## Description
Adjusts empty search script to stop only empty searches (previously was blocking one character searches).
Adjusts search image styling to fix ratio to 3:2


## To Test
- Checkout corresponding [ama-d8 PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3179)
- Link styleguide
- (Note, might need to run the script test on dev or stage)
- Run a search with a single character
- confirm search runs as expected
- Run search with NO INPUT
- Confirm search does not run and page reloads
- Repeat for main nav and search page form inputs

- Confirm images returned in search return in a 3:2 ratio (roughly 280px by 186px) per [zeplin design](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/60f7293fff2fd71110de55ea)

## Visual Regressions

- N/A

## Relevant Screenshots/GIFs
- N/A


## Remaining Tasks
- N/A


## Additional Notes
- N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
