### PR TITLE
EWL-7670: Update CSS for 3-up hub card layout

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -306,7 +306,7 @@
     &:nth-child(2):nth-last-child(2),
     &:nth-child(3):nth-last-child(1) {
       @include gutter($margin-right-half...);
-      width: calc(33.333% - 14px);
+      width: calc(33.333% - 9.5px);
     }
     // first of three doesn't have left padding
     &:nth-child(1):nth-last-child(3) {
@@ -315,7 +315,6 @@
     // last of three doesn't have right padding
     &:nth-child(3):nth-last-child(1) {
       margin-right: 0;
-      width: 33.333%;
     }
 
     // 4-up layout


### PR DESCRIPTION
## Ticket(s)
[EWL-7670: Last Hub page card in a row has an incorrectly-sized caption box](https://issues.ama-assn.org/browse/EWL-7670)

**Github Issue**
N/A

**Jira Ticket**
[EWL-7670: Last Hub page card in a row has an incorrectly-sized caption box](https://issues.ama-assn.org/browse/EWL-7670)

## Description
Original PR for this branch fixed caption box sizing for 4-up display.  This PR updates CSS width calculation to fix display issue with last card in each row of 3-up display.

## To Test
- Pull/Checkout branch [EWL-7670-hub-page-last-card-display-issue](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-7670-hub-page-last-card-display-issue)
- Serve and link SG
- Visit /amaone/ama-recovery-plan-america-s-physicians
- Verify caption box is the same size on all cards of 3-up card display (see screenshot)
- Visit /amaone/how-membership-moves-medicine
- Verify caption box is the same size on all cards of 3-up card display (see screenshot)
- Visit /amaone/ama-recovery-plan-america-s-physicians-reducing-physician-burnout
- Verify caption box is the same size on all cards of 3-up card display (see screenshot)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs

![physicians-after](https://user-images.githubusercontent.com/112415930/201016503-93738f98-f08f-47e4-923b-36d4451bffcb.jpg)

![medicine-after](https://user-images.githubusercontent.com/112415930/201016445-0aed265b-a108-487f-8063-feb7040b35e1.jpg)

![burnout-after](https://user-images.githubusercontent.com/112415930/201016525-228cfcaf-5d3a-49e9-b5d3-89edc0bfa2b0.jpg)

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
