### PR TITLE
EWL-9309: Fixes duplicate image issue when multiple simplecast embeds…

### DIFF
--- a/styleguide/source/assets/js/podcast-player.js
+++ b/styleguide/source/assets/js/podcast-player.js
@@ -2,29 +2,9 @@
   Drupal.behaviors.ama_podcast = {
     attach: function (context, settings) {
       $(document).ready(function() {
-        //Check initial window with
-        playerPlacement();
-
         //Check number of links
         oddLinks();
-      
-        //Check window width on resize
-        $(window).resize(function() {
-          playerPlacement();
-        });
-
       });
-
-      function playerPlacement() {
-        var podcastImage = $('div.ama__podcast-player .ama__image');
-        var width = $(document).width();
-
-        if (width < 600) {
-          podcastImage.insertBefore('div.podcast-container');
-        } else if (width > 600) {
-          podcastImage.insertAfter('div.ama__podcast-player__episode_info');
-        }
-      }
 
       function oddLinks() {
         var count = $("ul.ama__podcast-player__links li").length;

--- a/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
+++ b/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
@@ -3,7 +3,7 @@
   margin-top: 8px;
   @include breakpoint($bp-small) {
     display: flex;
-    flex-direction: row-reverse;
+    flex-direction: row;
     margin-top: 24px;
     margin-bottom: 30px;
   }
@@ -44,11 +44,28 @@
   }
 
   &__episode_info {
+    display: flex;
     flex: 1;
+    flex-direction: column;
     padding: 0;
-    .ama__h4--purple,
+    h4.ama__h4--purple,
     .podcast-container {
       padding: 0;
+      overflow: auto;
+    }
+    h4.ama__h4--purple {
+      order: -1;
+    }
+    @include breakpoint($bp-small) {
+      display: block;
+      flex-direction: row;
+      h4.ama__h4--purple,
+      .podcast-container {
+        order: 0;
+      }
+      img.ama__image {
+        float: left;
+      }
     }
   }
 }


### PR DESCRIPTION
… present

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-9309: Podcast Embed | Allow Multiple Players on One Page](https://issues.ama-assn.org/browse/EWL-9309)

## Description
Fixes issue where multiple images display when more than one podcast is placed on a page. Removes script causing error and reconfigures css to prevent multiple image issue while keeping elements responsive according to the provided zeplin designs.


## To Test
- Checkout the corresponding PR: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/3261](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3261)
- edit any article and embed two or more simplecast media items into the body
- save and publish article
- confirm styling matches the following zeplins: https://zpl.io/2EG85Ne
- confirm only one image displays next to each individual simeplecast

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs
![Screen Shot 2022-03-25 at 12 23 00 PM](https://user-images.githubusercontent.com/67962801/160171257-38f5f733-fa22-47d2-afbd-b8545a372414.png)



## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
