### PR TITLE
EWL-9965: Remove unflag CSS that was breaking unfollow links

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
@@ -342,14 +342,6 @@
   }
 }
 
-.index-page {
-  .flag.action-unflag {
-    a {
-      pointer-events: none;
-    }
-  }
-}
-
 .flag-topic {
   &.action-flag {
     a::before {


### PR DESCRIPTION
**Github Issue**
- N/A

**Jira Ticket**
- [EWL-9965: Unfollow toggle button does not work on series index page](https://issues.ama-assn.org/browse/EWL-9965)

## Description
Fixes unfollow button.


## To Test
- [ ] Unfollow article or topic

## Visual Regressions

N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
