### PR TITLE
EWL-10220: Interaction bar side scroll functionality.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_social-share.scss
+++ b/styleguide/source/assets/scss/03-organisms/_social-share.scss
@@ -122,7 +122,7 @@ a.index-page  {
         }
       }
     }
-    &.share {
+    &.share-icon {
       &:before {
         width: 48px;
         height: 42px;
@@ -245,12 +245,52 @@ a.index-page  {
   position: relative;
   .share-row {
     .share {
-      display: flex;
+      display: inline;
       margin-left: auto;
+
+      &.is-sticky {
+        .share-wrapper {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          align-items: center;
+          top: 0;
+          left: 0;
+          position: absolute;
+          margin-top: 250px;
+          width: 50px !important;
+        }
+      }
       .share-wrapper {
         border-bottom: 0;
         padding-top: 0;
         padding-bottom: 0;
+        &.share-wrapper--fixed {
+          top: 0;
+          left: 0;
+          position: absolute;
+          margin-top: 250px;
+          .icon, 
+          .bookmark,
+          .icon.share-icon {
+            margin: 0 0 15px 0;
+            width: 30px;
+            height: 30px;
+            padding-left: 0;
+          }
+          .icon.share-icon:before {
+            width: 40px;
+          }
+          .icon.copy {
+            margin-right: 0;
+            margin-top: 0;
+          }
+          .icon a.print {
+            margin-left: 5px;
+            width: 30px;
+            height: 30px;
+          }
+        }
         @include breakpoint($bp-small max-width) {
           display: flex;
           position: fixed;
@@ -280,7 +320,7 @@ a.index-page  {
             outline: 0;
           }
 
-          &.share {
+          &.share-icon {
             padding-left: 40px;
             margin-left: 21px;
             @include breakpoint($bp-small max-width) {
@@ -307,7 +347,7 @@ a.index-page  {
             margin-top: 3px;
           }
 
-          &.share,
+          &.share-icon,
           &.copy {
             &:focus {
               outline: 2px solid $tab-focus-blue;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

## JIRA Ticket(s)
- [EWL-10220: User Interaction Bar functionality - add side scroll ability](https://issues.ama-assn.org/browse/EWL-10220)


## Description:
Added a script to set the interaction bar icons to the left of the article page when scrolling on desktop and tablet.

**NOTE**: Main functionality can be found in modules/custom/ama_modal/js/share-bar.js starting on line 91. There are comments outlining whats happening. This essentially dupes the functionality from the social icon but adapts it to the new markup in the interaction bar.

## To Test:
- checkout ama-d8 pr locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4149
- clear caches
- navigate to any article pages
- on desktop, scroll page and confirm icons attach to left side of screen and follow along while scrolling (same as social icons on index and other non-article pages)
- repeat for tablet
- confirm on mobile this does not happen and icon bar appears as designed for mobile (attached to bottom of screen)

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
