### PR TITLE
EWL-8857: 30/70 block on category page styling.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
+++ b/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
@@ -119,7 +119,9 @@
   }
 }
 
-.ama__news-article {
+.ama__news-article,
+.js-layout-builder-block,
+.layout__region {
   .hero-evergreen {
     &__buttons .ama__button {
       border: solid 1px #471b6d;
@@ -129,6 +131,24 @@
         background-color: #46166b;
         color: $white;
       }
+    }
+  }
+}
+
+.js-layout-builder-block,
+.layout.section:not(.ama__category__row) {
+  .hero-evergreen {
+    margin-bottom: $gutter * .75;
+    @include breakpoint($bp-small) {
+      margin-bottom: $gutter;
+    }
+  }
+}
+
+.ama__layout--two-col-right--75-25__top {
+  .hero-evergreen {
+    @include breakpoint($bp-small) {
+      margin-right: 10px;
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-8857: Subcategory & Category | Add 30/70 Custom Block](https://issues.ama-assn.org/browse/EWL-8857)

## Description
Adjust styling for 30/70 block on category and subcategory pages.


## To Test
- lando gulp serve
- link styleguide locally
- navigate to any category page and edit layout
- place a 30/70 block in a section 
- confirm styling of block in the layout matches the following zeplin:
[Desktop](https://zpl.io/25RPy5J)

[Tablet](https://zpl.io/adwdpeL)

[Mobile](https://zpl.io/VqeB68G)
- save layout and view page, confirm styling of 30/70 block matches the above zeplins
- repeat for a subcategory page

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
