### PR TITLE
EWL-9733: Set topic catalog filters links centered on mobile viewports.

### DIFF
--- a/styleguide/source/assets/js/glossary.js
+++ b/styleguide/source/assets/js/glossary.js
@@ -17,6 +17,30 @@
             $(link).attr("href", newUrl);
           }
         })
+
+        // Set selected category link to center of horizontal div
+        function catalogLinkScroll() {
+          // Get link wrapper
+          var catalogLinkWrapper = $('#edit-name--2');
+          // Get horizontal position of currently selected link
+          var scrollPosition = $('#edit-name--2--wrapper a.bef-link--selected').position().left;
+          // Get current scroll position
+          var currentScrollPosition = catalogLinkWrapper.scrollLeft();
+          // Get current width of wrapper container
+          var containerWidth = catalogLinkWrapper.width();
+          // Set new scroll position to half of wrapper width
+          var scrollPosition = (scrollPosition + currentScrollPosition) - (containerWidth/2);
+          // Set horizontal scroll position to show letter
+          $('#edit-name--2').scrollLeft(scrollPosition);
+          // Scroll the bar automatically to show that item
+          catalogLinkWrapper.animate({'scrollLeft': scrollPosition});
+        }
+
+        // Only set the scroll on mobile
+        if ($(window).width() < 900) {
+          catalogLinkScroll();
+        }
+
       })
 
     }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- n/a

**Jira Ticket**
- [EWL-9733: Topics Catalog | Re-center letter selection in Mobile and Tablet](https://issues.ama-assn.org/browse/EWL-9733)

## Description
Adds script to re-center currently selected topic catalog link on mobile viewports.


## To Test
- link styleguide locally
- navigate to topic catalog page: http://ama-one.lndo.site/about/topic-catalog
- on mobile device or tablet/mobile viewport (900px screensize or less)
- select catalog link not currently in view
- confirm when page reloads with selection that the selected link is in the center of the link container (see attached image)

## Visual Regressions
- n/a

## Relevant Screenshots/GIFs
<img width="502" alt="Screen Shot 2022-12-21 at 10 44 38 AM" src="https://user-images.githubusercontent.com/67962801/208959057-8eb0f398-25d0-491c-ba4f-1a4e43ff77bf.png">


## Remaining Tasks
- n/a


## Additional Notes
- n/a

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
