### PR TITLE
EWL-9363: Add styling for read time on index page listings.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_read-time.scss
+++ b/styleguide/source/assets/scss/01-atoms/_read-time.scss
@@ -9,13 +9,4 @@
 .date + .read_time {
   display: inline-block;
   position: relative;
-  h3 {
-    &:before {
-      content: " . ";
-      font-size: 40px;
-      position: relative;
-      top: -5px;
-      left: 2px;
-    }
-  }
 }

--- a/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
@@ -30,19 +30,41 @@
     @extend .ama__h4--purple;
     font-weight: $font-weight-semibold;
     font-size: 0.78em;
+    line-height: 1;
     margin: 0 0 ($gutter / 2) 0;
-    .stub-date {
-      @include type($myriad-pro, $font-weight-regular);
-      text-transform: uppercase;
-      display: block;
-      color: $gray-50;
-      line-height:.9em;
-      padding-bottom: ($gutter / 2.5);
-    }
     &--topics {
       .stub-date {
         padding-bottom: 0;
       }
+    }
+  }
+
+  &__date-time {
+    font-weight: $font-weight-regular;
+    font-size: 20px;
+    line-height: 23px;
+    color: $gray-50;
+    text-transform: uppercase;
+    @include breakpoint($bp-small) {
+      font-size: 0.78em;
+      line-height: .9em;
+    }
+    .stub-date {
+      @include type($myriad-pro, $font-weight-regular);
+      padding-bottom: ($gutter / 2.5);
+      display: inline-block;
+    }
+    span {
+      font-size: 14px;
+      font-weight: bold;
+      padding-left: 1px;
+      padding-right: 3px;
+      position: relative;
+      bottom: 0px;
+    }
+    .read_time {
+      padding-bottom: 11.2px;
+      display: inline-block;
     }
   }
 

--- a/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
@@ -68,6 +68,10 @@
     }
   }
 
+  &__paragraph {
+    margin-bottom: 0;
+  }
+
   &:hover {
     .ama__subcategory-page-article-stub__heading {
       text-decoration: underline;

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -46,12 +46,31 @@
   }
 
   .stub-date {
-    display: block;
+    display: inline-block;
     font-size: 14px;
     text-transform: uppercase;
     line-height: normal;
     color: $gray-50;
     margin-bottom: 14px;
+  }
+
+  .stub-date + span {
+    display: inline-block;
+    font-size: 14px;
+    font-weight: bold;
+    color: $gray-50;
+    padding-left: 1px;
+    padding-right: 3px;
+    position: relative;
+    bottom: 0px;
+  }
+  .read_time {
+    font-weight: $font-weight-regular;
+    font-size: 14px;
+    color: $gray-50;
+    text-transform: uppercase;
+    padding-bottom: 11.2px;
+    display: inline-block;
   }
 
   &:hover .ama__search-result__title {

--- a/styleguide/source/assets/scss/05-pages/_content-type-listing.scss
+++ b/styleguide/source/assets/scss/05-pages/_content-type-listing.scss
@@ -140,17 +140,6 @@
     }
   }
 
-  .stub-date {
-    font-family: "myriad-pro", "Helvetica", "Arial", "Open Sans", sans-serif;
-    font-size: 14px;
-    font-weight: 400;
-    text-transform: uppercase;
-    display: block;
-    color: #767676;
-    line-height: .9em;
-    padding-bottom: 14px;
-  }
-
   .ama__subcategory-index__stub {
     .ama__subcategory-page-article-stub {
       border-bottom: solid 1px #CBCBCB;

--- a/styleguide/source/assets/scss/05-pages/_series.scss
+++ b/styleguide/source/assets/scss/05-pages/_series.scss
@@ -160,17 +160,6 @@
     margin-right: 28px;
   }
 
-  .stub-date {
-    font-family: "myriad-pro", "Helvetica", "Arial", "Open Sans", sans-serif;
-    font-size: 14px;
-    font-weight: 400;
-    text-transform: uppercase;
-    display: block;
-    color: #767676;
-    line-height: .9em;
-    padding-bottom: 14px;
- }
-
  .ama__subcategory-index__stub {
 
   .ama__subcategory-page-article-stub {

--- a/styleguide/source/assets/scss/05-pages/_trending.scss
+++ b/styleguide/source/assets/scss/05-pages/_trending.scss
@@ -37,21 +37,6 @@
     margin-right: 28px;
   }
 
-  .stub-date {
-    font-family: "myriad-pro", "Helvetica", "Arial", "Open Sans", sans-serif;
-    font-size: 14px;
-    font-weight: 400;
-    text-transform: uppercase;
-    display: block;
-    color: #767676;
-    line-height: .9em;
-    padding-bottom: 11.2px;
- }
-
- .ama__subcategory-page-article-stub__subcategory {
-  margin: 0 0 7px 0;
- }
-
  @include breakpoint($bp-small max-width) {
   .ama__category-index {
     .ama__membership {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

## JIRA Ticket(s)
- [EWL-9363: Read Time | Automatically Display on Indexes](https://issues.ama-assn.org/browse/EWL-9363)


## Description:
Adds read time to listing views on index pages.


## To Test:
- checkout ama-d8 pr: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/3307](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3307)
- Import latest config
- clear caches
- navigate to category page and confirm read time appears in listings view
- confirm styling matches the following [zeplin](https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/623e3db96a3c1aa6cb9ea865)
- Repeat last two steps above for subcategory, topic and series term pages

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs
![Screen Shot 2022-04-18 at 2 38 28 PM](https://user-images.githubusercontent.com/67962801/163871548-fbb87343-2078-4a03-b030-967f7b1d1d23.png)


## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
