### PR TITLE
EWL-9768: Adjust spacing between text and image for ama locker pages.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
@@ -8,10 +8,13 @@
   }
   .ama_bookmark_left {
     border-bottom: none;
-    padding-bottom: 96px;
-    padding-top: 0;
+    padding: 0 0 96px;
     @include breakpoint($bp-small) {
-      padding-bottom: 56px;
+      padding-bottom: 17px;
+      padding-right: 17px;
+    }
+    @include breakpoint($bp-med) {
+      padding-right: 20px;
     }
   }
   .ama_bookmark_right {
@@ -283,12 +286,18 @@
 //  My Topics view styling.
 .topic-search {
   margin-top: 28px !important;
-  margin-bototm: 14px;
+  margin-bottom: 14px;
 }
 .my-topic-listing {
   flex-direction: row;
   .text {
-    padding-right: 14px;
+    padding-right: 0;
+    @include breakpoint($bp-small) {
+      padding-right: 17px;
+    }
+    @include breakpoint($bp-med) {
+      padding-right: 20px;
+    }
     h2 {
       a {
         text-decoration: none;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-9678: AMA Locker | Fix spacing between text and image on My Topics and My Bookmarks index pagese](https://issues.ama-assn.org/browse/EWL-9678)

## Description
Adjust spacing between text and images on ama locker pages.


## To Test
- link styleguide locally
- on ama locker pages (my-bookmarks, my-topics) confirm padding between text (left) and images (right) matches the following zeplins:

Desktop https://zpl.io/brQnBgL
Tablet https://zpl.io/VKgnRwW 

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
