### PR TITLE
bugfix/fix block border padding issue

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -31,6 +31,8 @@
     background-color: #46166b;
     min-height: 28px;
     display: flex;
+    margin-bottom: 0;
+    margin-top: 0;
 
     .ama__membership_logo {
       margin-top: 4px;
@@ -132,7 +134,7 @@ a.ama__membership {
     }
     @include breakpoint($bp-med min-width) {
       width: 200px;
-      height: 70px; 
+      height: 70px;
     }
 
     .logo {
@@ -181,7 +183,7 @@ a.ama__membership {
   .ama__membership_cta_container {
     margin: 0 auto;
     display: block;
-    max-width: 75%; 
+    max-width: 75%;
     text-align: center;
     position: absolute;
     bottom: 21px;


### PR DESCRIPTION
## Ticket(s)
N/A

## Description
removes top and bottom margin from membership logo container


## To Test
- [ ] pull and serve
- [ ] verify that the purple top border of the membership blocks are flush to the top.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
