### PR TITLE
EWL-9831: Related series description spacing.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -73,13 +73,19 @@
       width: 75%;
     }
   }
-  .related-series-tag a {
-    font-size: 14px;
-    display:block;
-    color: $purple;
-    margin:-7px 0;
-    line-height: 16px;
-    font-weight: $font-weight-bold;
+  .ama__article-stub__description {
+    margin-top: -7px;
+  }
+  .related-series-tag {
+    display: block;
+    margin-top: 7px;
+    a {
+      font-size: 14px;
+      display:block;
+      color: $purple;
+      line-height: 16px;
+      font-weight: $font-weight-bold;
+    }
   }
   &--small {
     display: flex;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-9831: Ticket Title](https://issues.ama-assn.org/browse/EWL-9831)

## Description
corrected spacing issues on related series article blocks.


## To Test
- [ ] go here and verify that the "Shadow Me" specialty series block is displaying incorrectly.
- [ ] pull and serve
- [ ] set up d8 for local SG development `lando link-styleguides -a one && lando drush @one.local cr`
- [ ] verify that display is corrected.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
