### PR TITLE
EWL-9274: Adjust styling for page grouping custom bock to prevent lin…

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -115,12 +115,19 @@
     }
   }
 
+  ul.link-list {
+    margin-top: 4px;
+  }
+
   .links {
     background-color: $pg-xtra-lt-blue;
     padding: $gutter / 2;
     flex: 100%;
     @include breakpoint($bp-small) {
       padding: $gutter / 2 $gutter $gutter / 2  $gutter / 2;
+    }
+    @include breakpoint($bp-med) {
+      padding: 10px 28px 10px 14px;
     }
 
     .ama_page_grouping_title {
@@ -206,8 +213,11 @@
     line-height: 0;
     background-color: $pg-lt-blue;
     @include breakpoint($bp-small) {
-      width: 150px;
       display: initial;
+      width: 200px;
+    }
+    @include breakpoint($bp-med) {
+      width: 150px;
     }
   }
 }


### PR DESCRIPTION
…e below image.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-9274: Page Grouping Custom Block | Incorrect Line Below Image](https://issues.ama-assn.org/browse/EWL-9274)

## Description
Adjust styling prevent line from showing below images.


## To Test
- link styleguide locally
- navigate to page with page grouping block (ex: http://ama-one.lndo.site/practice-management/digital/remote-patient-monitoring-playbook-implementation)
- confirm no blue line appears below image 

## Visual Regressions
- n/a


## Relevant Screenshots/GIFs
- n/a


## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
