### PR TITLE
Added 5px margin to add gap between filter buttons

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
@@ -13,7 +13,11 @@
 
 .dr-finder-filter-list__menu-item {
   background: $white;
-  margin: 2px
+  margin: $gutter-mobile 0;
+
+  @include breakpoint($bp-small) {
+    margin: 0;
+  }
 }
 
 .dr-finder-filter-list__menu-item label {

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
@@ -13,6 +13,7 @@
 
 .dr-finder-filter-list__menu-item {
   background: $white;
+  margin: 2px
 }
 
 .dr-finder-filter-list__menu-item label {

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-filter-list.scss
@@ -13,7 +13,7 @@
 
 .dr-finder-filter-list__menu-item {
   background: $white;
-  margin: $gutter-mobile 0;
+  margin: $gutter-mobile/2 0;
 
   @include breakpoint($bp-small) {
     margin: 0;


### PR DESCRIPTION
**Jira Ticket**
- [ADF-243: Incorporate feedback from Sprint 2 demo](https://palantir.atlassian.net/browse/ADF-243)

## Description
In this P.R. I just added a margin to create a little bit of a larger gap between the filter buttons


## To Test
Navigate to Pages> dr-finder-with-search-results in the style guide 
change the sizing to mobile and you should notice that there is a slightly larger gap between the buttons 

## Relevant Screenshots/GIFs
<img width="1788" alt="Screen Shot 2022-10-21 at 1 01 52 PM" src="https://user-images.githubusercontent.com/89882376/197260280-0c1a45d1-6d83-49e9-94cc-7cdb6b8e10e7.png">

<img width="1788" alt="Screen Shot 2022-10-21 at 12 47 20 PM" src="https://user-images.githubusercontent.com/89882376/197259687-d9fa27dc-c83d-4321-9ca6-cc43b79e05c9.png">



[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
