### PR TITLE
EWL-9964: standardized padding between regular and hover states.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_contact-us-webform.scss
+++ b/styleguide/source/assets/scss/03-organisms/_contact-us-webform.scss
@@ -17,7 +17,7 @@
 
   .ui-checkboxradio-label,
   .ui-checkboxradio-label:hover {
-    @include gutter-all($padding-all-half...);
+    padding: 10px;
     border: 1px solid $purple;
     border-radius: 0;
     text-transform: none;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-9964: contact us button formatting](https://issues.ama-assn.org/browse/EWL-9964)

## Description
set hover and default state padding to 10px;


## To Test
- [ ] pull and serve
- [ ] set up d8 for local development
- [ ] Go to the contact us form and verify the buttons don't pop when you hover over them.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
