### PR TITLE
Adf 138 profile header with image

### DIFF
--- a/styleguide/source/_patterns/01-atoms/dr-finder-badge/dr-finder-badge.twig
+++ b/styleguide/source/_patterns/01-atoms/dr-finder-badge/dr-finder-badge.twig
@@ -1,3 +1,7 @@
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder member badge.
+#}
 <div class="dr-finder-badge">
-    {{ drFinderBadge.text ? drFinderBadge.text : "Member" }}
+  {{ drFinderBadge.text ? drFinderBadge.text : "Member" }}
 </div>

--- a/styleguide/source/_patterns/02-molecules/dr-finder-filter-list/dr-finder-filter-list.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-filter-list/dr-finder-filter-list.twig
@@ -1,3 +1,7 @@
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder filter list.
+#}
 <div class="dr-finder-filter-list">
   {% for filter in drFinderFilterList %}
     <div class="dr-finder-filter-list__menu-item">

--- a/styleguide/source/_patterns/02-molecules/dr-finder-modal/dr-finder-modal.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-modal/dr-finder-modal.twig
@@ -1,3 +1,7 @@
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder modal.
+#}
 <div class="dr-finder-modal">
   <div class="dr-finder-modal__content">
     <span class="dr-finder-modal__close">&times;</span>

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -10,6 +10,18 @@ AMA Dr Finder profile header.
     <div class="dr-finder-profile-header__doctor-info__address">{{ drFinderProfileHeader.data.address|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
     <div class="dr-finder-profile-header__doctor-info__specialty">{{ drFinderProfileHeader.data.specialty|raw }}</div>
+    <div class="dr-finder-profile-header-with-image__doctor-info__membership">{{ drFinderProfileHeaderWithImage.data.membership|raw}}</div>
+    <div class="dr-finder-profile-header-with-image__doctor-info__service">{{ drFinderProfileHeaderWithImage.data.service|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
+    {% for data in drFinderProfileHeaderWithImage %}
+      <div class="dr-finder-profile-header-with-image__doctor-info__button">
+        <button
+          class="ama__button--pill-secondary {{ data.button.class }}"
+          type="{{ data.button.type }}"
+          aria-label="{{ data.button.ariaLabel }}">
+            {{ data.button.text }}
+        </button>
+      </div>
+    {% endfor %}
   </div>
 </div>  

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -1,8 +1,8 @@
 {#
-@copyright Copyright (c) 2022 Palantir.net
-AMA Dr Finder profile header.
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder profile header.
 #}
-<div class="dr-finder-profile-header {{ drFinderProfileHeader.verified ? "verified": "" }} {{ drFinderProfileHeader.member ? "member": "" }}">
+<div class="dr-finder-profile-header {{ drFinderProfileHeader.verified ? "verified" : "" }} {{ drFinderProfileHeader.member ? "member" : "" }}">
   <div class="dr-finder-profile-header__image-column">
     <div class="dr-finder-profile-header__image-verified-container">
       <div class="dr-finder-profile-header__image-url {{ drFinderProfileHeader.imageUrl ? "with-image": "" }}">
@@ -15,7 +15,7 @@ AMA Dr Finder profile header.
       {% endif %}
     </div>
     <div class="dr-finder-profile-header__upload-delete-button">
-      {%  for button in drFinderProfileHeader.actions %}
+      {% for button in drFinderProfileHeader.imageActions %}
         <div>{% include '@atoms/button/button.twig' with { "button" : button } %}</div>
       {% endfor %}
     </div>
@@ -27,12 +27,12 @@ AMA Dr Finder profile header.
     <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
     <div class="dr-finder-profile-header__doctor-info__specialty">{{ drFinderProfileHeader.data.specialty|raw }}</div>
     {% if drFinderProfileHeader.member %}
-      <div class="dr-finder-profile-header__doctor-info__membership">{{ drFinderProfileHeader.membership|raw }}</div>
+      {% include '@atoms/dr-finder-badge/dr-finder-badge.twig' %}
     {% endif %}
     <div class="dr-finder-profile-header__doctor-info__service">{{ drFinderProfileHeader.service|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
     <div class="dr-finder-profile-header__upload-delete-button">
-      {%  for button in drFinderProfileHeader.action %}
+      {% for button in drFinderProfileHeader.actions %}
         {% include '@atoms/button/button.twig' with { "button" : button } %}
       {% endfor %}
     </div>

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -3,10 +3,24 @@
 AMA Dr Finder profile header.
 #}
 <div class="dr-finder-profile-header {{ drFinderProfileHeader.verified ? "verified": "" }} {{ drFinderProfileHeader.member ? "member": "" }}">
-  <div class="dr-finder-profile-header__image-url {{ drFinderProfileHeader.imageUrl ? "with-image": "" }}">
-    {% if drFinderProfileHeader.imageUrl %}
-     <img src="{{ drFinderProfileHeader.imageUrl }}" />
-    {% endif %}
+  <div class="dr-finder-profile-header__column">
+    <div class="dr-finder-profile-header__container">
+      <div class="dr-finder-profile-header__image-url {{ drFinderProfileHeader.imageUrl ? "with-image": "" }}">
+        {% if drFinderProfileHeader.imageUrl %}
+          <img src="{{ drFinderProfileHeader.imageUrl }}" alt="{{ drFinderProfileHeader.data.name }}"/>
+        {% endif %}
+      </div>
+      <div class="dr-finder-profile-header__verified">
+        {% if drFinderProfileHeader.verified %}
+          {% include '@atoms/media/icons/svg/icon-completed.twig' %}
+        {% endif %}
+      </div>
+    </div>
+    <div class="dr-finder-profile-header__upload-delete-button">
+      {%  for button in drFinderProfileHeader.actions %}
+        <div>{% include '@atoms/button/button.twig' with { "button" : button } %}</div>
+      {% endfor %}
+    </div>
   </div>
   <div class="dr-finder-profile-header__doctor-info">
     <h2 class="dr-finder-profile-header__doctor-info__name ama__h2">{{ drFinderProfileHeader.data.name|raw }}</h2>
@@ -14,11 +28,15 @@ AMA Dr Finder profile header.
     <div class="dr-finder-profile-header__doctor-info__address">{{ drFinderProfileHeader.data.address|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
     <div class="dr-finder-profile-header__doctor-info__specialty">{{ drFinderProfileHeader.data.specialty|raw }}</div>
-    <div class="dr-finder-profile-header-with-image__doctor-info__membership">{{ drFinderProfileHeader.data.membership|raw}}</div>
-    <div class="dr-finder-profile-header-with-image__doctor-info__service">{{ drFinderProfileHeader.data.service|raw }}</div>
+    {% if drFinderProfileHeader.member %}
+      <div class="dr-finder-profile-header__doctor-info__membership">{{ drFinderProfileHeader.membership|raw }}</div>
+    {% endif %}
+    <div class="dr-finder-profile-header__doctor-info__service">{{ drFinderProfileHeader.service|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
-    {%  for button in drFinderProfileHeader.actions %}
-      {% include '@atoms/button/button.twig' with { "button" : button } %}
-    {% endfor %}
+    <div class="dr-finder-profile-header__upload-delete-button">
+      {%  for button in drFinderProfileHeader.action %}
+        {% include '@atoms/button/button.twig' with { "button" : button } %}
+      {% endfor %}
+    </div>
   </div>
 </div>

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -3,25 +3,24 @@
 AMA Dr Finder profile header.
 #}
 <div class="dr-finder-profile-header">
-  <div class="dr-finder-profile-header__image-url">{{ drFinderProfileHeader.imageUrl }}</div>
+  <div class="{{ "drFinderProfileHeader.imageUrl" ? "dr-finder-profile-header__image-url": "dr-finder-profile-header-with-image__image-url"}}">
+     {{ drFinderProfileHeader.imageUrl }}
+  </div>
   <div class="dr-finder-profile-header__doctor-info">
     <h2 class="dr-finder-profile-header__doctor-info__name ama__h2">{{ drFinderProfileHeader.data.name|raw }}</h2>
     <div class="dr-finder-profile-header__doctor-info__pronouns">{{ drFinderProfileHeader.data.pronouns|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__address">{{ drFinderProfileHeader.data.address|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
     <div class="dr-finder-profile-header__doctor-info__specialty">{{ drFinderProfileHeader.data.specialty|raw }}</div>
-    <div class="dr-finder-profile-header-with-image__doctor-info__membership">{{ drFinderProfileHeaderWithImage.data.membership|raw}}</div>
-    <div class="dr-finder-profile-header-with-image__doctor-info__service">{{ drFinderProfileHeaderWithImage.data.service|raw }}</div>
+    <div class="dr-finder-profile-header-with-image__doctor-info__membership">{{ drFinderProfileHeader.data.membership|raw}}</div>
+    <div class="dr-finder-profile-header-with-image__doctor-info__service">{{ drFinderProfileHeader.data.service|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
-    {% for data in drFinderProfileHeaderWithImage %}
-      <div class="dr-finder-profile-header-with-image__doctor-info__button">
-        <button
-          class="ama__button--pill-secondary {{ data.button.class }}"
-          type="{{ data.button.type }}"
-          aria-label="{{ data.button.ariaLabel }}">
-            {{ data.button.text }}
-        </button>
-      </div>
+    {% for button in drFinderProfileHeader.data.button %}
+       <button class="ama__button--pill-secondary {{ button.class }}"
+          type="{{ button.type }}"
+          aria-label="{{ button.ariaLabel }}">
+            {{ button.text }}
+       </button>
     {% endfor %}
   </div>
 </div>  

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -2,9 +2,11 @@
 @copyright Copyright (c) 2022 Palantir.net
 AMA Dr Finder profile header.
 #}
-<div class="dr-finder-profile-header">
-  <div class="{{ "drFinderProfileHeader.imageUrl" ? "dr-finder-profile-header__image-url": "dr-finder-profile-header-with-image__image-url"}}">
-     {{ drFinderProfileHeader.imageUrl }}
+<div class="dr-finder-profile-header {{ drFinderProfileHeader.verified ? "verified": "" }} {{ drFinderProfileHeader.member ? "member": "" }}">
+  <div class="dr-finder-profile-header__image-url {{ drFinderProfileHeader.imageUrl ? "with-image": "" }}">
+    {% if drFinderProfileHeader.imageUrl %}
+     <img src="{{ drFinderProfileHeader.imageUrl }}" />
+    {% endif %}
   </div>
   <div class="dr-finder-profile-header__doctor-info">
     <h2 class="dr-finder-profile-header__doctor-info__name ama__h2">{{ drFinderProfileHeader.data.name|raw }}</h2>
@@ -15,12 +17,8 @@ AMA Dr Finder profile header.
     <div class="dr-finder-profile-header-with-image__doctor-info__membership">{{ drFinderProfileHeader.data.membership|raw}}</div>
     <div class="dr-finder-profile-header-with-image__doctor-info__service">{{ drFinderProfileHeader.data.service|raw }}</div>
     <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
-    {% for button in drFinderProfileHeader.data.button %}
-       <button class="ama__button--pill-secondary {{ button.class }}"
-          type="{{ button.type }}"
-          aria-label="{{ button.ariaLabel }}">
-            {{ button.text }}
-       </button>
+    {%  for button in drFinderProfileHeader.actions %}
+      {% include '@atoms/button/button.twig' with { "button" : button } %}
     {% endfor %}
   </div>
-</div>  
+</div>

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -3,18 +3,16 @@
 AMA Dr Finder profile header.
 #}
 <div class="dr-finder-profile-header {{ drFinderProfileHeader.verified ? "verified": "" }} {{ drFinderProfileHeader.member ? "member": "" }}">
-  <div class="dr-finder-profile-header__column">
-    <div class="dr-finder-profile-header__container">
+  <div class="dr-finder-profile-header__image-column">
+    <div class="dr-finder-profile-header__image-verified-container">
       <div class="dr-finder-profile-header__image-url {{ drFinderProfileHeader.imageUrl ? "with-image": "" }}">
         {% if drFinderProfileHeader.imageUrl %}
           <img src="{{ drFinderProfileHeader.imageUrl }}" alt="{{ drFinderProfileHeader.data.name }}"/>
         {% endif %}
       </div>
-      <div class="dr-finder-profile-header__verified">
-        {% if drFinderProfileHeader.verified %}
-          {% include '@atoms/media/icons/svg/icon-completed.twig' %}
-        {% endif %}
-      </div>
+      {% if drFinderProfileHeader.verified %}
+        {% include '@atoms/media/icons/svg/icon-completed.twig' %}
+      {% endif %}
     </div>
     <div class="dr-finder-profile-header__upload-delete-button">
       {%  for button in drFinderProfileHeader.actions %}

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~logged-in.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~logged-in.json
@@ -1,0 +1,19 @@
+{
+  "drFinderProfileHeader": {
+    "imageUrl": "http://via.placeholder.com/220x220",
+    "member": true,
+    "verified": true,
+    "membership": "MEMBER",
+    "service": "Accepting new patients",
+    "action": [
+      {
+      "href": "",
+      "info": "alt",
+      "text": "Edit Physician Page",
+      "type": "button",
+      "style": "pill-secondary",
+      "size": ""
+      }
+    ]
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~logged-in.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~logged-in.json
@@ -3,9 +3,8 @@
     "imageUrl": "http://via.placeholder.com/220x220",
     "member": true,
     "verified": true,
-    "membership": "MEMBER",
     "service": "Accepting new patients",
-    "action": [
+    "actions": [
       {
       "href": "",
       "info": "alt",

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~verified-and-member.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~verified-and-member.json
@@ -1,0 +1,8 @@
+{
+  "drFinderProfileHeader": {
+    "imageUrl": "",
+    "member": true,
+    "verified": true,
+    "membership": "MEMBER"
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
@@ -3,8 +3,7 @@
     "imageUrl": "http://via.placeholder.com/220x220",
     "member": true,
     "verified": true,
-    "membership": "MEMBER",
-    "actions": [
+    "imageActions": [
       {
         "href": "",
         "info": "alt",

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
@@ -1,21 +1,24 @@
 {
   "drFinderProfileHeader": {
-    "imageUrl": "https://www.freepik.com/free-vector/doctor-character-background_1130796.htm#query=doctor%20background&position=0&from_view=keyword",
-    "data": {
-      "name": "Henry Jackson, MD",
-      "pronouns": "(He\/Him\/His)",
-      "address": "330 N.Wabash Ave <br/> Chicago,IL 60611",
-      "phoneNumber": "(312) 922-3815",
-      "specialty": "Cardiology",
-      "membership": "MEMBER",
-      "service": "Accepting new patients",
-      "url": "<a href=\"#\">https://www.nm.org/doctors</a>",
-      "button": {
-        "text": "Edit Physician Page",
+    "imageUrl": "http://via.placeholder.com/170x170",
+    "member": true,
+    "actions": [
+      {
+        "href": "",
+        "info": "alt",
+        "text": "Upload New Picture",
         "type": "button",
-        "ariaLabel": "Edit Physician Page button",
-        "class": "edit-page"
+        "style": "pill-secondary",
+        "size": ""
+      },
+      {
+        "href": "",
+        "info": "alt",
+        "text": "Delete Picture",
+        "type": "button",
+        "style": "pill-secondary",
+        "size": ""
       }
-    }
+    ]
   }
 }

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
@@ -1,6 +1,6 @@
 {
-  "drFinderProfileHeaderWithImage": {
-    "imageUrl": "",
+  "drFinderProfileHeader": {
+    "imageUrl": "https://www.freepik.com/free-vector/doctor-character-background_1130796.htm#query=doctor%20background&position=0&from_view=keyword",
     "data": {
       "name": "Henry Jackson, MD",
       "pronouns": "(He\/Him\/His)",

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
@@ -1,7 +1,9 @@
 {
   "drFinderProfileHeader": {
-    "imageUrl": "http://via.placeholder.com/170x170",
+    "imageUrl": "http://via.placeholder.com/220x220",
     "member": true,
+    "verified": true,
+    "membership": "MEMBER",
     "actions": [
       {
         "href": "",

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header~with-image.json
@@ -1,0 +1,21 @@
+{
+  "drFinderProfileHeaderWithImage": {
+    "imageUrl": "",
+    "data": {
+      "name": "Henry Jackson, MD",
+      "pronouns": "(He\/Him\/His)",
+      "address": "330 N.Wabash Ave <br/> Chicago,IL 60611",
+      "phoneNumber": "(312) 922-3815",
+      "specialty": "Cardiology",
+      "membership": "MEMBER",
+      "service": "Accepting new patients",
+      "url": "<a href=\"#\">https://www.nm.org/doctors</a>",
+      "button": {
+        "text": "Edit Physician Page",
+        "type": "button",
+        "ariaLabel": "Edit Physician Page button",
+        "class": "edit-page"
+      }
+    }
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/dr-finder-search-result-card/dr-finder-search-result-card.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-search-result-card/dr-finder-search-result-card.twig
@@ -1,3 +1,7 @@
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder search result card.
+#}
 <div class="dr-finder-search-result-card {{ drFinderSearchResultCard.verified ? "verified" : "" }} {{ drFinderSearchResultCard.member ? "member" : "" }}">
   <div class="dr-finder-search-result-card__image {{ drFinderSearchResultCard.imgUrl ? "with-image" : "" }}">
     {% if drFinderSearchResultCard.imgUrl %}

--- a/styleguide/source/_patterns/02-molecules/dr-finder-search-results-header/dr-finder-search-results-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-search-results-header/dr-finder-search-results-header.twig
@@ -1,4 +1,7 @@
-
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder search result header.
+#}
 <div class="dr-finder-search-results-header">
    <div class="ama__h1 dr-finder-search-results-header__results-text" >
       {{ drFinderSearchResultsHeader.resultsText|raw }}

--- a/styleguide/source/_patterns/03-organisms/dr-finder-main-navigation/dr-finder-main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-main-navigation/dr-finder-main-navigation.twig
@@ -1,9 +1,12 @@
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder main navigation.
+#}
 <div id="amaCategoryNavigation" class="ama__main-navigation ama__main-navigation--dr-finder">
   <div class="container">
     {% include '@molecules/explore-menu.twig' with { exploreMenu : drFinderMainNavigation.exploreMenu } %}
     {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : drFinderMainNavigation.siteLogo } %}
     {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : drFinderMainNavigation.signInDropdown } %}
     {% include "@atoms/heading/heading.twig"  with { heading : exploreMenu.heading } %}
-    {#{% include '@organisms/category-navigation-menu-dr-finder.twig' with { categoryNavigationMenu : mainNavigation.categoryNavigationMenu } %}#}
   </div>
 </div>

--- a/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-search/dr-finder-search.twig
@@ -1,5 +1,7 @@
-{# @copyright Copyright (c) 2022 Palantir.net #}
-
+{#
+  @copyright Copyright (c) 2022 Palantir.net
+  AMA Dr Finder search field.
+#}
 <div class="dr-finder-search">
   <div class="dr-finder-search__search-field">
     {% include '@atoms/forms/search-field-dr-finder.twig' with { 'searchFieldDrFinder' : drFinderSearch.searchFieldDrFinder } %}

--- a/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-edit.json
+++ b/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-edit.json
@@ -113,6 +113,8 @@
   },
   "drFinderProfileHeader": {
     "imageUrl": "",
+    "member": true,
+    "verified":  true,
     "data": {
       "name": "Henry Jackson, MD",
       "pronouns": "(He\/Him\/His)",
@@ -120,7 +122,25 @@
       "phoneNumber": "(312) 922-3815",
       "specialty": "Cardiology",
       "url": "<a href=\"#\">https://www.nm.org/doctors</a>"
-    }
+    },
+    "imageActions": [
+      {
+        "href": "",
+        "info": "alt",
+        "text": "Upload New Picture",
+        "type": "button",
+        "style": "pill-secondary",
+        "size": ""
+      },
+      {
+        "href": "",
+        "info": "alt",
+        "text": "Delete Picture",
+        "type": "button",
+        "style": "pill-secondary",
+        "size": ""
+      }
+    ]
   },
   "footer": {
     "siteLogo": {

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
@@ -1,7 +1,10 @@
+// @copyright Copyright (c) 2022 Palantir.net
+
 .dr-finder-filter-list {
   margin-bottom: $gutter;
   padding-bottom: $gutter;
   border-bottom: 1px solid $purple;
+
   @include breakpoint($bp-small) {
     display: flex;
     gap: 10px;
@@ -55,8 +58,8 @@
 
 .dr-finder-filter-list__submenu:before {
   content: "";
-  width: 0px;
-  height: 0px;
+  width: 0;
+  height: 0;
   position: absolute;
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
@@ -68,8 +71,8 @@
 
 .dr-finder-filter-list__submenu:after {
   content: "";
-  width: 0px;
-  height: 0px;
+  width: 0;
+  height: 0;
   position: absolute;
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-modal.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-modal.scss
@@ -1,4 +1,5 @@
-/* The Modal (background) */
+// @copyright Copyright (c) 2022 Palantir.net
+
 .dr-finder-modal {
   position: fixed; /* Stay in place */
   z-index: 1; /* Sit on top */

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -17,7 +17,7 @@
 }
 
 .dr-finder-profile-header__doctor-info {
-    margin: 0 $gutter;
+  margin: 0 $gutter;
 }
 
 .dr-finder-profile-header__doctor-info__specialty {
@@ -40,16 +40,20 @@
   font-weight: bold;
 }
 
-.dr-finder-profile-header__verified {
-  position: absolute;
-  bottom: 60px;
-  left: 195px;
-}
-
 .dr-finder-profile-header__upload-delete-button {
   padding: $gutter 0;
 }
 
-.dr-finder-profile-header__container {
+.dr-finder-profile-header__image-verified-container {
   position: relative;
+
+  svg {
+    position: absolute;
+    max-width: fit-content;
+    max-height: fit-content;
+    transform: translate(244%,205%);
+    bottom: 110px;
+    left: 85px;
+  }
 }
+

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -11,13 +11,10 @@
   width: 170px;
   height: 170px;
   margin: 0 $gutter;
-}
 
-.dr-finder-profile-header-with-image__image-url {
-  border-radius: 50%;
-  width: 170px;
-  height: 170px;
-  margin: 0 $gutter;
+  img {
+    border-radius: 50%;
+  }
 }
 
 .dr-finder-profile-header__doctor-info {

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -4,9 +4,16 @@
   margin: $gutter 0;
 }
 
-.dr-finder-profile-header__image-url{
+.dr-finder-profile-header__image-url {
   background: $profileHeader-image;
   border: none;
+  border-radius: 50%;
+  width: 170px;
+  height: 170px;
+  margin: 0 $gutter;
+}
+
+.dr-finder-profile-header-with-image__image-url {
   border-radius: 50%;
   width: 170px;
   height: 170px;
@@ -25,4 +32,16 @@
 
 .dr-finder-profile-header__doctor-info__url a {
   color: $blue;
+}
+
+.dr-finder-profile-header-with-image__doctor-info__membership {
+  color: $white;
+  background: $purple;
+  width: 50%;
+  heigh: 15%;
+  text-align: center;
+}
+
+.dr-finder-profile-header-with-image__doctor-info__service {
+  font-weight: bold;
 }

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -8,9 +8,8 @@
   background: $profileHeader-image;
   border: none;
   border-radius: 50%;
-  width: 170px;
-  height: 170px;
-  margin: 0 $gutter;
+  width: 220px;
+  height: 220px;
 
   img {
     border-radius: 50%;
@@ -18,9 +17,7 @@
 }
 
 .dr-finder-profile-header__doctor-info {
-  .ama__h2 {
-    margin: 0;
-  }
+    margin: 0 $gutter;
 }
 
 .dr-finder-profile-header__doctor-info__specialty {
@@ -31,14 +28,28 @@
   color: $blue;
 }
 
-.dr-finder-profile-header-with-image__doctor-info__membership {
+.dr-finder-profile-header__doctor-info__membership {
   color: $white;
   background: $purple;
-  width: 50%;
-  heigh: 15%;
+  width: 120px;
   text-align: center;
+  margin: 10px 0;
 }
 
-.dr-finder-profile-header-with-image__doctor-info__service {
+.dr-finder-profile-header__doctor-info__service {
   font-weight: bold;
+}
+
+.dr-finder-profile-header__verified {
+  position: absolute;
+  bottom: 60px;
+  left: 195px;
+}
+
+.dr-finder-profile-header__upload-delete-button {
+  padding: $gutter 0;
+}
+
+.dr-finder-profile-header__container {
+  position: relative;
 }

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -1,7 +1,13 @@
+// @copyright Copyright (c) 2022 Palantir.net
+
 .dr-finder-profile-header {
   display: flex;
   padding: $gutter 0;
   margin: $gutter 0;
+}
+
+.dr-finder-profile-header__doctor-info__name {
+  margin: 0;
 }
 
 .dr-finder-profile-header__image-url {
@@ -28,14 +34,6 @@
   color: $blue;
 }
 
-.dr-finder-profile-header__doctor-info__membership {
-  color: $white;
-  background: $purple;
-  width: 120px;
-  text-align: center;
-  margin: 10px 0;
-}
-
 .dr-finder-profile-header__doctor-info__service {
   font-weight: bold;
 }
@@ -56,4 +54,3 @@
     left: 85px;
   }
 }
-

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-search-result-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-search-result-card.scss
@@ -1,3 +1,5 @@
+// @copyright Copyright (c) 2022 Palantir.net
+
 .dr-finder-search-result-card {
   display: flex;
   padding: $gutter;
@@ -31,5 +33,3 @@
 .dr-finder-search-result-card__content__name {
   margin: 0;
 }
-
-

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-search-results-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-search-results-header.scss
@@ -1,3 +1,5 @@
+// @copyright Copyright (c) 2022 Palantir.net
+
 .dr-finder-search-results-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
**Jira Ticket**
- [ADF-138:Prototype doctor edit header - with image](https://palantir.atlassian.net/browse/ADF-138)

## Description

Add 4 Dr Finder Profile Header molecules in style guide.

-  Dr Finder Profile Header
-  Dr Finder Profile Header Verified and member
-  Dr Finder Profile Header With Image
-  Dr Finder Profile Header Logged In


## To Test

- Checkout the **ADF-138-profile-header-with-image** branch and cd into style guide, run gulp serve to spin up the pattern lab style guide.

- Verify that dr-finder-profile-header and related states existed under Molecules.

- Visit **http://localhost:3000/?p=viewall-molecules-dr-finder-profile-header** and verify modal.


## Relevant Screenshots/GIFs
<img width="786" alt="Screen Shot 2022-10-09 at 7 22 02 PM" src="https://user-images.githubusercontent.com/54925022/194789074-65ba34e0-cdbb-4337-8058-8e2e096cd9ae.png">
<img width="830" alt="Screen Shot 2022-10-09 at 7 22 17 PM" src="https://user-images.githubusercontent.com/54925022/194789077-f999ed9d-4676-4b59-9421-4125e230ce6f.png">
