### PR TITLE
ADF-261: Show/Hide Profile Header fields according to "Claimed" in template

### DIFF
--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -24,7 +24,7 @@
     {% if drFinderProfileHeader.data.name %}
       <h2 class="dr-finder-profile-header__doctor-info__name ama__h2">{{ drFinderProfileHeader.data.name|raw }}</h2>
     {% endif %}
-    {% if drFinderProfileHeader.data.pronouns %}
+    {% if drFinderProfileHeader.data.pronouns and profile.claimedProfile.value == true %}
       <div class="dr-finder-profile-header__doctor-info__pronouns">{{ drFinderProfileHeader.data.pronouns|raw }}</div>
     {% endif %}
     {% if drFinderProfileHeader.data.address %}
@@ -39,10 +39,10 @@
     {% if drFinderProfileHeader.member %}
       {% include '@atoms/dr-finder-badge/dr-finder-badge.twig' %}
     {% endif %}
-    {% if drFinderProfileHeader.service %}
+    {% if drFinderProfileHeader.service and profile.claimedProfile.value == true %}
       <div class="dr-finder-profile-header__doctor-info__service">Accepting new patients</div>
     {% endif %}
-    {% if drFinderProfileHeader.data.url %}
+    {% if drFinderProfileHeader.data.url and profile.claimedProfile.value == true %}
       <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
     {% endif %}
     {% if drFinderProfileHeader.claimed %}


### PR DESCRIPTION

**Jira Ticket**
- [ADF-261:Show/Hide Profile Header fields according to "Claimed" in template](https://palantir.atlassian.net/browse/ADF-261)

## Description
Add conditions to show and hide profile header fields for claimed and non-member profile.


## To Test

- Checkout the `ADF-261-show-hide-profile-header-fields-claimed `branch and cd into style guide, run composer install
- Check the if conditions code that added for `dr-finder-profile-header.twig`
- Go to `Dr-finder` Repo and make the same code change in the `dr-finder-profile-header.twig` file.
- Test it by change the physician user's data( add pronouns, change "acceptingNewPatients": true  or add URL for " practiceURL" )
- Do you see if it's not `Claimed` profile, it won't show those fields on the profile header?