### PR TITLE
EWL-9308: Adds hover state explore series links

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_series-tag.scss
+++ b/styleguide/source/assets/scss/02-molecules/_series-tag.scss
@@ -39,6 +39,9 @@
     text-decoration: none;
     margin-left: 17px;
     line-height: 1.8;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-9308: Explore Series Link | Add Hover State](https://issues.ama-assn.org/browse/EWL-9308)

## Description
Adds hover state to explore series link.


## To Test
- Link latest styles locally 
- Navigate to any article with a series tag (ex: /residents-students/match/advice-sanjay-desai-md-what-do-if-you-dont-match)
- Confirm series link hover state produces an underline

## Visual Regressions
- n/a


## Relevant Screenshots/GIFs
![Screen Shot 2022-03-17 at 4 51 37 PM](https://user-images.githubusercontent.com/67962801/158900691-877b576b-0404-4a57-86db-983e26f9d78e.png)



## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
