### PR TITLE
EWL-10005 membership block category styling

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -358,3 +358,73 @@ a.ama__membership {
     }
   }
 }
+
+// Category specific layout builder styling
+.layout--onecol .layout__region {
+  .ama__membership {
+    display: flex;
+    flex-direction: column-reverse;
+    column-gap: 120px;
+    border-bottom: 0.5px solid #000;
+    padding-bottom: 28px;
+    margin-bottom: 28px;
+    @include breakpoint($bp-small) {
+      flex-direction: row;
+      column-gap: 17px;
+    }
+    @include breakpoint($bp-med) {
+      column-gap: 120px;
+      padding-bottom: 56px;
+      margin-bottom: 41px;
+    }
+    .ama__membership-content {
+      background: none;
+      display: block;
+      @include breakpoint($bp-small) {
+        max-width: 380px;
+      }
+  
+      .ama__membership_title_container, 
+      .membership-body,
+      .ama__membership_cta_container {
+        padding: 0;
+      }
+
+      .ama__membership_logo-container {
+        display: none;
+      }
+
+      .ama__membership_title_container {
+        margin-top: 28px;
+        @include breakpoint($bp-small) {
+          margin-top: 0;
+        }
+      }
+  
+      .ama__membership_cta_container {
+        font-weight: bold;
+        margin: 21px 0 0;
+        @include breakpoint($bp-small) {
+          margin: 28px 0 0;
+          max-width: 224px;
+        }
+        a.ama__button {
+          padding: 8px 14px 7px;
+        }
+      }
+  
+      .ama__h2 {
+        text-transform: uppercase;
+        color: $purple;
+        font-weight: bold;
+      }
+    }
+
+    .ama__membership_media-container {
+      width: 100%;
+      max-width: 680px;
+      padding: 0;
+      margin: 0;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -299,16 +299,14 @@ a.ama__membership {
 .ama__category .layout__region--content .layout--ama-page-section-one-col .ama__membership {
     display: flex;
     flex-direction: column-reverse;
-    column-gap: 120px;
     border-bottom: 0.5px solid #000;
     padding-bottom: 28px;
     margin-bottom: 28px;
+    width: 100%;
     @include breakpoint($bp-small) {
       flex-direction: row;
-      column-gap: 17px;
     }
     @include breakpoint($bp-med) {
-      column-gap: 120px;
       padding-bottom: 56px;
       margin-top: 56px;
       margin-bottom: 41px;
@@ -374,6 +372,12 @@ a.ama__membership {
       max-width: 680px;
       padding: 0;
       margin: 0;
+      @include breakpoint($bp-small) {
+        margin-left: 17px;
+      }
+      @include breakpoint($bp-med) {
+        margin-left: 120px;
+      }  
     }
 }
 

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -68,6 +68,10 @@
     }
   }
   @extend .display-list;
+
+  .ama__membership_media-container {
+    display: none;
+  }
 }
 
 a.ama__membership {
@@ -290,8 +294,9 @@ a.ama__membership {
 }
 
 // Category page membership block styling
-.ama__category .layout__region--content {
-  > .ama__membership {
+.ama__category .layout__region--content > .ama__membership,
+.ama__category .layout__region--content .layout--onecol .ama__membership,
+.ama__category .layout__region--content .layout--ama-page-section-one-col .ama__membership {
     display: flex;
     flex-direction: column-reverse;
     column-gap: 120px;
@@ -305,11 +310,13 @@ a.ama__membership {
     @include breakpoint($bp-med) {
       column-gap: 120px;
       padding-bottom: 56px;
+      margin-top: 56px;
       margin-bottom: 41px;
     }
     .ama__membership-content {
       background: none;
       display: block;
+      padding: 0;
       @include breakpoint($bp-small) {
         max-width: 380px;
       }
@@ -326,20 +333,28 @@ a.ama__membership {
 
       .ama__membership_title_container {
         margin-top: 28px;
+        margin-bottom: 14px;
         @include breakpoint($bp-small) {
           margin-top: 0;
+          margin-bottom: 0;
         }
       }
   
       .ama__membership_cta_container {
         font-weight: bold;
         margin: 21px 0 0;
+        max-width: unset;
+        position: unset;
         @include breakpoint($bp-small) {
           margin: 28px 0 0;
           max-width: 224px;
         }
         a.ama__button {
           padding: 8px 14px 7px;
+          line-height: 1;
+          height: unset;
+          width: 100%;
+          margin: 0;
         }
       }
   
@@ -347,20 +362,24 @@ a.ama__membership {
         text-transform: uppercase;
         color: $purple;
         font-weight: bold;
+        text-align: left;
+        padding: 0;
+        margin: 0;
       }
     }
 
     .ama__membership_media-container {
+      display: block;
       width: 100%;
       max-width: 680px;
       padding: 0;
       margin: 0;
     }
-  }
 }
 
 // Category specific layout builder styling
-.layout-builder__layout.layout--onecol .layout__region {
+.layout-builder__layout.layout--onecol .layout__region,
+.layout-builder__layout.layout--ama-page-section-one-col .layout__region {
   .ama__membership {
     display: flex;
     flex-direction: column-reverse;
@@ -375,11 +394,13 @@ a.ama__membership {
     @include breakpoint($bp-med) {
       column-gap: 120px;
       padding-bottom: 56px;
+      margin-top: 56px;
       margin-bottom: 41px;
     }
     .ama__membership-content {
       background: none;
       display: block;
+      padding: 0;
       @include breakpoint($bp-small) {
         max-width: 380px;
       }
@@ -396,20 +417,28 @@ a.ama__membership {
 
       .ama__membership_title_container {
         margin-top: 28px;
+        margin-bottom: 14px;
         @include breakpoint($bp-small) {
           margin-top: 0;
+          margin-bottom: 0;
         }
       }
   
       .ama__membership_cta_container {
         font-weight: bold;
         margin: 21px 0 0;
+        max-width: unset;
+        position: unset;
         @include breakpoint($bp-small) {
           margin: 28px 0 0;
           max-width: 224px;
         }
         a.ama__button {
           padding: 8px 14px 7px;
+          line-height: 1;
+          height: unset;
+          width: 100%;
+          margin: 0;
         }
       }
   
@@ -417,10 +446,14 @@ a.ama__membership {
         text-transform: uppercase;
         color: $purple;
         font-weight: bold;
+        text-align: left;
+        padding: 0;
+        margin: 0;
       }
     }
 
     .ama__membership_media-container {
+      display: block;
       width: 100%;
       max-width: 680px;
       padding: 0;

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -1,4 +1,4 @@
-.ama__membership {
+.ama__membership .ama__membership-content  {
   background: #ece7f0;
   @include gutter($padding-bottom-full...);
   @include child-top-gutters(calc($gutter / 2));
@@ -27,8 +27,8 @@
     margin-bottom: 0;
   }
 
-  &_logo-container {
-    background-color: #46166b;
+  .ama__membership_logo-container {
+    background-color: $purple;
     min-height: 28px;
     display: flex;
     margin-bottom: 0;
@@ -86,7 +86,7 @@ a.ama__membership {
 }
 
 //Slim Membership Block styling
-.layout--ama-page-section-one-col .ama__membership {
+.layout--ama-page-section-one-col .ama__membership .ama__membership-content {
   background: #ece7f0;
   height: 210px;
   margin: 0 0 35px;
@@ -285,6 +285,72 @@ a.ama__membership {
       position: relative;
       margin-left: -40px;
       margin-right: -30px;
+    }
+  }
+}
+
+// Category page membership block styling
+.ama__category .layout__region--content {
+  > .ama__membership {
+    display: flex;
+    flex-direction: column-reverse;
+    column-gap: 120px;
+    border-bottom: 0.5px solid #000;
+    padding-bottom: 28px;
+    margin-bottom: 28px;
+    @include breakpoint($bp-small) {
+      flex-direction: row;
+      column-gap: 17px;
+    }
+    @include breakpoint($bp-med) {
+      column-gap: 120px;
+      padding-bottom: 56px;
+      margin-bottom: 41px;
+    }
+    .ama__membership-content {
+      background: none;
+      display: block;
+      @include breakpoint($bp-small) {
+        max-width: 380px;
+      }
+  
+      .ama__membership_title_container, 
+      .membership-body,
+      .ama__membership_cta_container {
+        padding: 0;
+      }
+
+      .ama__membership_logo-container {
+        display: none;
+      }
+
+      .ama__membership_title_container {
+        margin-top: 0;
+      }
+  
+      .ama__membership_cta_container {
+        font-weight: bold;
+        margin: 21px 0 0;
+        @include breakpoint($bp-small) {
+          margin: 28px 0 0;
+          max-width: 224px;
+        }
+        a.ama__button {
+          padding: 8px 14px 7px;
+        }
+      }
+  
+      .ama__h2 {
+        text-transform: uppercase;
+        color: $purple;
+        font-weight: bold;
+      }
+    }
+
+    .ama__membership_media-container {
+      max-width: 680px;
+      padding: 0;
+      margin: 0;
     }
   }
 }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -325,7 +325,10 @@ a.ama__membership {
       }
 
       .ama__membership_title_container {
-        margin-top: 0;
+        margin-top: 28px;
+        @include breakpoint($bp-small) {
+          margin-top: 0;
+        }
       }
   
       .ama__membership_cta_container {
@@ -348,6 +351,7 @@ a.ama__membership {
     }
 
     .ama__membership_media-container {
+      width: 100%;
       max-width: 680px;
       padding: 0;
       margin: 0;

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -360,7 +360,7 @@ a.ama__membership {
 }
 
 // Category specific layout builder styling
-.layout--onecol .layout__region {
+.layout-builder__layout.layout--onecol .layout__region {
   .ama__membership {
     display: flex;
     flex-direction: column-reverse;

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -318,11 +318,18 @@ a.ama__membership {
       @include breakpoint($bp-small) {
         max-width: 380px;
       }
+      @include breakpoint($bp-med) {
+        margin-right: 17px;
+      }
   
       .ama__membership_title_container, 
       .membership-body,
       .ama__membership_cta_container {
         padding: 0;
+      }
+
+      .membership-body {
+        display: block;
       }
 
       .ama__membership_logo-container {
@@ -376,7 +383,7 @@ a.ama__membership {
         margin-left: 17px;
       }
       @include breakpoint($bp-med) {
-        margin-left: 120px;
+        margin-left: auto;
       }  
     }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10005: Membership Custom Block | For Category Page | Styleguide component](https://issues.ama-assn.org/browse/EWL-10005)

## Description
Update styling for membership blocks on category pages.


## To Test
- Import latest config 'lando drush @one.local cim -y'
- link styleguide PR: 'lando link-styleguides' 
- navigate to existing top level category page, i.e http://ama-one.lndo.site/about
- edit layout of page, move existing or add new membership block to to a full width column
- save and view page, confirm styling matches the following zeplins:https://app.zeplin.io/project/63bda76d34cc000c4febbb66/screen/63bdaaac6377ad0cac611496

- add/edit existing membership custom block
- confirm 'Media' field appears in form
- add media (image, brightcove or alternative video)
- confirm block can be saved
- add/move block to full width column on top level category page
- confirm block displays and matches the following zeplins:
- https://app.zeplin.io/project/63bda76d34cc000c4febbb66/screen/63cff7283f59617ab25eaa92

- navigate to homepage and subcategories, confirm existing membership blocks have not changed

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
