### PR TITLE
EWL-10082: changed focus properties.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_category-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/_category-hero.scss
@@ -97,10 +97,8 @@ Styles for the new Category Featured Content Custom Block.
   h3.title,
   .description {
     margin-bottom: 0;
-    &:focus {
-      h3 {
-        border: 3px solid $description-blue-visited;
-      }
+    &:focus-visible {
+      border: 3px solid $description-blue-visited;
     }
   }
 
@@ -121,7 +119,7 @@ Styles for the new Category Featured Content Custom Block.
         text-decoration: underline;
       }
     }
-    &:focus {
+    &:focus-visible {
       h3.title {
         border: 3px solid $description-blue-visited;
       }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-10087: Ticket Title](https://issues.ama-assn.org/browse/EWL-10087)

## Description
changed :focus to :focus-visible, so keyboard nav will light up the focus style, but a mouse won't


## To Test
- [ ] pull and serve
- [ ] go to a featured content block. 
- [ ] verify that if you tab through the highlight is visible
- [ ] verify that if you click the title, no focus highlight displays.

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
