### PR TITLE
EWL-9238: Article stub series link style update.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -73,7 +73,7 @@
       width: 75%;
     }
   }
-  .related-series-tag {
+  .related-series-tag a {
     font-size: 14px;
     display:block;
     color: $purple;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

## JIRA Ticket(s)
- [EWL-9238: Article Stub List Custom Block Series Automation | Link to Series Index Page](https://issues.ama-assn.org/browse/EWL-9238)


## Description:
Makes any series title within an article stub block a link to the series index page.

## To Test:
- checkout ama-d8 pr locally: [https://github.com/AmericanMedicalAssociation/ama-d8/pull/3502](https://github.com/AmericanMedicalAssociation/ama-d8/pull/3502)
- import latest config
- navigate to an index page with a series article
- confirm series title links to full series page
- confirm hover state of series link matches the following zeplin: [https://app.zeplin.io/project/621ea02e23d31ca9240cb683/screen/62bf2ae7a7a0451592a11b41](https://app.zeplin.io/project/621ea02e23d31ca9240cb683/screen/62bf2ae7a7a0451592a11b41)

