### PR TITLE
EWL-9500: Fix 30/70 block image on mobile.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
+++ b/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
@@ -103,7 +103,8 @@
     &__background {
 
       @include breakpoint($bp-small max-width) {
-        background-image: none;
+        background-image: none !important;
+        min-height: unset;
       }
     }
   }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-9500: 30/70 Custom Block | Image Broken on Mobile](https://issues.ama-assn.org/browse/EWL-9500)

## Description
Adjust styling to fix 30/70 image repeat bug on mobile.


## To Test
- link styleguide locally
- clear caches
- Naivgate to page with 30/70 block (ex: /delivering-care/public-health/covid-19-2019-novel-coronavirus-resource-center-physicians)
- Confirm on mobile 30/70 block displays correctly (No doubling of images, no white space between image and header)

## Visual Regressions
- n/a


## Relevant Screenshots/GIFs
![Screen Shot 2022-05-23 at 10 34 13 AM](https://user-images.githubusercontent.com/67962801/169855517-cb011450-93ec-43bd-990c-8908f5a96b44.png)



## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
