### PR TITLE
EWL-9950: New styles for category theme blocks. Removed all bold.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
+++ b/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
@@ -4,7 +4,7 @@
   color: $black;
   font-size: 26px;
   line-height: 31px;
-  font-weight: 600;
+  font-weight: $font-weight-bold;
   padding: 0 0 14px 0;
   @include breakpoint($bp-med max-width) {
     display: none;

--- a/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
+++ b/styleguide/source/assets/scss/01-atoms/_content-grouping-header.scss
@@ -4,7 +4,7 @@
   color: $black;
   font-size: 26px;
   line-height: 31px;
-  font-weight: bold;
+  font-weight: 600;
   padding: 0 0 14px 0;
   @include breakpoint($bp-med max-width) {
     display: none;

--- a/styleguide/source/assets/scss/02-molecules/_category-theme.scss
+++ b/styleguide/source/assets/scss/02-molecules/_category-theme.scss
@@ -1,3 +1,4 @@
+//  Remove duplicate styles.
 .ama__category-theme {
   padding-bottom: 0;
   padding-top: 0;
@@ -22,241 +23,6 @@
     display:none;
     @include breakpoint($bp-small) {
       display: block;
-    }
-  }
-  .date,
-  .mobile-date {
-    font-size: 14px;
-    color: #424242;
-    text-transform: uppercase;
-    padding-bottom: 4px;
-    .article-event-date {
-      display: inline;
-    }
-    .read_time {
-      display: inline;
-      margin-bottom: 0;
-      padding-bottom: 0;
-      .ama__h3 {
-        display: inline;
-        font-size: 14px;
-        color: #424242;
-        line-height: 27px;
-      }
-    }
-  }
-  .category-theme {
-    &__header {
-      font-weight: bold;
-      padding-bottom: $gutter;
-      margin-bottom: 0;
-      @include breakpoint($bp-small) {
-        padding-bottom: calc($gutter * .75);
-      }
-    }
-    &__container {
-      h3,
-      .ama__h3 {
-        margin-bottom: 0 !important;
-      }
-      display: flex;
-      flex-direction: column;
-      @include breakpoint($bp-small) {
-        flex-direction: row;
-      }
-    }
-    &--content {
-      .ama__subcategory-page-article-stub__date-time,
-      .ama__article-stub__copy {
-        padding-left: 0;
-        padding-right: 0;
-      }
-    }
-    &--four-up {
-      .category-theme__container--right {
-        .category-theme__stub {
-          .description {
-            display: none;
-          }
-        }
-      }
-    }
-    &--three-up,
-    &--two-up {
-      .category-theme__container--right {
-        .category-theme__stub {
-          .description {
-            display: none;
-            @include breakpoint($bp-small) {
-              display: block;
-            }
-          }
-        }
-      }
-    }
-    &--two-up {
-      .category-theme__container--right {
-        .category-theme__stub {
-          .description {
-            display: none;
-            @include breakpoint($bp-small) {
-              display: block;
-            }
-          }
-        }
-      }
-    }
-  }
-  .category-theme__container--left {
-    padding-bottom: $gutter;
-    padding-right: 0;
-    flex: 1;
-    @include breakpoint($bp-small) {
-      padding-right: calc($gutter * .75);
-      flex: .5;
-    }
-    @include breakpoint($bp-med) {
-      padding-right: calc($gutter * 4.25);
-      flex: .4;
-    }
-    .mobile-date {
-      display: none;
-    }
-    .category-theme--content {
-      .ama__article-stub__title {
-        font-size: 18px;
-        line-height: 22px;
-        padding-bottom: calc($gutter * .5);
-        @include breakpoint($bp-small) {
-          font-size: 20px;
-          line-height: 27px;
-          padding-bottom: calc($gutter * .75);
-        }
-      }
-    }
-    @include breakpoint($bp-small) {
-      padding-bottom: 0;
-      .category-theme--image {
-        max-width: 100%;
-      }
-    }
-  }
-  .category-theme__container--right {
-    margin-left: auto;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    @include breakpoint($bp-small) {
-      flex: .5;
-    }
-    @include breakpoint($bp-med) {
-      flex: .6;
-    }
-
-    .category-theme__stub {
-      padding-bottom: calc($gutter * .75);
-      &:last-of-type {
-        padding-bottom: 0;
-      }
-      @include breakpoint($bp-small) {
-        border-bottom: 1px solid #a1a1a4;
-        padding-top: calc($gutter * .75);
-        &:last-of-type {
-          border-bottom: none;
-          padding-bottom: 0;
-        }
-        &:first-of-type {
-          padding-top: 0;
-        }
-      }
-      @include breakpoint($bp-med) {
-        min-height: 128px;
-      }
-      .stub__container {
-        display: flex;
-        flex-direction: row-reverse;
-        flex-wrap: wrap;
-        justify-content: end;
-        .mobile-date {
-          display: block;
-          flex-basis: 100%;
-          padding-bottom: calc($gutter * .25);
-          @include breakpoint($bp-small) {
-            display: none;
-          }
-        }
-        .date {
-          display: none;
-          @include breakpoint($bp-small) {
-            display: block;
-          }
-        }
-
-        &.stub__has-image {
-          min-height: 100px;
-          .category-theme--content {
-            flex: .75;
-            @include breakpoint($bp-small) {
-              flex: 1;
-            }
-            @include breakpoint($bp-med) {
-              flex: .7;
-            }
-          }
-          .category-theme--image {
-            flex: .25;
-            @include breakpoint($bp-small) {
-              flex: .5;
-            }
-            @include breakpoint($bp-med) {
-              flex: .3;
-            }
-          }
-        }
-        @include breakpoint($bp-small) {
-          flex-direction: row;
-        }
-        .category-theme--content {
-          flex: 1;
-          @include breakpoint($bp-med) {
-            padding-right: calc($gutter * .25);
-          }
-          h3.ama__h3 {
-            margin-bottom: 0;
-          }
-          h3.ama__article-stub__title {
-            font-size: 18px;
-            line-height: 1.39;
-            margin-bottom: 0;
-            padding-top: 0;
-            @include breakpoint($bp-small) {
-              padding-bottom: calc($gutter * .75);
-            }
-            @include breakpoint($bp-med) {
-              font-size: 18px;
-              line-height: 25px;
-            }
-          }
-        }
-        .category-theme--image {
-          display: block;
-          flex: .25;
-          padding-right: $gutter;
-          padding-left: 0;
-          @include breakpoint($bp-small max-width) {
-            flex: .75;
-          }
-          @include breakpoint($bp-small) {
-            align-items: unset;
-            display: none;
-            padding-right: 0;
-          }
-          @include breakpoint($bp-med) {
-            display: block;
-            padding-left: $gutter;
-          }
-        }
-      }
     }
   }
   .wrapper-link {
@@ -300,7 +66,434 @@
       display: block;
     }
   }
+  .date,
+  .mobile-date {
+    font-size: 14px;
+    color: #424242;
+    text-transform: uppercase;
+    padding-bottom: 4px;
+    .article-event-date {
+      display: inline;
+    }
+    .read_time {
+      display: inline;
+      margin-bottom: 0;
+      padding-bottom: 0;
+      .ama__h3 {
+        display: inline;
+        font-size: 14px;
+        color: #424242;
+        line-height: 27px;
+      }
+    }
+  }
+  .category-theme {
+    &__header {
+      font-weight: $font-weight-bold;
+      padding-bottom: $gutter;
+      margin-bottom: 0;
+      @include breakpoint($bp-small) {
+        padding-bottom: calc($gutter * .75);
+      }
+    }
+
+    &__container {
+      h3,
+      .ama__h3 {
+        margin-bottom: 0 !important;
+      }
+      display: flex;
+      flex-direction: column;
+      @include breakpoint($bp-small) {
+        flex-direction: row;
+      }
+      &--left {
+        //padding-bottom: $gutter;
+        padding-right: 0;
+        flex: 1;
+        @include breakpoint($bp-small) {
+          padding-right: calc($gutter * .75);
+          flex: .5;
+        }
+        @include breakpoint($bp-med) {
+          padding-right: calc($gutter * 4.25);
+          flex: .4;
+        }
+        .mobile-date {
+          display: none;
+        }
+        .category-theme--content {
+          .ama__article-stub__title {
+            font-size: 18px;
+            line-height: 22px;
+            padding-bottom: calc($gutter * .5);
+            @include breakpoint($bp-small) {
+              font-size: 20px;
+              line-height: 27px;
+              padding-bottom: calc($gutter * .75);
+            }
+          }
+        }
+        @include breakpoint($bp-small) {
+          padding-bottom: 0;
+          .category-theme--image {
+            max-width: 100%;
+          }
+        }
+      }
+      &--right {
+        margin-left: auto;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        @include breakpoint($bp-small) {
+          flex: .5;
+        }
+        @include breakpoint($bp-med) {
+          flex: .6;
+        }
+        .category-theme__stub {
+          padding-bottom: calc($gutter * .75);
+          &:last-of-type {
+            padding-bottom: 0;
+          }
+          @include breakpoint($bp-small) {
+            border-bottom: 1px solid #a1a1a4;
+            padding-top: calc($gutter * .75);
+            &:last-of-type {
+              border-bottom: none;
+              padding-bottom: 0;
+            }
+            &:first-of-type {
+              padding-top: 0;
+            }
+          }
+          @include breakpoint($bp-med) {
+            min-height: 128px;
+          }
+          .stub__container {
+            display: flex;
+            flex-direction: row-reverse;
+            flex-wrap: wrap;
+            justify-content: end;
+            .mobile-date {
+              display: block;
+              flex-basis: 100%;
+              padding-bottom: calc($gutter * .25);
+              @include breakpoint($bp-small) {
+                display: none;
+              }
+            }
+            .date {
+              display: none;
+              @include breakpoint($bp-small) {
+                display: block;
+              }
+            }
+
+            &.stub__has-image {
+              min-height: 100px;
+              .category-theme--content {
+                flex: .75;
+                @include breakpoint($bp-small) {
+                  flex: 1;
+                }
+                @include breakpoint($bp-med) {
+                  flex: .7;
+                }
+              }
+              .category-theme--image {
+                flex: .25;
+                @include breakpoint($bp-small) {
+                  flex: .5;
+                }
+                @include breakpoint($bp-med) {
+                  flex: .3;
+                }
+              }
+            }
+            @include breakpoint($bp-small) {
+              flex-direction: row;
+            }
+            .category-theme--content {
+              flex: 1;
+              @include breakpoint($bp-med) {
+                padding-right: calc($gutter * .25);
+              }
+              h3.ama__h3 {
+                margin-bottom: 0;
+              }
+              h3.ama__article-stub__title {
+                font-size: 18px;
+                line-height: 1.39;
+                margin-bottom: 0;
+                padding-top: 0;
+                @include breakpoint($bp-small) {
+                  padding-bottom: calc($gutter * .75);
+                }
+                @include breakpoint($bp-med) {
+                  font-size: 18px;
+                  line-height: 25px;
+                }
+              }
+            }
+            .category-theme--image {
+              flex: .25;
+              padding-right: $gutter;
+              padding-left: 0;
+              @include breakpoint($bp-small max-width) {
+                flex: .75;
+              }
+              @include breakpoint($bp-small) {
+                align-items: unset;
+                padding-right: 0;
+              }
+              @include breakpoint($bp-med) {
+                padding-left: $gutter;
+              }
+            }
+          }
+        }
+      }
+    }
+    &--content {
+      .ama__subcategory-page-article-stub__date-time,
+      .ama__article-stub__copy {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    }
+    &--four-up {
+      .category-theme__container--right {
+        .category-theme__stub {
+          .stub__container {
+            .description {
+              display: none;
+            }
+            .category-theme--image {
+              display: block;
+              @include breakpoint($bp-small) {
+                display: none;
+              }
+              @include breakpoint($bp-med) {
+                display: block;
+              }
+            }
+          }
+        }
+      }
+    }
+    &--three-up {
+      flex-direction: column;
+      @include breakpoint($bp-med) {
+        flex-direction: row;
+      }
+      .category-theme__container--left {
+        padding-right: 0;
+        @include breakpoint($bp-med) {
+          padding-right: calc($gutter * 4.25);
+        }
+        .category-theme__stub {
+          border-bottom: none;
+          padding-bottom: calc($gutter * .75);
+          @include breakpoint($bp-small) {
+            border-bottom: 1px solid $border-gray;
+          }
+          @include breakpoint($bp-med) {
+            border-bottom: none;
+            padding-bottom: 0;
+          }
+          .stub__container {
+            &.stub__has-image {
+              display: flex;
+              flex-direction: column-reverse;
+              @include breakpoint($bp-small) {
+                flex-direction: row;
+              }
+              @include breakpoint($bp-med) {
+                flex-direction: column;
+              }
+              .category-theme--image {
+                flex: 1;
+                @include breakpoint($bp-small) {
+                  flex: .66;
+                }
+                @include breakpoint($bp-med) {
+                  flex: 1;
+                }
+              }
+              .category-theme--content {
+                flex: 1;
+                @include breakpoint($bp-small) {
+                  flex: .34;
+                }
+                @include breakpoint($bp-med) {
+                  flex: 1;
+                }
+              }
+            }
+          }
+        }
+      }
+      .category-theme__container--right {
+        .category-theme__stub {
+          padding-top: calc($gutter * .75);
+          padding-bottom: calc($gutter * .75);
+          border-bottom: none;
+          @include breakpoint($bp-small) {
+            border-bottom: 1px solid $border-gray;
+          }
+          @include breakpoint($bp-med) {
+            padding-top: 0;
+          }
+          &:last-child {
+            padding-top: calc($gutter * .75);
+            border-bottom: none;
+
+          }
+          .stub__container {
+            .category-theme--content {
+              flex: 1;
+              flex-direction: column;
+              @include breakpoint($bp-small) {
+                flex: 1;
+                flex-direction: column;
+              }
+              @include breakpoint($bp-med) {
+                flex: 1;
+                flex-direction: column;
+              }
+              @include breakpoint($bp-large) {
+                flex: 1;
+                flex-direction: column;
+              }
+              .ama__article-stub__title {
+                padding-bottom: calc($gutter * .75);
+              }
+              .description {
+                display: none;
+                padding-bottom: 0;
+                @include breakpoint($bp-small) {
+                  display: block;
+                }
+              }
+            }
+            &.stub__has-image {
+              flex-direction: column-reverse;
+              @include breakpoint($bp-small) {
+                flex-direction: row;
+              }
+              .category-theme--image {
+                padding-right: 0;
+                flex: 1;
+                @include breakpoint($bp-small) {
+                  flex: .33;
+                }
+                @include breakpoint($bp-med) {
+                  flex: .4;
+                }
+              }
+              .category-theme--content {
+                flex: 1;
+                padding-right: 0;
+                @include breakpoint($bp-small) {
+                  flex: .67;
+                  padding-right: calc($gutter * .75);
+                }
+                @include breakpoint($bp-med) {
+                  flex: .6;
+                }
+              }
+            }
+            .mobile-date {
+              display: none;
+            }
+            .date {
+              display: block;
+            }
+          }
+        }
+      }
+    }
+    &--two-up {
+      .category-theme__container--right {
+        flex: 1;
+        @include breakpoint($bp-small) {
+          flex: .5;
+        }
+        @include breakpoint($bp-large) {
+          flex: .6;
+        }
+      }
+      .category-theme__container--left {
+        flex: 1;
+        padding-right: 0;
+        @include breakpoint($bp-small) {
+          flex: .5;
+          padding-right: calc($gutter * 3.25);
+        }
+        @include breakpoint($bp-large) {
+          flex: .4;
+          padding-right: calc($gutter * 4.25);
+        }
+      }
+      .category-theme__container--left {
+        .category-theme__stub {
+          border-bottom: 1px solid $border-gray;
+          @include breakpoint($bp-small) {
+            border-bottom: none;
+          }
+          .stub__container {
+            display:flex;
+            flex-direction: column-reverse;
+            @include breakpoint($bp-small) {
+              flex-direction: column;
+            }
+          }
+        }
+      }
+      .category-theme__container--right {
+        .category-theme__stub {
+          padding-top: calc($gutter * .75);
+          @include breakpoint($bp-small) {
+            padding-top: 0;
+          }
+          .stub__container {
+            flex-direction: column-reverse;
+            @include breakpoint($bp-small) {
+              flex-direction: column;
+            }
+            .description {
+              display: none;
+              @include breakpoint($bp-small) {
+                display: block;
+              }
+            }
+            .mobile-date {
+              display: none;
+            }
+            .category-theme--content {
+              .date {
+                display: block;
+              }
+            }
+            &.stub__has-image {
+              .category-theme--content {
+
+              }
+              .category-theme--image {
+                padding-left: 0;
+                padding-right: 0;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }
+
+//  Subcategory block styles.
 .category-theme__container {
   &.category-subcat {
     h3.ama__h3 {
@@ -358,17 +551,12 @@
     &.category-theme--three-up {
       .category-theme__container--right {
         .category-theme__stub {
-          .stub__container {
-            border-bottom: 1px solid $border-gray;
-            padding-bottom: 0;
-            @include breakpoint($bp-small) {
-              border-bottom: none;
-            }
-          }
+          border-bottom: 1px solid $border-gray;
           &:last-child {
-            .stub__container {
-              border-bottom: none;
-            }
+            border-bottom: 0;
+          }
+          .stub__container {
+            padding-bottom: 0;
           }
           .stub__container {
             .category-theme--content {

--- a/styleguide/source/assets/scss/02-molecules/_forum-topic.scss
+++ b/styleguide/source/assets/scss/02-molecules/_forum-topic.scss
@@ -103,7 +103,7 @@
     }
   }
   &-resolution {
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     margin-bottom: .5em;
   }
   &-downloads {

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -93,7 +93,7 @@
     }
 
     .ama__button {
-      font-weight: bold;
+      font-weight: $font-weight-bold;
       margin: 21px 0 0;
       @include breakpoint($bp-small) {
         margin: 28px 0 0;
@@ -152,7 +152,7 @@
       color: $black;
     }
     .ama__button {
-      font-weight: bold;
+      font-weight: $font-weight-bold;
       margin: 21px 0 0;
       @include breakpoint($bp-small) {
         margin: 28px 0 0;

--- a/styleguide/source/assets/scss/02-molecules/_series-tag.scss
+++ b/styleguide/source/assets/scss/02-molecules/_series-tag.scss
@@ -24,8 +24,8 @@
     content: '';
     position: absolute;
     right: -13px;
-    bottom: 0; 
-    width: 0; 
+    bottom: 0;
+    width: 0;
     height: 0;
     border-left: 13px solid $purple;
     border-top: 13px solid transparent;
@@ -34,7 +34,7 @@
   a {
     flex: 1;
     font-size: 15px;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     font-style: italic;
     text-decoration: none;
     margin-left: 17px;

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -315,7 +315,7 @@
       width: 13px;
       min-width: 13px;
       height: 16px;
-  
+
     }
     span.us-verify {
       color: $text-navy;
@@ -335,7 +335,7 @@
   .ama__subscribe-promo__form .ama__button {
     background-color: $orange;
     color: $black;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     width: 100%;
     margin: 0;
     text-transform: none;
@@ -420,7 +420,7 @@
   .ama__subscribe-promo__form .ama__button {
     background-color: $orange;
     color: $black;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     width: 100%;
     max-width: 220px;
     margin: 0;

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -61,7 +61,7 @@
   .stub-date + span {
     display: inline-block;
     font-size: 14px;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     color: $gray-50;
     padding-left: 1px;
     padding-right: 1px;

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -320,8 +320,8 @@ a.ama__membership {
       @include breakpoint($bp-med) {
         margin-right: 17px;
       }
-  
-      .ama__membership_title_container, 
+
+      .ama__membership_title_container,
       .membership-body,
       .ama__membership_cta_container {
         padding: 0;
@@ -343,9 +343,9 @@ a.ama__membership {
           margin-bottom: 0;
         }
       }
-  
+
       .ama__membership_cta_container {
-        font-weight: bold;
+        font-weight: $font-weight-bold;
         margin: 21px 0 0;
         max-width: unset;
         position: unset;
@@ -363,11 +363,11 @@ a.ama__membership {
           margin: 0;
         }
       }
-  
+
       .ama__h2 {
         text-transform: uppercase;
         color: $purple;
-        font-weight: bold;
+        ffont-weight: $font-weight-bold;
         text-align: left;
         padding: 0;
         margin: 0;
@@ -417,8 +417,8 @@ a.ama__membership {
       @include breakpoint($bp-small) {
         max-width: 380px;
       }
-  
-      .ama__membership_title_container, 
+
+      .ama__membership_title_container,
       .membership-body,
       .ama__membership_cta_container {
         padding: 0;
@@ -436,9 +436,9 @@ a.ama__membership {
           margin-bottom: 0;
         }
       }
-  
+
       .ama__membership_cta_container {
-        font-weight: bold;
+        font-weight: $font-weight-bold;
         margin: 21px 0 0;
         max-width: unset;
         position: unset;
@@ -456,11 +456,11 @@ a.ama__membership {
           margin: 0;
         }
       }
-  
+
       .ama__h2 {
         text-transform: uppercase;
         color: $purple;
-        font-weight: bold;
+        font-weight: $font-weight-bold;
         text-align: left;
         padding: 0;
         margin: 0;

--- a/styleguide/source/assets/scss/05-pages/_application.scss
+++ b/styleguide/source/assets/scss/05-pages/_application.scss
@@ -12,7 +12,7 @@
     @include breakpoint($bp-med) {
       h1 {
         line-height: 1.16;
-        font-weight: bold;
+        font-weight: $font-weight-bold;
       }
     }
   }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-9950: Ticket Title](https://issues.ama-assn.org/browse/EWL-9950)

## Description
Verify that category theme blocks 2-up, 3-up, and 4-up all display correctly at all breakpoints according to the zeplins
Removed all 'bold' statements. for legacy reasons, our site does not use true bold anywhere.


## To Test
- [ ] set up for local SG development and serve
- [ ] create each type of category theme block and test each at all breakpoints against the zeplin designs. 
- [ ] https://app.zeplin.io/project/63bda76d34cc000c4febbb66/screen/63cff7283f59617ab25eaa92

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
