### PR TITLE
EWL-10112: partner promo bugfixes.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -80,12 +80,12 @@
   }
   .ama__partner-promo__text {
     display: block;
+    margin-right: 0;
     padding: 0;
+    flex: 1;
     @include breakpoint($bp-small) {
-      max-width: 380px;
-    }
-    @include breakpoint($bp-med) {
-      margin-right: 17px;
+      margin-right: calc($gutter * .75);
+      flex: .34;
     }
     h2.ama__h2 {
       color: $blue;
@@ -98,7 +98,7 @@
     .ama__button {
       font-weight: $font-weight-bold;
       margin: 21px 0 0;
-      @include breakpoint($bp-small) {
+      @include breakpoint($bp-med) {
         margin: 28px 0 0;
         max-width: 224px;
       }
@@ -111,11 +111,12 @@
   .ama__partner-promo--media {
     display: block;
     width: 100%;
-    max-width: 680px;
     padding: 0;
     margin: 0;
+    flex: 1;
     @include breakpoint($bp-small) {
       margin-left: 17px;
+      flex: .66;
     }
     @include breakpoint($bp-med) {
       margin-left: auto;
@@ -131,7 +132,7 @@
   @include breakpoint($bp-med) {
     padding: 0;
     margin-top: $gutter;
-    flex-direction: row-reverse;
+    flex-direction: row;
     .ama__partner-promo__text {
       h2.ama__h2 {
         color: $purple;
@@ -140,24 +141,15 @@
     }
   }
   .ama__partner-promo--media {
-    margin: 0 0 calc($gutter /2) 0;
+    margin: 0;
     padding-left: 0;
     @include breakpoint($bp-med) {
       margin-bottom: 0;
-      max-width: unset;
-      padding-right: 22px;
     }
   }
   .ama__partner-promo__text {
     h2.ama__h2 {
-      color: $purple;
-    }
-  }
-  .ama__button {
-    background: $purple;
-    color: $white;
-    &:hover{
-      background: $hoverPurple;
+      color: $blue;
     }
   }
 }
@@ -184,8 +176,9 @@
   .ama__partner-promo__text {
     display: block;
     padding: 0;
+    flex: 1;
     @include breakpoint($bp-small) {
-      max-width: 380px;
+      flex: .34;
     }
     h2.ama__h2 {
       color: $blue;
@@ -209,7 +202,10 @@
   .ama__partner-promo--media {
     display: block;
     width: 100%;
-    max-width: 680px;
+    flex: 1;
+    @include breakpoint($bp-med) {
+      flex: 66;
+    }
     padding: 0;
     margin: 0;
   }

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -110,7 +110,6 @@
   }
   .ama__partner-promo--media {
     display: block;
-    width: 100%;
     padding: 0;
     margin: 0;
     flex: 1;
@@ -203,8 +202,8 @@
     display: block;
     width: 100%;
     flex: 1;
-    @include breakpoint($bp-med) {
-      flex: 66;
+    @include breakpoint($bp-small) {
+      flex: .66;
     }
     padding: 0;
     margin: 0;

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -131,7 +131,7 @@
   @include breakpoint($bp-med) {
     padding: 0;
     margin-top: $gutter;
-    flex-direction: row;
+    flex-direction: row-reverse;
     .ama__partner-promo__text {
       h2.ama__h2 {
         color: $purple;
@@ -142,14 +142,23 @@
   .ama__partner-promo--media {
     margin: 0;
     padding-left: 0;
+    margin-right: auto;
     @include breakpoint($bp-med) {
       margin-bottom: 0;
+      padding-right: 22px;
     }
   }
   .ama__partner-promo__text {
     h2.ama__h2 {
       color: $blue;
     }
+  }
+  .ama__button {	
+    background: $purple;	
+    color: $white;	
+    &:hover{	
+      background: $hoverPurple;	
+    }	    
   }
 }
 

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -292,7 +292,7 @@
     padding: 0;
     flex: 1;
     @include breakpoint($bp-small) {
-      flex: .375;
+      flex: .34;
     }
   }
   .ama__subscribe-promo--media {
@@ -303,7 +303,7 @@
     margin: 0 0 28px 0;
     @include breakpoint($bp-small) {
       padding-left: calc($gutter * .75);
-      flex: .625;
+      flex: .66;
     }
     @include breakpoint($bp-med) {
       padding-left: calc($gutter * 4.25);

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -314,8 +314,9 @@ a.ama__membership {
       background: none;
       display: block;
       padding: 0;
+      flex: 1;
       @include breakpoint($bp-small) {
-        max-width: 380px;
+        flex: .34;
       }
       @include breakpoint($bp-med) {
         margin-right: 17px;
@@ -377,11 +378,12 @@ a.ama__membership {
     .ama__membership_media-container {
       display: block;
       width: 100%;
-      max-width: 680px;
       padding: 0;
       margin: 0;
+      flex: 1;
       @include breakpoint($bp-small) {
         margin-left: 17px;
+        flex: .66;
       }
       @include breakpoint($bp-med) {
         margin-left: auto;
@@ -412,9 +414,9 @@ a.ama__membership {
   .ama__membership_media-container {
     margin: 0 0 calc($gutter /2) 0;
     padding-left: 0;
+    margin-right: auto;
     @include breakpoint($bp-med) {
       margin-bottom: 0;
-      max-width: unset;
       padding-right: 22px;
     }
   }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-10112: Ticket Title](https://issues.ama-assn.org/browse/EWL-10112)

## Description
Fixed issues with Partner promo block in index hero position and on cat page

- Set flex ratios for text and media containers so they won't collapse if there isn't much text
- changed cta to gold and header to blue
- switched text and image so text is now on left.
- updated same styles for mobile breakpoints


## To Test
- [ ] place a partner promo in a category page and an index page.
- [ ] observe both blocks at all breakpoints and verify that they display the same
- [ ] test with lots of text and a little text. With an image or with a video.

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
