### PR TITLE
EWL-10159: Click to Copy Styling

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_social-share.scss
+++ b/styleguide/source/assets/scss/03-organisms/_social-share.scss
@@ -76,6 +76,11 @@ a.index-page  {
       }
     }
     &.copy {
+      color: $black;
+      background-color: $white;
+      padding-top: 0;
+      padding-bottom: 0;
+      border: none;
       &:before {
         height: 38.5px;
         width: 35.5px;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
[EWL-10159: Share / Copy / Bookmark - click to copy](https://issues.ama-assn.org/browse/EWL-10159)

## Description
Add CSS declarations for copy icon to override default button styling.

## To Test
- Pull branch [feature/EWL-10159-click-to-copy-styling](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-10159-click-to-copy-styling)
- Run `lando gulp serve` from /styleguide directory

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/2d43343f-6d2a-4f50-bee0-ddfc27eb9988)

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
