### PR TITLE
EWL-10203: Fix mobile spacing issue for homepage slim membership block.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -90,9 +90,9 @@ a.ama__membership {
 }
 
 //Slim Membership Block styling
-.layout--ama-page-section-one-col .ama__membership .ama__membership-content {
+.ama__homepage div .layout--ama-page-section-one-col .ama__membership .ama__membership-content {
   background: #ece7f0;
-  margin: 0 0 35px;
+  margin: 0 -21px 35px -21px;
   position: relative;
   padding-bottom: 0;
   @include breakpoint($bp-small min-width) {
@@ -104,6 +104,7 @@ a.ama__membership {
     flex-direction: row;
     flex-wrap: nowrap;
     align-items: center;
+    margin: 0;
   }
 
   // Remove margins on child elements so that we can set consistent spacing elsewhere.
@@ -183,15 +184,12 @@ a.ama__membership {
     }
   }
   .ama__membership_cta_container {
-    margin: 0 auto;
+    margin: 21px auto;
     display: block;
     max-width: 75%;
     text-align: center;
-    position: absolute;
-    bottom: 21px;
-    left: 0;
-    right: 0;
     @include breakpoint($bp-small min-width) {
+      margin: 0 auto;
       -webkit-box-orient: horizontal;
       -webkit-box-direction: normal;
       -ms-flex-direction: row;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10203: Membership promo displaying incorrectly on homepage in mobile](https://issues.ama-assn.org/browse/EWL-10203)

## Description
Adjust styling for the slim homepage membership block to fix display on mobile.


## To Test
- link styleguide locally 
- clear caches
- confirm homepage slim membership promo on mobile matches the following zeplin: https://app.zeplin.io/project/59dd1f9c36a8b21d569bb9e8/screen/5f3fe82b12485e157ba260ab
- confirm tablet and desktop still display as expected
- confirm membership blocks both full width and right rail version still appear as expected on category, subcategory and topic pages

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
<img width="498" alt="Screen Shot 2023-06-20 at 4 23 49 PM" src="https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/67962801/db281d2f-fd88-49bc-8d0c-3d62b0a9657a">



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
