### PR TITLE
EWL-9284: Update simplecast player padding.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
+++ b/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
@@ -1,9 +1,14 @@
 .ama__podcast-player {
   max-width: 966px;
+  margin-top: 8px;
   @include breakpoint($bp-small) {
     display: flex;
     flex-direction: row-reverse;
+    margin-top: 24px;
     margin-bottom: 30px;
+  }
+  @include breakpoint($bp-med) {
+    margin-top: 27px;
   }
   h3 {
     margin-bottom: 6px;
@@ -52,16 +57,16 @@ ul.ama__podcast-player__links {
   max-width: 966px;
   justify-content: space-between;
   margin-left: 0;
-  margin-bottom: 32px;
+  margin-bottom: 21px;
   padding: 0;
   @include breakpoint($bp-small) {
     display: flex;
     flex-wrap: wrap;
-    margin-bottom: 20px;
+    margin-bottom: 26px;
   }
   @include breakpoint($bp-large) {
     flex-direction: row;
-    margin-bottom: 32px;
+    margin-bottom: 29px;
   }
   li {
     list-style: none;
@@ -159,9 +164,33 @@ ul.ama__podcast-player__links {
         }
         &:nth-child(even) {
           margin-right: 4.35%;
+          margin-bottom: 0;
         }
         &:last-child {
           margin-right: 0;
+          margin-bottom: 0;
+        }
+      }
+      @include breakpoint($bp-small max-width) {
+        &:nth-child(even) {
+          margin-bottom: 28px;
+        }
+      }
+    }
+  }
+  //Custom styling for when all podcast links present
+  &.full_links {
+    @include breakpoint($bp-large max-width) {
+      li {
+        &:nth-child(3), &:nth-child(4) {
+          margin-bottom: 0;
+        }
+      }
+    }
+    @include breakpoint($bp-small max-width) {
+      li {
+        &:nth-child(3) {
+          margin-bottom: 28px;
         }
       }
     }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-9284: Podcast Player | Adjust Padding](https://issues.ama-assn.org/browse/EWL-9284)

## Description
Adjusts simplecast template to add class for when all links are present, this is in order to better control the padding/spacing between and before/after elements.


## To Test
- checkout and link ama-d8 PR locally: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/3221](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3221)
- Add a simplecast to an article somewhere in the middle of the body text 
- **NOTE** for easier results, place a <hr> tag above and below podcast 
- **This styling is for the padding above and below the player itself, ignore spacing coming from sibling elements**
- Compare padding against the following [zeplins](https://zpl.io/3XkgBLA) and confirm spacing above and below podcast player matches
- Repeat for all configurations of podcast player links (1 - 4 links, desktop, tablet, mobile)

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
