### PR TITLE
EWL-9971: Update styling for article stub list redesign.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
+++ b/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
@@ -6,6 +6,9 @@
   line-height: 31px;
   font-weight: bold;
   padding: 0 0 14px 0;
+  @include breakpoint($bp-med max-width) {
+    display: none;
+  }
 }
 
 //Subcat specific header styling, also inline article stub lists on news articles.

--- a/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
+++ b/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
@@ -1,9 +1,11 @@
 .ama__content-grouping-header {
   display: inline-block;
-  background: $purple;
-  color: $white;
-  font-weight: $font-weight-regular;
-  padding: (calc($gutter / 4)) $gutter (calc($gutter / 4)) (calc($gutter / 2));
+  background: none;
+  color: $black;
+  font-size: 26px;
+  line-height: 31px;
+  font-weight: bold;
+  padding: 0 0 14px 0;
 }
 
 //Subcat specific header styling, also inline article stub lists on news articles.

--- a/styleguide/source/assets/scss/02-molecules/_article-stub-metadata.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub-metadata.scss
@@ -4,4 +4,7 @@
   display: block;
   font-size: 12px;
   text-transform: uppercase;
+  .stub-date {
+    padding-bottom: 0;
+  }
 }

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -1,6 +1,7 @@
 .ama__article-stub {
   a {
     text-decoration: none;
+    line-height: 1;
 
     &:hover {
       text-decoration: underline;
@@ -10,6 +11,8 @@
   &__title {
     padding: 0;
     width: 100%;
+    font-size: 20px;
+    line-height: 26px;
   }
 
   &__copy {
@@ -73,9 +76,6 @@
       width: 75%;
     }
   }
-  .paragraph--type--series-related-article .ama__article-stub__description {
-    margin-top: -7px;
-  }
   .related-series-tag {
     display: block;
     margin-top: 7px;
@@ -84,7 +84,6 @@
       display:block;
       color: $purple;
       line-height: 16px;
-      font-weight: $font-weight-bold;
     }
   }
   &--small {
@@ -213,6 +212,34 @@
       span,
       .read_time h3 {
         font-size: 12px;
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .tags {
+    color: $grape-purple;
+    font-size: 14px;
+    text-transform: uppercase;
+    .tag {
+      position:relative;
+      padding-left:15px;
+      padding-right: 15px;
+      &:after {
+        content: "/";
+        position: absolute;
+        right: 0;
+        top: 0;
+        color: $grape-purple;
+      }
+      &:first-child {
+        &:before {
+          content: "/";
+          position: absolute;
+          left: 0;
+          top: 0;
+          color: $grape-purple;
+        }
       }
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -81,9 +81,14 @@
     margin-top: 7px;
     a {
       font-size: 14px;
-      display:block;
+      font-weight: bold;
+      display: block;
       color: $purple;
       line-height: 16px;
+      opacity: .7;
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
   &--small {
@@ -218,7 +223,7 @@
   }
 
   .tags {
-    color: $grape-purple;
+    color: $purple;
     font-size: 14px;
     text-transform: uppercase;
     .tag {
@@ -230,7 +235,7 @@
         position: absolute;
         right: 0;
         top: 0;
-        color: $grape-purple;
+        color: $purple;
       }
       &:first-child {
         &:before {
@@ -238,7 +243,7 @@
           position: absolute;
           left: 0;
           top: 0;
-          color: $grape-purple;
+          color: $purple;
         }
       }
     }

--- a/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subcategory-page-article-stub.scss
@@ -45,13 +45,14 @@
     line-height: 23px;
     color: $gray-50;
     text-transform: uppercase;
+    margin-bottom: 7px;
     @include breakpoint($bp-small) {
       font-size: 0.78em;
       line-height: .9em;
     }
     .stub-date {
       @include type($myriad-pro, $font-weight-regular);
-      padding-bottom: (calc($gutter / 2.5));
+      padding-bottom: 0;
       display: inline-block;
     }
     span {
@@ -62,8 +63,10 @@
       bottom: 0px;
     }
     .read_time {
-      padding-bottom: 11.2px;
       display: inline-block;
+      h3 {
+        margin-bottom: 0;
+      }
     }
   }
 

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -1,13 +1,17 @@
 .ama__category-page-article-stub {
 
   .grid-container {
-    @include gutter($margin-top-full...);
+    padding-top: $gutter;
+    margin: 0;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: space-between;
 
     @include breakpoint($bp-med min-width) {
+      @include gutter($margin-top-full...);
+      @include gutter($margin-bottom-full...);
+      padding-top: 0;
       flex-wrap: nowrap;
     }
 
@@ -18,13 +22,20 @@
 
   .ama__article-stub {
     margin-left: 0;
-    margin-bottom: 26px;
+    margin-top: 28px;
+    padding-top: 28px;
     width: 100%;
     max-width: unset;
-    border-bottom: 0.5px solid $border-gray;
+    border-top: 0.5px solid $border-gray;
 
     &:first-child {
       margin-left: 0;
+    }
+
+    &:first-of-type {
+      margin-top: 0;
+      padding-top: 0;
+      border-top: 0;
     }
 
     &:last-of-type {
@@ -33,33 +44,44 @@
 
     @include breakpoint($bp-small max-width) {
       &:last-of-type {
-        margin-bottom: 33px;
+        margin-bottom: 28px;
       }
     }
 
     @include breakpoint($bp-small min-width) {
-      @include gutter($margin-left-full...);
-      margin-bottom: 60px;
-      width: 45%;
-      max-width: 303px;
+      margin-bottom: 0;
+      width: 50%;
       flex: 1 1 auto;
-      border-bottom: none;
+      border-top: none;
+      margin-top: 0;
+      padding-top: 0;
+      > div {
+        max-width: 303px;
+        width: 86%;
+      }
       &:last-of-type,
       &:nth-of-type(3) {
-        border-top: .5px solid $border-gray;
-        padding-top: 25px;
+        margin-top: 56px;
+        > div {
+          display: block;
+          position: relative;
+          &::before {
+            content: '';
+            border-top: .5px solid $border-gray;
+            width: 100%;
+            position: absolute;
+            top: -28px;
+          }
+        }
       }
+
       &:nth-of-type(3) {
         margin-left: 0;
       }
       &:nth-of-type(even) {
-        &:before {
-          content: "";
-          display: block;
-          border-left: .5px solid $border-gray;
-          position: absolute;
-          height: 343px;
-          left: 50%;
+        border-left: .5px solid $border-gray;
+        > div {
+          float: right;
         }
       }
       &.five-up {
@@ -70,33 +92,46 @@
     @include breakpoint($bp-med min-width) {
       @include gutter($margin-left-full...);
       width: 25%;
-      max-width: 250px;
+      margin-top: 0;
+      padding-top: 0;
+      > div {
+        max-width: unset;
+        width: 100%;
+      }
       &:first-of-type {
         // The 2.1 is bases off a 29.5px margin in a 1400px wide container.
         // Someone forgot that global max container size is actually 1140px...
-        margin-right: 2.1%;
+        padding-right: 2.1%;
+      }
+      &:nth-of-type(even) {
+        border-left: none;
+        > div {
+          float: unset;
+        }
       }
       &:nth-of-type(even),
       &:nth-of-type(3) {
-        margin-left: 2.1%;
-        margin-right: 2.1%;
+        margin-left: 0;
+        padding-left: 2.1%;
         position: relative;
-        &:before {
-          content: "";
-          display: block;
-          border-left: .5px solid $border-gray;
-          position: absolute;
-          height: 330px;
-          left: -10%;
+        border-left: 0.5px solid #a1a1a4;
+        > div {
+          border-top: none;
+          padding-top: 0;
+          margin-top: 0;
+          &::before {
+            display: none;
+          }
         }
       }
       &:last-of-type,
       &:nth-of-type(3) {
         padding-top: 0;
+        margin-top: 0;
         border-top: none;
+        margin-left: 2.1%;
       }
       &:nth-of-type(3) {
-        @include gutter($margin-left-full...);
         &.five-up {
           margin-left: $gutter*.75;
         }

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -39,7 +39,7 @@
 
     @include breakpoint($bp-small min-width) {
       @include gutter($margin-left-full...);
-      margin-bottom: 25px;
+      margin-bottom: 60px;
       width: 45%;
       max-width: 303px;
       flex: 1 1 auto;
@@ -58,7 +58,7 @@
           display: block;
           border-left: .5px solid $border-gray;
           position: absolute;
-          height: 40%;
+          height: 343px;
           left: 50%;
         }
       }

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -18,12 +18,17 @@
 
   .ama__article-stub {
     margin-left: 0;
-    @include gutter($margin-bottom-full...);
+    margin-bottom: 26px;
     width: 100%;
     max-width: unset;
+    border-bottom: 0.5px solid $border-gray;
 
     &:first-child {
       margin-left: 0;
+    }
+
+    &:last-of-type {
+      border-bottom: none;
     }
 
     @include breakpoint($bp-small max-width) {
@@ -38,6 +43,7 @@
       width: 45%;
       max-width: 303px;
       flex: 1 1 auto;
+      border-bottom: none;
       &:last-of-type,
       &:nth-of-type(3) {
         border-top: .5px solid $border-gray;
@@ -64,6 +70,26 @@
     @include breakpoint($bp-med min-width) {
       @include gutter($margin-left-full...);
       width: 25%;
+      max-width: 250px;
+      &:first-of-type {
+        // The 2.1 is bases off a 29.5px margin in a 1400px wide container.
+        // Someone forgot that global max container size is actually 1140px...
+        margin-right: 2.1%;
+      }
+      &:nth-of-type(even),
+      &:nth-of-type(3) {
+        margin-left: 2.1%;
+        margin-right: 2.1%;
+        position: relative;
+        &:before {
+          content: "";
+          display: block;
+          border-left: .5px solid $border-gray;
+          position: absolute;
+          height: 330px;
+          left: -10%;
+        }
+      }
       &:last-of-type,
       &:nth-of-type(3) {
         padding-top: 0;
@@ -77,12 +103,6 @@
       }
       &.five-up {
         width: 33%;
-      }
-      &:nth-of-type(even) {
-        margin-left: 28px;
-      }
-      &:before {
-        display: none !important;
       }
     }
     @include breakpoint($bp-large min-width) {

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -5,6 +5,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    justify-content: space-between;
 
     @include breakpoint($bp-med min-width) {
       flex-wrap: nowrap;
@@ -19,17 +20,41 @@
     margin-left: 0;
     @include gutter($margin-bottom-full...);
     width: 100%;
+    max-width: unset;
 
     &:first-child {
       margin-left: 0;
     }
 
+    @include breakpoint($bp-small max-width) {
+      &:last-of-type {
+        margin-bottom: 33px;
+      }
+    }
+
     @include breakpoint($bp-small min-width) {
       @include gutter($margin-left-full...);
-      @include gutter($margin-bottom-full...);
-      width: 47%;
+      margin-bottom: 25px;
+      width: 45%;
+      max-width: 303px;
+      flex: 1 1 auto;
+      &:last-of-type,
+      &:nth-of-type(3) {
+        border-top: .5px solid $border-gray;
+        padding-top: 25px;
+      }
       &:nth-of-type(3) {
         margin-left: 0;
+      }
+      &:nth-of-type(even) {
+        &:before {
+          content: "";
+          display: block;
+          border-left: .5px solid $border-gray;
+          position: absolute;
+          height: 40%;
+          left: 50%;
+        }
       }
       &.five-up {
         width: 30%;
@@ -39,6 +64,11 @@
     @include breakpoint($bp-med min-width) {
       @include gutter($margin-left-full...);
       width: 25%;
+      &:last-of-type,
+      &:nth-of-type(3) {
+        padding-top: 0;
+        border-top: none;
+      }
       &:nth-of-type(3) {
         @include gutter($margin-left-full...);
         &.five-up {
@@ -47,6 +77,12 @@
       }
       &.five-up {
         width: 33%;
+      }
+      &:nth-of-type(even) {
+        margin-left: 28px;
+      }
+      &:before {
+        display: none !important;
       }
     }
     @include breakpoint($bp-large min-width) {
@@ -62,6 +98,9 @@
 
   .ama__article-stub__copy {
     padding: 0;
+    display: block;
+    min-height: 15px;
+    margin-bottom: 7px;
   }
   .grid-container {
     &:last-child {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

## JIRA Ticket(s)
- [EWL-9971: Article Stub List Custom Block | Redesign](https://issues.ama-assn.org/browse/EWL-9971)


## Description:
Update templates and series listing view for redesign of article stub list custom blocks.


## To Test:
- import config changes (lando drush @one.local cim -y)
- checkout ama-d8 PR: https://github.com/AmericanMedicalAssociation/ama-d8/pull/3927
- clear caches

- navigate to various category, subcategory, series and topic term pages. confirm all existing stub lust custom blocks match the following zeplins, **especially tablet:**
Desktop: https://zpl.io/KG14ZN8
Tablet: https://zpl.io/PqQvM8A 
Mobile: https://zpl.io/B1lOBpK

- add article stub list custom block
- confirm fields and available paragraphs match the AC in the Jira ticket above

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
![Screen Shot 2023-03-16 at 3 58 41 PM](https://user-images.githubusercontent.com/67962801/225751751-3d111fca-6907-4e9b-b790-8d7e8ed50702.png)
![Screen Shot 2023-03-16 at 3 58 53 PM](https://user-images.githubusercontent.com/67962801/225751753-80be8158-75aa-4468-9796-d3f02d147219.png)
![Screen Shot 2023-03-16 at 3 59 53 PM](https://user-images.githubusercontent.com/67962801/225751758-8f2d2aae-e1a4-4c35-8696-1e3cbdbcffe4.png)



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
