### PR TITLE
EWL-9531: restyled mobile display of 70/30 block.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
+++ b/styleguide/source/assets/scss/02-molecules/_hero-evergreen.scss
@@ -42,14 +42,17 @@
     min-height: 366px;
 
     .hero-evergreen__buttons {
-      @include gutter($padding-top-half...);
-      @include gutter($padding-bottom-full...);
       display: flex;
-      background: $white;
       flex-flow: column wrap;
       justify-content: space-evenly;
-      min-height: 200px;
+      min-height: 150px;
       align-self: auto;
+      @include breakpoint($bp-small) {
+        min-height: 200px;
+        background: $white;
+        @include gutter($padding-top-half...);
+        @include gutter($padding-bottom-full...);
+      }
 
       //Fix for overriding jquery widget
       .ama__button {
@@ -103,8 +106,7 @@
     &__background {
 
       @include breakpoint($bp-small max-width) {
-        background-image: none !important;
-        min-height: unset;
+
       }
     }
   }


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-9531: 70/30 mobile display](https://issues.ama-assn.org/browse/EWL-9531)


## Description:
removed mobile image and button formatting on mobile


## To Test:
- pull and serve branch
- see further instructions in D8 PR https://github.com/AmericanMedicalAssociation/ama-d8/pull/3435

## Automated Test:
N/A


## Style Guide:
N/A


## Relevant Screenshots/GIFs:
N/A


## Additional Notes:
N/A


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
