### PR TITLE
EWL-9841: Adjust styling of ama locker nav menu.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
@@ -9,7 +9,6 @@
   }
   a {
     position: relative;
-    width: 101px;
     height: 44px;
     border: 1px solid #a28ab5;
     padding: 2px 0 0;
@@ -18,12 +17,17 @@
     text-decoration: none;
     text-align: center;
     background-color: $white;
+    white-space: nowrap;
+    width: auto;
+    @include breakpoint($bp-small max-width) {
+      min-width: 115px;
+    }
     @include breakpoint($bp-small) {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      width: 162px;
-      font-size: 18px;
+      min-width: 162px;
+      font-size: 16px;
     }
     &::before {
       display: block;
@@ -36,17 +40,15 @@
       background-size: cover;
     }
     &.subscriptions {
-      white-space: nowrap;
-      width: auto;
-      
       @include breakpoint($bp-small) {
         padding: 9px 11px 8px;
       }
       &::before {
         background-image: url('../images/SubscriptionsMenuIcon_Locker.svg');
         @include breakpoint($bp-small) {
-          width: 32px;
-          height: 32px;
+          width: 23px;
+          height: 24px;
+          margin-right: 5px;
         }
       }
       &:hover {
@@ -57,15 +59,15 @@
     }
     &.topics {
       @include breakpoint($bp-small) {
-        width: 155px;
-        padding: 9px 37px 8px 36px;
+        min-width: 155px;
+        padding: 9px 28px 8px 24px;
       }
       &::before {
         width: 23px;
         background-image: url('../images/TopicsMenuIcon_Locker.svg');
         @include breakpoint($bp-small) {
-          width: 27px;
-          height: 27px;
+          width: 23px;
+          height: 23px;
         }
       }
       &:hover {
@@ -82,6 +84,9 @@
         width: 22px;
         height: 23px;
         background-image: url('../images/BookmarksMenuIcon_Locker.svg');
+        @include breakpoint($bp-small) {
+          margin-right: 5px;
+        }
       }
       &:hover {
         &::before {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-XXXX: Ticket Title](https://issues.ama-assn.org/browse/EWL-XXXX)

## Description
Adjust styling for ama locker navigation.


## To Test
- link styleguide locally
- clear caches 
- add/edit custom ama locker nav block to list the links as 'my subscriptions', 'my topics' and 'my bookmarks'
- confirm locker nav links are each on one line are not ugly (warning: subjective)
- on mobile confirm styling matches the following: https://app.zeplin.io/project/62e3ed605bad8f119cc59bf2/screen/62e8117ffa2b5b12f9625dd3

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
<img width="1047" alt="Screen Shot 2022-11-11 at 11 25 34 AM" src="https://user-images.githubusercontent.com/67962801/201395946-e2351a95-3d74-4966-9294-79ae8415f519.png">
<img width="499" alt="Screen Shot 2022-11-11 at 11 25 47 AM" src="https://user-images.githubusercontent.com/67962801/201395948-c37fe199-4460-4852-a0b5-28c0af9dfd7f.png">



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
