### PR TITLE
ADF-122: Prototype search bar ( AMA Doctor Finder)

### DIFF
--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
@@ -1,13 +1,12 @@
 {
-  "searchField": {
-    "label": "Search",
-    "id": "ama__search__input",
-    "name": "text field",
+  "searchFieldDrFinder": {
+    "label": "Search by name, location, or specialty",
+    "id": "ama-dr-finder-search-field__input",
+    "name": "ama-dr-finder-search-field__name",
     "placeholder": "",
-    "helpText": "Help Text"
-  },
-  "button" : {
-    "type" : "button",
-    "buttonSize" : ""
+    "button": {
+      "type": "button",
+      "ariaLabel": "Search button"
+    }
   }
 }

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
@@ -1,0 +1,13 @@
+{
+  "searchField": {
+    "label": "Search",
+    "id": "ama__search__input",
+    "name": "text field",
+    "placeholder": "",
+    "helpText": "Help Text"
+  },
+  "button" : {
+    "type" : "button",
+    "buttonSize" : ""
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.md
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.md
@@ -9,7 +9,6 @@ Search field that appears in the Doctor Finder pages.
      "label": type: string / optional
      "name": type: string / optional
      "placeholder": type: string / optional
-     "helpText": type: string / optional
   }
 }
 ~~~

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.md
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.md
@@ -1,0 +1,15 @@
+### Description
+Search field that appears in the Doctor Finder pages.
+
+
+### Variables
+~~~
+{
+  "searchField": {
+     "label": type: string / optional
+     "name": type: string / optional
+     "placeholder": type: string / optional
+     "helpText": type: string / optional
+  }
+}
+~~~

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
@@ -1,3 +1,8 @@
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder search field with label.
+#}
+
 <div class="ama-dr-finder-search-field">
   <label
     for="{{ searchFieldDrFinder.id }}"

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
@@ -1,11 +1,23 @@
-<div class="ama-dr-finder__search__field ama-dr-finder__search__field--in-body">
-  <label for="ama-dr-finder__search__label" class="is-vishidden">{{ searchField.label }}:</label>
-  <input id="{{ searchField.id }}" class="ama-dr-finder__search__field__input" name="{{ searchField.name }}" type="text" placeholder="{{ searchField.placeholder }}" required="" aria-required="true">
-  <div class="ama-dr-finder__global-search__action" aria-label="Search button">
-    <button type="{{ button.type }}"
-            class="ama-dr-finder__button {{ " " ~ buttonSize }} {{ " " ~ buttonStyle}} {{ " " ~ class }}"
-            aria-label="{{ button.info }}">
-      {% include '@atoms/media/icons/svg/icon-search-white.twig' %}
-    </button>
-  </div>
+<div class="ama-dr-finder-search-field">
+  <label
+    for="{{ searchFieldDrFinder.id }}"
+    class="ama-dr-finder-search-field__label"
+  >{{ searchFieldDrFinder.label }}
+  </label>
+  <input
+    id="{{ searchFieldDrFinder.id }}"
+    class="ama-dr-finder-search-field__input"
+    name="{{ searchFieldDrFinder.name }}"
+    type="text"
+    placeholder="{{ searchFieldDrFinder.placeholder }}"
+    required="{{ searchFieldDrFinder.required }}"
+    aria-required="{{ searchFieldDrFinder.required }}"
+  >
+  <button
+    type="{{ searchFieldDrFinder.button.type }}"
+    class="ama-dr-finder-search-field__button"
+    aria-label="{{ searchFieldDrFinder.button.ariaLabel }}"
+  >
+    {% include '@atoms/media/icons/svg/icon-search-white.twig' %}
+  </button>
 </div>

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
@@ -1,0 +1,11 @@
+<div class="ama-dr-finder__search__field ama-dr-finder__search__field--in-body">
+  <label for="ama-dr-finder__search__label" class="is-vishidden">{{ searchField.label }}:</label>
+  <input id="{{ searchField.id }}" class="ama-dr-finder__search__field__input" name="{{ searchField.name }}" type="text" placeholder="{{ searchField.placeholder }}" required="" aria-required="true">
+  <div class="ama-dr-finder__global-search__action" aria-label="Search button">
+    <button type="{{ button.type }}"
+            class="ama-dr-finder__button {{ " " ~ buttonSize }} {{ " " ~ buttonStyle}} {{ " " ~ class }}"
+            aria-label="{{ button.info }}">
+      {% include '@atoms/media/icons/svg/icon-search-white.twig' %}
+    </button>
+  </div>
+</div>

--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -1,0 +1,120 @@
+.ama-dr-finder__search__field {
+  display: flex;
+  align-items: center;
+
+  @include breakpoint($bp-small) {
+    flex-direction: row;
+    align-items: baseline;
+    margin-bottom: 0;
+  }
+
+  .form-actions {
+    margin-left: -24px;
+  }
+
+  // This has to be specific b/c it's so different.
+  &__input[type="text"] {
+    font-style: italic;
+    border: 0;
+    border-bottom: 1px solid $pg-blue;
+    color: $gray-50;
+    line-height: 1.2;
+    padding: 1em 28px 3px 0;
+
+    &:focus,
+    &:active {
+      border: 0;
+      border-bottom: 1px solid $light-blue;
+      color: $black;
+      font-style: normal;
+    }
+  }
+
+  .form-submit {
+    @extend .icon--search-purple;
+    background-color: transparent;
+    background-size: contain;
+    background-position: 0 0;
+    width: 25px;
+    height: 30px;
+    padding:0;
+    margin: 0;
+    min-height: 30px;
+    min-width: 25px;
+    max-height: 30px;
+    max-width: 25px;
+    text-indent: -999px;
+    overflow: hidden;
+    padding-bottom: calc(100% * 3 / 4);
+
+    &:hover {
+      border: 0;
+    }
+  }
+
+  .ama__applied-filters__remove {
+    display: none;
+  }
+
+  // This has to be specific b/c it's so different.
+  &__button {
+    margin-left: -24px;
+    background-color: transparent;
+    border: none;
+    padding: 0;
+    background-size: 25px 25px;
+    min-height: 25px;
+    max-height: 25px;
+  }
+
+  &--in-body {
+    align-items: stretch;
+
+    input[type="text"] {
+      border: 1px solid $purple;
+      margin: 0;
+
+      &:active,
+      &:focus {
+        border: 1px solid $purple;
+      }
+    }
+
+
+    .ama__search__field__input[type="text"],
+    .ama__search__field__input[type="text"]:focus,
+    .ama__search__field__input[type="text"]:active {
+      padding: 5px 10px;
+    }
+
+    .ama__search__field__button {
+      background-color: $purple;
+      margin: 0;
+      padding: 5px 5px 0;
+    }
+
+    .subcategory_listing {
+      min-height: 37px;
+      max-height: 40px;
+
+      svg {
+        height: 24px;
+        width: 26px;
+      }
+    }
+  }
+
+  &__clear-button {
+    color: $purple;
+    display: inline-block;
+    font-size: 20px;
+    line-height: 25px;
+    font-style: italic;
+    padding: 21px 0;
+    @include breakpoint($bp-med min-width) {
+      padding: 7px 0 14px 0;
+      font-size: 18px;
+      line-height: 27px;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -31,7 +31,5 @@
 .ama-dr-finder-search-field__button {
   background-color: $purple;
   margin: 0;
-  padding: 10px 15px;
+  padding: 10px 20px;
 }
-
-

--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -30,32 +30,6 @@
     }
   }
 
-  .form-submit {
-    @extend .icon--search-purple;
-    background-color: transparent;
-    background-size: contain;
-    background-position: 0 0;
-    width: 25px;
-    height: 30px;
-    padding:0;
-    margin: 0;
-    min-height: 30px;
-    min-width: 25px;
-    max-height: 30px;
-    max-width: 25px;
-    text-indent: -999px;
-    overflow: hidden;
-    padding-bottom: calc(100% * 3 / 4);
-
-    &:hover {
-      border: 0;
-    }
-  }
-
-  .ama__applied-filters__remove {
-    display: none;
-  }
-
   // This has to be specific b/c it's so different.
   &__button {
     margin-left: -24px;
@@ -81,26 +55,16 @@
     }
 
 
-    .ama__search__field__input[type="text"],
-    .ama__search__field__input[type="text"]:focus,
-    .ama__search__field__input[type="text"]:active {
+    .ama-dr-finder__search__field__input[type="text"],
+    .ama-dr-finder__search__field__input[type="text"]:focus,
+    .ama-dr-finder__search__field__input[type="text"]:active {
       padding: 5px 10px;
     }
 
-    .ama__search__field__button {
+    .ama-dr-finder__search__field__button {
       background-color: $purple;
       margin: 0;
       padding: 5px 5px 0;
-    }
-
-    .subcategory_listing {
-      min-height: 37px;
-      max-height: 40px;
-
-      svg {
-        height: 24px;
-        width: 26px;
-      }
     }
   }
 

--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -1,84 +1,34 @@
-.ama-dr-finder__search__field {
+.ama-dr-finder-search-field {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+}
 
-  @include breakpoint($bp-small) {
-    flex-direction: row;
-    align-items: baseline;
-    margin-bottom: 0;
-  }
+.ama-dr-finder-search-field__label {
+  width: 100%;
+  color: $purple;
+  font-size: inherit;
+  text-transform: inherit;
+}
 
-  .form-actions {
-    margin-left: -24px;
-  }
+.ama-dr-finder-search-field__input[type="text"] {
+  flex: 1;
+  font-style: italic;
+  border: 1px solid $purple;
+  color: $gray-50;
+  line-height: 1.2;
 
-  // This has to be specific b/c it's so different.
-  &__input[type="text"] {
-    font-style: italic;
-    border: 0;
-    border-bottom: 1px solid $pg-blue;
-    color: $gray-50;
-    line-height: 1.2;
-    padding: 1em 28px 3px 0;
-
-    &:focus,
-    &:active {
-      border: 0;
-      border-bottom: 1px solid $light-blue;
-      color: $black;
-      font-style: normal;
-    }
-  }
-
-  // This has to be specific b/c it's so different.
-  &__button {
-    margin-left: -24px;
-    background-color: transparent;
-    border: none;
-    padding: 0;
-    background-size: 25px 25px;
-    min-height: 25px;
-    max-height: 25px;
-  }
-
-  &--in-body {
-    align-items: stretch;
-
-    input[type="text"] {
-      border: 1px solid $purple;
-      margin: 0;
-
-      &:active,
-      &:focus {
-        border: 1px solid $purple;
-      }
-    }
-
-
-    .ama-dr-finder__search__field__input[type="text"],
-    .ama-dr-finder__search__field__input[type="text"]:focus,
-    .ama-dr-finder__search__field__input[type="text"]:active {
-      padding: 5px 10px;
-    }
-
-    .ama-dr-finder__search__field__button {
-      background-color: $purple;
-      margin: 0;
-      padding: 5px 5px 0;
-    }
-  }
-
-  &__clear-button {
-    color: $purple;
-    display: inline-block;
-    font-size: 20px;
-    line-height: 25px;
-    font-style: italic;
-    padding: 21px 0;
-    @include breakpoint($bp-med min-width) {
-      padding: 7px 0 14px 0;
-      font-size: 18px;
-      line-height: 27px;
-    }
+  &:focus,
+  &:active {
+    border: 1px solid $purple;
+    color: $black;
+    font-style: normal;
   }
 }
+
+.ama-dr-finder-search-field__button {
+  background-color: $purple;
+  margin: 0;
+  padding: 10px 15px;
+}
+
+

--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -3,6 +3,7 @@
   flex-wrap: wrap;
 }
 
+// This label needs to be on top of input.
 .ama-dr-finder-search-field__label {
   width: 100%;
   color: $purple;

--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -11,7 +11,9 @@
 }
 
 .ama-dr-finder-search-field__input[type="text"] {
-  flex: 1;
+  flex-grow : 1;
+  flex-shrink : 1;
+  flex-basis : 0;
   font-style: italic;
   border: 1px solid $purple;
   color: $gray-50;


### PR DESCRIPTION
**Jira Ticket**
- [ADF-122: Prototype search bar](https://palantir.atlassian.net/browse/ADF-122)

## Description

- Add Search field dr finder forms on the styleguide

## To Test

- Checkout the **ADF-122-prototype-search-bar** branch and cd into styleguid, run gulp serve to spin up the pattern lab style guide.

- Verify that **search-field-dr-finder.json / search-field-dr-finder.md / search-field-dr-finder.twig** files exist under  styleguide/ source / _patterns/01-atomas/ forms. 

- Verify that **_search-field-dr-finder.scss** file exists under  styleguide/ source / assets/scss/01-atoms.

## Relevant Screenshots/GIFs

<img width="1176" alt="Screen Shot 2022-09-26 at 3 12 00 PM" src="https://user-images.githubusercontent.com/54925022/192381816-175d7a93-96a6-40ad-a7e9-e73d6727b00f.png">


## Additional Notes
Please check if there is a way to make the search button with icon little wider. let me know. I can make the change.
