### PR TITLE
EWL-10016: Styling for partner promo redesign on category pages.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -55,4 +55,115 @@
       padding: 10px 5.5% 10px 10px;
     }
   }
+  // Only show partner promo media on category pages
+  .ama__partner-promo--media {
+    display: none;
+  }
+}
+
+// Category page membership block styling
+.ama__category .layout__region--content {
+  > .ama__partner-promo {
+    background: none;
+    display: flex;
+    flex-direction: column-reverse;
+    column-gap: 120px;
+    padding-bottom: 28px;
+    margin-bottom: 28px;
+    border-bottom: 0.5px solid #000;
+    @include breakpoint($bp-small) {
+      flex-direction: row;
+      column-gap: 17px;
+    }
+    @include breakpoint($bp-med) {
+      column-gap: 120px;
+      padding-bottom: 56px;
+      margin-bottom: 41px;
+    }
+    .ama__partner-promo__text {
+      display: block;
+      padding: 0;
+      @include breakpoint($bp-small) {
+        max-width: 380px;
+      }
+      h2.ama__h2 {
+        color: $blue;
+      }
+      p {
+        color: $black;
+      }
+
+      .ama__button {
+        font-weight: bold;
+        margin: 21px 0 0;
+        @include breakpoint($bp-small) {
+          margin: 28px 0 0;
+          max-width: 224px;
+        }
+        a.ama__button {
+          padding: 8px 14px 7px;
+        }
+      }
+    }
+    .ama__partner-promo--media {
+      display: block;
+      width: 100%;
+      max-width: 680px;
+      padding: 0;
+      margin: 0;
+    }
+  }
+}
+
+// Category specific layout builder styling
+.layout-builder__layout.layout--onecol .layout__region {
+  .ama__partner-promo {
+    background: none;
+    display: flex;
+    flex-direction: column-reverse;
+    column-gap: 120px;
+    padding-bottom: 28px;
+    margin-bottom: 28px;
+    border-bottom: 0.5px solid #000;
+    @include breakpoint($bp-small) {
+      flex-direction: row;
+      column-gap: 17px;
+    }
+    @include breakpoint($bp-med) {
+      column-gap: 120px;
+      padding-bottom: 56px;
+      margin-bottom: 41px;
+    }
+    .ama__partner-promo__text {
+      display: block;
+      padding: 0;
+      @include breakpoint($bp-small) {
+        max-width: 380px;
+      }
+      h2.ama__h2 {
+        color: $blue;
+      }
+      p {
+        color: $black;
+      }
+      .ama__button {
+        font-weight: bold;
+        margin: 21px 0 0;
+        @include breakpoint($bp-small) {
+          margin: 28px 0 0;
+          max-width: 224px;
+        }
+        a.ama__button {
+          padding: 8px 14px 7px;
+        }
+      }
+    }
+    .ama__partner-promo--media {
+      display: block;
+      width: 100%;
+      max-width: 680px;
+      padding: 0;
+      margin: 0;
+    }
+  }
 }

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -116,7 +116,8 @@
 }
 
 // Category specific layout builder styling
-.layout-builder__layout.layout--onecol .layout__region {
+.layout-builder__layout.layout--onecol .layout__region,
+.layout-builder__layout.layout--ama-page-section-one-col .layout__region {
   .ama__partner-promo {
     background: none;
     display: flex;

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -69,16 +69,13 @@
   width: 100%;
   display: flex;
   flex-direction: column-reverse;
-  // column-gap: 120px;
   padding-bottom: 28px;
   margin-bottom: 28px;
   border-bottom: 0.5px solid #000;
   @include breakpoint($bp-small) {
     flex-direction: row;
-    // column-gap: 17px;
   }
   @include breakpoint($bp-med) {
-    // column-gap: 120px;
     padding-bottom: 56px;
     margin-bottom: 41px;
   }
@@ -87,6 +84,9 @@
     padding: 0;
     @include breakpoint($bp-small) {
       max-width: 380px;
+    }
+    @include breakpoint($bp-med) {
+      margin-right: 17px;
     }
     h2.ama__h2 {
       color: $blue;
@@ -117,7 +117,7 @@
       margin-left: 17px;
     }
     @include breakpoint($bp-med) {
-      margin-left: 120px;
+      margin-left: auto;
     }
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -62,58 +62,66 @@
 }
 
 // Category page membership block styling
-.ama__category .layout__region--content {
-  > .ama__partner-promo {
-    background: none;
-    display: flex;
-    flex-direction: column-reverse;
-    column-gap: 120px;
-    padding-bottom: 28px;
-    margin-bottom: 28px;
-    border-bottom: 0.5px solid #000;
+.ama__category .layout__region--content > .ama__partner-promo,
+.ama__category .layout__region--content .layout--onecol .ama__partner-promo,
+.ama__category .layout__region--content .layout--ama-page-section-one-col .ama__partner-promo {
+  background: none;
+  width: 100%;
+  display: flex;
+  flex-direction: column-reverse;
+  // column-gap: 120px;
+  padding-bottom: 28px;
+  margin-bottom: 28px;
+  border-bottom: 0.5px solid #000;
+  @include breakpoint($bp-small) {
+    flex-direction: row;
+    // column-gap: 17px;
+  }
+  @include breakpoint($bp-med) {
+    // column-gap: 120px;
+    padding-bottom: 56px;
+    margin-bottom: 41px;
+  }
+  .ama__partner-promo__text {
+    display: block;
+    padding: 0;
     @include breakpoint($bp-small) {
-      flex-direction: row;
-      column-gap: 17px;
+      max-width: 380px;
+    }
+    h2.ama__h2 {
+      color: $blue;
+    }
+    p {
+      color: $black;
+    }
+
+    .ama__button {
+      font-weight: bold;
+      margin: 21px 0 0;
+      @include breakpoint($bp-small) {
+        margin: 28px 0 0;
+        max-width: 224px;
+      }
+      a.ama__button {
+        padding: 8px 14px 7px;
+      }
+    }
+  }
+  .ama__partner-promo--media {
+    display: block;
+    width: 100%;
+    max-width: 680px;
+    padding: 0;
+    margin: 0;
+    @include breakpoint($bp-small) {
+      margin-left: 17px;
     }
     @include breakpoint($bp-med) {
-      column-gap: 120px;
-      padding-bottom: 56px;
-      margin-bottom: 41px;
-    }
-    .ama__partner-promo__text {
-      display: block;
-      padding: 0;
-      @include breakpoint($bp-small) {
-        max-width: 380px;
-      }
-      h2.ama__h2 {
-        color: $blue;
-      }
-      p {
-        color: $black;
-      }
-
-      .ama__button {
-        font-weight: bold;
-        margin: 21px 0 0;
-        @include breakpoint($bp-small) {
-          margin: 28px 0 0;
-          max-width: 224px;
-        }
-        a.ama__button {
-          padding: 8px 14px 7px;
-        }
-      }
-    }
-    .ama__partner-promo--media {
-      display: block;
-      width: 100%;
-      max-width: 680px;
-      padding: 0;
-      margin: 0;
+      margin-left: 120px;
     }
   }
 }
+
 
 // Category specific layout builder styling
 .layout-builder__layout.layout--onecol .layout__region,


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10016: Partner Promo Custom Block | For Category Page | Styleguide component](https://issues.ama-assn.org/browse/EWL-10016)

## Description
Update styling for partner promo blocks on category pages.


## To Test
- Import latest config 'lando drush @one.local cim -y'
- link styleguide PR: 'lando link-styleguides' 
- navigate to existing top level category page, i.e http://ama-one.lndo.site/about
- edit layout of page, move existing or add partner promo block to to a full width column
- save and view page, confirm styling matches the following zeplins: https://app.zeplin.io/project/63bda76d34cc000c4febbb66/screen/63bdaaac6377ad0cac611496

- add/edit existing partner promo block
- confirm 'Media' field appears in form
- add media (image, brightcove or alternative video)
- confirm block can be saved
- add/move block to full width column on top level category page
- confirm block displays and matches the following zeplins:
- https://app.zeplin.io/project/63bda76d34cc000c4febbb66/screen/63bdaaac6377ad0cac611496

- navigate to homepage and subcategories, confirm existing membership blocks have not changed

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
