### PR TITLE
Fix subscribe button styling on mobile, fix subscribe and follow butt…

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
+++ b/styleguide/source/assets/scss/03-organisms/_bookmarks.scss
@@ -343,6 +343,13 @@
 }
 
 .flag-topic {
+  @include breakpoint($bp-med) {
+    &.anonymous {
+      a {
+        padding: 9px 0 9px 27px;
+      }
+    }
+  }
   &.action-flag {
     a::before {
       background-image: url('../images/FollowIcon_Locker@1x.svg');

--- a/styleguide/source/assets/scss/03-organisms/_series-subscribe.scss
+++ b/styleguide/source/assets/scss/03-organisms/_series-subscribe.scss
@@ -9,6 +9,8 @@
     background-repeat: no-repeat;
     background-position: 0 0;
     background-size: cover;
+    position: relative;
+    top: -8px;
     @include breakpoint($bp-small) {
       padding-left: 5px;
       width: 21px;
@@ -45,6 +47,12 @@
       height: 44px;
     }
     @include subscribeIcon();
+    @include breakpoint($bp-small max-width) {
+      &::before {
+        position: relative;
+        top: -2px;
+      }
+    }
     .form-actions {
       margin: 0;
     }
@@ -63,7 +71,7 @@
         height: 44px;
         font-size: 14px;
         line-height: 2;
-        top: -8px;
+        top: -10px;
       }
       @include breakpoint($bp-small) {
         min-width: 180px;
@@ -83,7 +91,7 @@
     }
     + .flag {
       display: inline-block;
-      margin-top: 0;
+      margin-top: 1px;
     }
   }
 
@@ -110,12 +118,16 @@
       min-width: 180px;
       max-width: 180px;
       max-height: 46px;
-      padding: 9px 0 8px 25px;
+      padding: 7px 0 8px 25px;
       margin-bottom: 5px;
     }
     + .flag {
       display: inline-block;
-      margin-top: 0;
+      margin-top: 0px;
+      @include breakpoint($bp-small max-width) {
+        position: relative;
+        top: -10px;
+      }
     }
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
…ons on topic pages.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-XXXX: Ticket Title](https://issues.ama-assn.org/browse/EWL-XXXX)

## Description
Adjust styling to fix display of subscribe button on mobile trending page and fix styling of subscribe and follow buttons for anonymous users on topic term pages.


## To Test
- link styleguides locally
- clear caches
- confirm subscribe button appears as expected on trending pages with mobile screensizes
- confirm subscribe button and follow button are aligned for all screen sizes for anonymous and logged in users on applicable series taxonomy pages (ex: /series/what-doctors-wish-patients-knew)

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
