### PR TITLE
ADF-373, Display multi address

### DIFF
--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.json
@@ -6,7 +6,7 @@
     "data": {
       "name": "Henry Jackson, MD",
       "pronouns": "(He\/Him\/His)",
-      "address": "330 N.Wabash Ave <br/> Chicago,IL 60611",
+      "address": ["330 N.Wabash Ave <br/> Chicago,IL 60611"],
       "phoneNumber": "(312) 922-3815",
       "specialty": "Cardiology",
       "url": "<a href=\"#\">https://www.nm.org/doctors</a>"

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -38,7 +38,16 @@
       <div class="dr-finder-profile-header__doctor-info__pronouns">{{ drFinderProfileHeader.data.pronouns|raw }}</div>
     {% endif %}
     {% if drFinderProfileHeader.data.address %}
-      <div class="dr-finder-profile-header__doctor-info__address">{{ drFinderProfileHeader.data.address|raw }}</div>
+      {% set isMulti = drFinderProfileHeader.data.address|length > 1 %}
+      {% if drFinderProfileHeader.data.phoneNumber and isMulti %}
+        <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
+      {% endif %}
+      {% for item in drFinderProfileHeader.data.address %}
+        <div class="dr-finder-profile-header__doctor-info__address {{ isMulti ? 'multiadress'  : '' }}">{{ item|raw }}</div>
+      {% endfor %}
+      {% if drFinderProfileHeader.data.phoneNumber and not isMulti %}
+        <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
+      {% endif %}
     {% endif %}
     {% if drFinderProfileHeader.data.phoneNumber %}
       <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>

--- a/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-clam.json
+++ b/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-clam.json
@@ -145,7 +145,7 @@
     "service": "",
     "data": {
       "name": "Henry Jackson, MD",
-      "address": "330 N.Wabash Ave <br/> Chicago,IL 60611",
+      "address": ["330 N.Wabash Ave <br/> Chicago,IL 60611"],
       "phoneNumber": "(312) 922-3815",
       "specialty": "Cardiology"
     },

--- a/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-complete.json
+++ b/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-complete.json
@@ -120,7 +120,7 @@
     "data": {
       "name": "Henry Jackson, MD",
       "pronouns": "(He\/Him\/His)",
-      "address": "330 N.Wabash Ave <br/> Chicago,IL 60611",
+      "address": ["330 N.Wabash Ave <br/> Chicago,IL 60611", "330 N.Wabash Ave <br/> Chicago,IL 60611"],
       "phoneNumber": "(312) 922-3815",
       "specialty": "Cardiology",
       "url": "<a href=\"#\">https://www.nm.org/doctors</a>"

--- a/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-edit.json
+++ b/styleguide/source/_patterns/05-pages/dr-finder/dr-finder-with-profile-edit.json
@@ -121,7 +121,7 @@
     "data": {
       "name": "Henry Jackson, MD",
       "pronouns": "(He\/Him\/His)",
-      "address": "330 N.Wabash Ave <br/> Chicago,IL 60611",
+      "address": ["330 N.Wabash Ave <br/> Chicago,IL 60611"],
       "phoneNumber": "(312) 922-3815",
       "specialty": "Cardiology",
       "url": "<a href=\"#\">https://www.nm.org/doctors</a>"

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -111,3 +111,15 @@
     max-height: inherit;
   }
 }
+
+.dr-finder-profile-header__doctor-info__address {
+
+  &.multiadress {
+    border-bottom: solid 1px $gray-30;
+    padding: .5em 0;
+
+    @include breakpoint($bp-small) {
+      max-width: 275px;
+    }
+  }
+}


### PR DESCRIPTION
**Jira Ticket**
- [ADF-373: Display of multiple addresses on profile pages](https://palantir.atlassian.net/browse/ADF-373)

## Description
Adding option to display multiple addresses on profile pages keeping the ability to display just one.


## To Test
- [x] Checkout this branch `git fetch -a` and `git checkout ADF-373`
- [x] Set up you local environment https://github.com/AmericanMedicalAssociation/ama-style-guide-2#style-guide-developers---to-begin-working
- [x] To se a single address visit http://localhost:3000/?p=pages-dr-finder-with-search-results and http://localhost:3000/?p=pages-dr-finder-with-profile-clam
- [x] To see multiple addresses visit http://localhost:3000/?p=pages-dr-finder-with-profile-complete 

