### PR TITLE
EWL-7670: Hub page last card display issue

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -8,15 +8,15 @@
   text-decoration: none;
   min-height: 400px;
   width: 100%;
-  
-  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) { 
+
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
     display: block;
 
     &--no-image {
       display: flex;
     }
   }
-  
+
 
   &__heading,
   & .ama__h2 {
@@ -325,13 +325,12 @@
     &:nth-child(3):nth-last-child(2),
     &:nth-child(4):nth-last-child(1) {
       @include gutter($margin-right-half...);
-      width: calc(25% - 14px);
+      width: calc(25% - 10.5px);
     }
 
     // last of three doesn't have right padding
     &:nth-child(4):nth-last-child(1) {
       margin-right: 0;
-      width: 25%;
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
[EWL-7670: Last Hub page card in a row has an incorrectly-sized caption box](https://issues.ama-assn.org/browse/EWL-7670)

**Github Issue**
N/A

**Jira Ticket**
[EWL-7670: Last Hub page card in a row has an incorrectly-sized caption box](https://issues.ama-assn.org/browse/EWL-7670)

## Description
Updated CSS width calculation to fix display issue with last card in each row on Hub page.

## To Test
- Pull/Checkout branch [EWL-7670-hub-page-last-card-display-issue](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-7670-hub-page-last-card-display-issue)
- Serve and link SG
- Visit /amaone/ama-member-spotlight
- Verify  caption box size is the same for all cards in each row for desktop view

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
