### PR TITLE
EWL-9814: scss fixes

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_brightcove_video.scss
+++ b/styleguide/source/assets/scss/02-molecules/_brightcove_video.scss
@@ -31,3 +31,15 @@
     }
   }
 }
+
+//  Make Brightcove videos within 50-50 hub CTA paragraphs 100% width.
+.ama__hub-card {
+  &.ama__hub-hero--fifty-fifty {
+    &.ama__hub-hero {
+      .ama__brightcove-gallery {
+        width: 100%;
+      }
+    }
+  }
+}
+

--- a/styleguide/source/assets/scss/03-organisms/_member-feature.scss
+++ b/styleguide/source/assets/scss/03-organisms/_member-feature.scss
@@ -43,6 +43,7 @@
       background: $gray-7;
 
       .ama__hero-story {
+        grid-column-end: 2;
         justify-content: flex-end;
       }
 
@@ -71,6 +72,7 @@
         margin-right: $gutter*-1;
         max-height: 600px;
         justify-content: flex-start;
+        grid-column-end: 1;
       }
 
       .ama__hero-story__media {

--- a/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
+++ b/styleguide/source/assets/scss/04-templates/_two-column-right--75-25.scss
@@ -6,6 +6,8 @@
   display: grid;
   grid-template-columns: 3fr 1fr;
   grid-template-rows: max-content auto auto;
+  grid-template-areas: 'content sidebar'
+                        'content_below sidebar';
 
   &__top {
     @include breakpoint($bp-small max-width) {
@@ -15,6 +17,7 @@
       grid-column: 1 / 1;
     }
     @include gutter($margin-bottom-full...);
+    grid-area: content;
     grid-row: 1 / 1;
     grid-column: 1 / 2;
   }
@@ -28,6 +31,7 @@
     @include gutter($margin-right-half...);
     grid-column: 1 / 1;
     grid-row: 2 / 2;
+    grid-area: content_below;
   }
 
   &__right {
@@ -55,6 +59,7 @@
 
     grid-column: 2 / 2;
     grid-row: 2 / 2;
+    grid-area: sidebar;
   }
 }
 
@@ -63,5 +68,6 @@
 .ama__category-index.ama__layout--two-col-right--75-25 {
   .ama__layout--two-col-right--75-25__left {
     grid-row: unset;
+    grid-area: unset;
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_category.scss
+++ b/styleguide/source/assets/scss/05-pages/_category.scss
@@ -217,6 +217,7 @@
   .ama__layout--two-col-right--75-25 {
     &.ama__category__row {
       grid-template-rows: none;
+      grid-template-areas: 'content_below sidebar';
     }
   }
 


### PR DESCRIPTION
**Jira Ticket**
- [EWL-9814: Ticket Title](https://issues.ama-assn.org/browse/EWL-9814)

## Description
display fixes for brightcove videos and column order issues
rolled back css grid changes that were flagged as warnings during a recent gulp upgrade.


## To Test
- [ ] pull and serve
- [ ] set up d8 for local sg development `lando link-styleguides -a one && lando drush @one.local cr`
- [ ] go to a hub page. http://ama-one.lndo.site/node/24691/edit
- [ ] Add a brightcove video in a 50/50 block
- [ ] view the site as admin and verify that the video is 50% width.
- [ ] create a user that is a managing editor http://ama-one.lndo.site/admin/people
- [ ] log in as a managing editor and verify that the video displays correctly. https://ama-one.lndo.site/user
- [ ] go to trending, cat, subcat, and taxonomy term pages and verify that the right rail is displaying next to the main content area properly.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
