### PR TITLE
EWL-0: Prevents facet gutter shift for empty searches

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -96,6 +96,9 @@ body.search-results {
       padding-right: 20px;
       max-width: 280px;
     }
+    @include breakpoint($bp-large) {
+      min-width: 280px;
+    }
     .ama__filter {
       border-top: 1px solid $gray-20;
       border-bottom: 1px solid $gray-20;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- N/A

**Jira Ticket**
- N/A

## Description
Adds min width to prevent visual error on large screen sizes for facet column in search.

## To Test
**NOTE**: Might need to be tested on dev or stage
- Run a search that returns no results (ex: https://wwwtest.ama-assn.org/search?search=Q2022&sort_by=search_api_relevance)
- Confirm no layout shift happens on load when at larger screen sizes
- Confirms sizing of column matches the following [zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/60f7293fff2fd71110de55ea)

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs
![Screen Shot 2022-02-14 at 10 43 47 AM](https://user-images.githubusercontent.com/67962801/153908006-c201b9b2-a0e5-4c75-a49e-be3323c6f3c8.png)


## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
