### PR TITLE
EWL-9799: Fix ama locker nav icon clipping.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
@@ -75,11 +75,8 @@
       }
       &::before {
         width: 22px;
+        height: 23px;
         background-image: url('../images/BookmarksMenuIcon_Locker.svg');
-        @include breakpoint($bp-small) {
-          width: 32px;
-          height: 26px;
-        }
       }
       &:hover {
         &::before {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-9799: AMA Locker | Bookmarks persistent nav icon is clipped](https://issues.ama-assn.org/browse/EWL-9799)

## Description
Adjust styling to fix icon clipping for my bookmarks link in ama locker nav.


## To Test
- link styleguide locally
- navigate to any page that is not the homepage
- confirm icon next to my-bookmarks link in ama locker nav is shown without any clipping.
- confirm it matches the following zeplins:
Desktop https://zpl.io/p1zDmEE 

Tablet https://zpl.io/9q6BgLp 

Mobile https://zpl.io/9q6BgLA 

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
![Screen Shot 2022-11-03 at 1 57 38 PM](https://user-images.githubusercontent.com/67962801/199810457-f8577d11-0061-44e9-adec-01126d94a5cd.png)


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
