### PR TITLE
EWL-9350 reduce image size search

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -18,8 +18,8 @@
   }
 
   &__image img {
-    max-width: 280px;
-    max-height: 186px;
+    max-width: 180px;
+    max-height: 120px;
   }
 
   &__text {

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -17,13 +17,15 @@
     }
   }
 
-  &__image img {
-    max-width: 180px;
-    max-height: 120px;
-  }
-
   &__text {
     flex-grow: 1;
+  }
+
+  @include breakpoint($bp-small) {
+    &__image img {
+      max-width: 180px;
+      max-height: 120px;
+    }
   }
 
   @include breakpoint($bp-med) {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-9350: SERP | Reduce Image Size](https://issues.ama-assn.org/browse/EWL-9350)

## Description
Adjusted image size of search result images.


## To Test
- link latest styleguide
- index search locally if not done already (/admin/config/search/search-api/index/acquia_search_solr_search_api_solr_index)
- run a search and confirm images appear according to the following zeplin: [https://zpl.io/W4pGmB1](https://zpl.io/W4pGmB1)
- **NOTE** This does not include Best Bet image, that should stay at the same size it currently is displayed as.

## Visual Regressions
- n/a


## Relevant Screenshots/GIFs
![Screen Shot 2022-03-17 at 1 52 27 PM](https://user-images.githubusercontent.com/67962801/158875232-b8164649-ad1a-468f-9d97-4b2cbb57bea1.png)



## Remaining Tasks
- n/a


## Additional Notes
**NOTE** This does not include Best Bet image, that should stay at the same size it currently is displayed as.

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
