### PR TITLE
EWL-9798: Fix bookmark page cta overlap.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
@@ -41,6 +41,11 @@
         a::before {
           left: 35px;
         }
+        &.action-flag {
+          a::before {
+            left: 25px;
+          }
+        }
         &.action-unflag {
           a {
             pointer-events: all;
@@ -51,12 +56,6 @@
           a:hover {
             &::before {
               background-image: url('../images/RemoveHoverIcon_Locker.svg');
-            }
-          }
-          // When re-flagging unflagged bookmarks
-          &:not(.flag-glossary) {
-            a::before {
-              left: 20px;
             }
           }
         }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-9798: AMA Locker | Change Bookmark CTA to Add Clarity](https://issues.ama-assn.org/browse/EWL-9798)

## Description
Adjust styling for cta bookmarks icons on my bookmarks page.


## To Test
- link styleguide locally
- navigate to my bookmarks (if no bookmarks available, go bookmark some content)
- unbookmark item on my bookmarks page
- confirm text changes to 'add bookmark' and the icon shifts to the left and does not cover the text
- rebookmark the item, confirm text has changed to 'added'

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
![Screen Shot 2022-11-09 at 9 54 46 AM](https://user-images.githubusercontent.com/67962801/200877957-e0d8b298-1f3b-4de9-b3b2-bf986954d0dd.png)



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
