### PR TITLE
Remove styling rule to prevent video shift on homepage.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_home-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_home-page-hero.scss
@@ -30,7 +30,6 @@
           font-size: 14px;
         }
       }
-      .ama__video__container,
       > .ama__image {
         .series-icon {
           display: none;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- n/a

## Description
Adjust styling to prevent youtube video layout shifting into place on load.


## To Test
-checkout ama-d8 pr: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/3336](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3336)
- link styleguide locally
- clear caches
- load ama one homepage and confirm youtube video in hero section loads in place

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs
- n/a


## Remaining Tasks
- n/a


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
