### PR TITLE
EWL-10132: Suppress Mobile Simplecast Image Display

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
+++ b/styleguide/source/assets/scss/02-molecules/_podcast_player.scss
@@ -32,11 +32,12 @@
   }
 
   img.ama__image {
-    display: block;
+    display: none;
     height: 230px;
     width: 230px;
     margin: 0 auto 14px;
     @include breakpoint($bp-small) {
+      display: block;
       height: 144px;
       width: 144px;
       margin: 0 24px 0 0;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-100132: Suppress display of Simplecast image on mobile article template](https://issues.ama-assn.org/browse/EWL-10132)

## Description:
Remove display of the image associated with the Simplecast player from article pages at the mobile breakpoint (600px or less).

## To Test:

**Setup**
- Pull branch [EWL-10132-suppress-mobile-simplecast-image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/EWL-10132-suppress-mobile-simplecast-image)
- Serve and link SG
- Go to http://ama-one.lndo.site/delivering-care/public-health/what-doctors-wish-patients-knew-about-shingles-virus
- Verify "Listen to this article" image under "AMA NEWS WIRE" does not display on mobile (600px or less)
- Verify image still displays on tablet/desktop (600 px or more)

## Automated Test:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
