### PR TITLE
EWL-8141: Remove leading and trailing white space from search queries.

### DIFF
--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -214,6 +214,13 @@
             console.log('No search term entered');
             location.reload();
           }
+
+          //Ensure no spaces before or after query are counted in search
+          $(this).find(searchInput).each(function(){
+            //Submit trimmed value
+            $(this).val($.trim($(this).val()));
+          });   
+          
       });
     }
   };


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-8141: Ticket Title](https://issues.ama-assn.org/browse/EWL-8141)

## Description
Added script to remove any white space before/after term entered as search query. Does not remove any spaces between words in the query.


## To Test
- link styleguide locally
- clear caches
- on any search form, perform a search with spaces before/after the entered term/terms
- confirm search submits with spaces before/after term removed

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs
- n/a


## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
