### PR TITLE
ADF-124 : Prototype "credentialing products" bar (AMA Doctor Finder)

### DIFF
--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
@@ -6,7 +6,8 @@
     "placeholder": "",
     "button": {
       "type": "button",
-      "ariaLabel": "Search button"
+      "ariaLabel": "Search button",
+      "class": "search-location"
     }
   }
 }

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.json
@@ -1,10 +1,19 @@
 {
   "searchFieldDrFinder": {
-    "label": "Search by name, location, or specialty",
-    "id": "ama-dr-finder-search-field__input",
-    "name": "ama-dr-finder-search-field__name",
-    "placeholder": "",
+    "fieldFirst": {
+      "label": "Name",
+      "id": "ama-dr-finder-search-field__input-first",
+      "name": "ama-dr-finder-search-field__name-first",
+      "placeholder": "First Last"
+    },
+    "fieldSecond": {
+      "label": "State, city, zip code",
+      "id": "ama-dr-finder-search-field__input-second",
+      "name": "ama-dr-finder-search-field__name-second",
+      "placeholder": "Chicago"
+    },
     "button": {
+      "text": "Search",
       "type": "button",
       "ariaLabel": "Search button",
       "class": "search-location"

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
@@ -4,25 +4,43 @@
 #}
 
 <div class="ama-dr-finder-search-field">
-  <label
-    for="{{ searchFieldDrFinder.id }}"
-    class="ama-dr-finder-search-field__label"
-  >{{ searchFieldDrFinder.label }}
-  </label>
-  <input
-    id="{{ searchFieldDrFinder.id }}"
-    class="ama-dr-finder-search-field__input"
-    name="{{ searchFieldDrFinder.name }}"
-    type="text"
-    placeholder="{{ searchFieldDrFinder.placeholder }}"
-    required="{{ searchFieldDrFinder.required }}"
-    aria-required="{{ searchFieldDrFinder.required }}"
-  >
+  <div class="ama-dr-finder-search-field__first">
+    <label
+      for="{{ searchFieldDrFinder.fieldFirst.id }}"
+      class="ama-dr-finder-search-field__label"
+    >{{ searchFieldDrFinder.fieldFirst.label }}
+    </label>
+    <input
+      id="{{ searchFieldDrFinder.fieldFirst.id }}"
+      class="ama-dr-finder-search-field__input"
+      name="{{ searchFieldDrFinder.fieldFirst.name }}"
+      type="text"
+      placeholder="{{ searchFieldDrFinder.fieldFirst.placeholder }}"
+      required="{{ searchFieldDrFinder.fieldFirst.required }}"
+      aria-required="{{ searchFieldDrFinder.fieldFirst.required }}"
+    >
+  </div>
+  <div class="ama-dr-finder-search-field__second">
+    <label
+      for="{{ fieldSecond.searchFieldDrFinder.id }}"
+      class="ama-dr-finder-search-field__label"
+    >{{ searchFieldDrFinder.fieldSecond.label }}
+    </label>
+    <input
+      id="{{ searchFieldDrFinder.fieldSecond.id }}"
+      class="ama-dr-finder-search-field__input"
+      name="{{ searchFieldDrFinder.fieldSecond..name }}"
+      type="text"
+      placeholder="{{ searchFieldDrFinder.fieldSecond.placeholder }}"
+      required="{{ searchFieldDrFinder.fieldSecond.required }}"
+      aria-required="{{ searchFieldDrFinder.fieldSecond.required }}"
+    >
+  </div>
   <button
     type="{{ searchFieldDrFinder.button.type }}"
     class="ama-dr-finder-search-field__button {{ searchFieldDrFinder.button.class }}"
     aria-label="{{ searchFieldDrFinder.button.ariaLabel }}"
   >
-    {% include '@atoms/media/icons/svg/icon-search-white.twig' %}
+    {{ searchFieldDrFinder.button.text }}
   </button>
 </div>

--- a/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
+++ b/styleguide/source/_patterns/01-atoms/forms/search-field-dr-finder.twig
@@ -20,7 +20,7 @@
   >
   <button
     type="{{ searchFieldDrFinder.button.type }}"
-    class="ama-dr-finder-search-field__button"
+    class="ama-dr-finder-search-field__button {{ searchFieldDrFinder.button.class }}"
     aria-label="{{ searchFieldDrFinder.button.ariaLabel }}"
   >
     {% include '@atoms/media/icons/svg/icon-search-white.twig' %}

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
@@ -1,22 +1,20 @@
 {
   "drFinderSearch": {
-    "searchFieldDrFinder1": {
-      "label": "Search by name",
-      "id": "ama-dr-finder-search-field__input1",
-      "name": "ama-dr-finder-search-field__name1",
-      "placeholder": "",
+    "searchFieldDrFinder": {
+      "fieldFirst": {
+        "label": "Name",
+        "id": "ama-dr-finder-search-field__input-first",
+        "name": "ama-dr-finder-search-field__name-first",
+        "placeholder": "First Last"
+      },
+      "fieldSecond": {
+        "label": "State, city, zip code",
+        "id": "ama-dr-finder-search-field__input-second",
+        "name": "ama-dr-finder-search-field__name-second",
+        "placeholder": "Chicago"
+      },
       "button": {
-        "type": "button",
-        "ariaLabel": "Search button",
-        "class": "search-name"
-      }
-    },
-    "searchFieldDrFinder2": {
-      "label": "Search by location",
-      "id": "ama-dr-finder-search-field__input2",
-      "name": "ama-dr-finder-search-field__name2",
-      "placeholder": "",
-      "button": {
+        "text": "Search",
         "type": "button",
         "ariaLabel": "Search button",
         "class": "search-location"

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
@@ -1,0 +1,11 @@
+{
+  "drFinderSearch":{
+    "heading": {
+      "level": "3",
+      "text":"Looking for credentialing products? Visit the <a href='https://commerce.ama-assn.org/amaprofiles/'> AMA Profiles HUB.</a>",
+      "class":"ama-dr-finder__h3"
+    }
+  }
+
+}
+

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
@@ -1,5 +1,27 @@
 {
   "drFinderSearch": {
+    "searchFieldDrFinder1": {
+      "label": "Search by name",
+      "id": "ama-dr-finder-search-field__input1",
+      "name": "ama-dr-finder-search-field__name1",
+      "placeholder": "",
+      "button": {
+        "type": "button",
+        "ariaLabel": "Search button",
+        "class": "search-name"
+      }
+    },
+    "searchFieldDrFinder2": {
+      "label": "Search by location",
+      "id": "ama-dr-finder-search-field__input2",
+      "name": "ama-dr-finder-search-field__name2",
+      "placeholder": "",
+      "button": {
+        "type": "button",
+        "ariaLabel": "Search button",
+        "class": "search-location"
+      }
+    },
     "cta": {
       "text": "Looking for credentialing products? Visit the <a href='https://commerce.ama-assn.org/amaprofiles/'> AMA Profiles HUB.</a>"
     }

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.json
@@ -1,11 +1,8 @@
 {
-  "drFinderSearch":{
-    "heading": {
-      "level": "3",
-      "text":"Looking for credentialing products? Visit the <a href='https://commerce.ama-assn.org/amaprofiles/'> AMA Profiles HUB.</a>",
-      "class":"ama-dr-finder__h3"
+  "drFinderSearch": {
+    "cta": {
+      "text": "Looking for credentialing products? Visit the <a href='https://commerce.ama-assn.org/amaprofiles/'> AMA Profiles HUB.</a>"
     }
   }
-
 }
 

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.md
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.md
@@ -1,0 +1,15 @@
+### Description
+Doctor finder search page contains different search fields.
+
+### Variables
+~~~
+ drFinderSearch: {
+  heading {
+      level:
+        type: string /optional
+      text:
+        type: string / required
+      class:
+        type: string / optional
+}
+~~~

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
@@ -1,0 +1,5 @@
+{# @copyright Copyright (c) 2022 Palantir.net #}
+<div class="dr-finder-search">
+{# Include the dr finder search fields #}
+    <h{{ drFinderSearch.heading.level}} class="{{ drFinderSearch.heading.class }}">{{ drFinderSearch.heading.text|raw }}</h{{ drFinderSearch.heading.level }}>
+</div>

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
@@ -1,5 +1,11 @@
 {# @copyright Copyright (c) 2022 Palantir.net #}
+
 <div class="dr-finder-search">
-{# Include the dr finder search fields #}
-    <h{{ drFinderSearch.heading.level }} class="{{ drFinderSearch.heading.class }}"> {{ drFinderSearch.heading.text|raw }} </h{{ drFinderSearch.heading.level }}>
+  <div class="dr-finder-search__search-field">
+    {# include '@atoms/forms/search-field-dr-finder.twig' #}
+  </div>
+  <div class="dr-finder-search__quick-finder">
+    {# include '@molecules/forms/quick-finder-dr-finder.twig' TO BE CREATED IN THE FUTURE #}
+  </div>
+  <div class="dr-finder-search__cta"> {{ drFinderSearch.cta.text|raw }} </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
@@ -1,5 +1,5 @@
 {# @copyright Copyright (c) 2022 Palantir.net #}
 <div class="dr-finder-search">
 {# Include the dr finder search fields #}
-    <h{{ drFinderSearch.heading.level}} class="{{ drFinderSearch.heading.class }}">{{ drFinderSearch.heading.text|raw }}</h{{ drFinderSearch.heading.level }}>
+    <h{{ drFinderSearch.heading.level }} class="{{ drFinderSearch.heading.class }}"> {{ drFinderSearch.heading.text|raw }} </h{{ drFinderSearch.heading.level }}>
 </div>

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
@@ -2,8 +2,7 @@
 
 <div class="dr-finder-search">
   <div class="dr-finder-search__search-field">
-    {% include '@atoms/forms/search-field-dr-finder.twig' with { 'searchFieldDrFinder' : drFinderSearch.searchFieldDrFinder1 } %}
-    {% include '@atoms/forms/search-field-dr-finder.twig' with { 'searchFieldDrFinder' : drFinderSearch.searchFieldDrFinder2 } %}
+    {% include '@atoms/forms/search-field-dr-finder.twig' with { 'searchFieldDrFinder' : drFinderSearch.searchFieldDrFinder } %}
   </div>
   <div class="dr-finder-search__quick-finder">
     {# include '@molecules/forms/quick-finder-dr-finder.twig' TO BE CREATED IN THE FUTURE #}

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
@@ -2,7 +2,8 @@
 
 <div class="dr-finder-search">
   <div class="dr-finder-search__search-field">
-    {# include '@atoms/forms/search-field-dr-finder.twig' #}
+    {% include '@atoms/forms/search-field-dr-finder.twig' with { 'searchFieldDrFinder' : drFinderSearch.searchFieldDrFinder1 } %}
+    {% include '@atoms/forms/search-field-dr-finder.twig' with { 'searchFieldDrFinder' : drFinderSearch.searchFieldDrFinder2 } %}
   </div>
   <div class="dr-finder-search__quick-finder">
     {# include '@molecules/forms/quick-finder-dr-finder.twig' TO BE CREATED IN THE FUTURE #}

--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -1,6 +1,13 @@
 .ama-dr-finder-search-field {
-  display: flex;
-  flex-wrap: wrap;
+  > div,
+  > button {
+    width: 100%;
+  }
+
+  @include breakpoint($bp-small) {
+    display: flex;
+    gap: 15px;
+  }
 }
 
 // This label needs to be on top of input.
@@ -9,6 +16,7 @@
   color: $purple;
   font-size: inherit;
   text-transform: inherit;
+  font-weight: normal;
 }
 
 .ama-dr-finder-search-field__input[type="text"] {
@@ -29,7 +37,13 @@
 }
 
 .ama-dr-finder-search-field__button {
+  margin-top: $gutter;
+  border-radius: 25px;
+  align-self: flex-end;
   background-color: $purple;
-  margin: 0;
-  padding: 10px 20px;
+  padding: 8px 20px;
+
+  @include breakpoint($bp-small) {
+    margin-top: 0;
+  }
 }

--- a/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
+++ b/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
@@ -1,16 +1,6 @@
 .dr-finder-search {}
 
-.dr-finder-search__search-field {
-  @include breakpoint($bp-small) {
-    display: flex;
-    justify-content: space-between;
-    gap: 20px;
-  }
-
-  .ama-dr-finder-search-field {
-    width: 100%;
-  }
-}
+.dr-finder-search__search-field {}
 
 .dr-finder-search__quick-finder {}
 

--- a/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
+++ b/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
@@ -1,0 +1,4 @@
+.ama-dr-finder__h3,
+.ama-dr-finder__h3 a{
+  color: $purple;
+}

--- a/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
+++ b/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
@@ -1,4 +1,10 @@
-.ama-dr-finder__h3,
-.ama-dr-finder__h3 a{
+.dr-finder-search {}
+
+.dr-finder-search__search-field {}
+
+.dr-finder-search__quick-finder {}
+
+.dr-finder-search__cta,
+.dr-finder-search__cta a {
   color: $purple;
 }

--- a/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
+++ b/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
@@ -1,10 +1,24 @@
 .dr-finder-search {}
 
-.dr-finder-search__search-field {}
+.dr-finder-search__search-field {
+  @include breakpoint($bp-small) {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+  }
+
+  .ama-dr-finder-search-field {
+    width: 100%;
+  }
+}
 
 .dr-finder-search__quick-finder {}
 
 .dr-finder-search__cta,
 .dr-finder-search__cta a {
   color: $purple;
+}
+
+.dr-finder-search__cta {
+  padding-top: $gutter;
 }


### PR DESCRIPTION
**Jira Ticket**
- [ADF-124: Prototype "credentialing products" bar](https://palantir.atlassian.net/browse/ADF-124)

## Description

- Add dr finder search organisms with related files.
- Add  "credentialing products" bar in the dr finder search field.

## To Test

- Checkout the **ADF-124-prototype-credentialing-bar** branch and cd into styleguid, run **gulp serve** to spin up the pattern lab style guide.

- Verify that **dr-finder-search** folder and related files exist  under 
   styleguide/source/_patterns/03-organisms
- Verify that **_dr-finder-search.scss** file exists under  styleguide/ source / assets/scss/03-organisms.

## Relevant Screenshots/GIFs

<img width="789" alt="Screen Shot 2022-09-27 at 12 53 09 PM" src="https://user-images.githubusercontent.com/54925022/192616242-7ec0d7fe-5476-403a-a0ca-b6abc8154e84.png">

## Additional Notes
This ticket fit in one of the field for dr finder search organisms,  So If someone else is working on the other parts of this organisms in future can fit under those files too.