### PR TITLE
EWL-10194: Remove Event Header Top Border

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -204,7 +204,6 @@
     align-content: stretch;
     align-items: flex-start;
     color: $gray-64;
-    border-top: solid .5px $black;
     border-bottom: solid .5px $black;
     @include breakpoint($bp-med min-width) {
       flex-direction: row;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10194: Article as Event Headers](https://issues.ama-assn.org/browse/EWL-10194)

## Description:
Remove top border of event header to prevent conflict with article header bottom border.

## To Test:

**Setup**
- Pull branch [feature/EWL-10194-remove-event-header-top-border](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-10194-remove-event-header-top-border)
- Serve and link SG
- Go to any article page and edit the article to show the event header (refer to [Original PR](https://github.com/AmericanMedicalAssociation/ama-d8/pull/4129) for instructions)
- Verify only one border is shown between article header and event header

## Automated Test:
N/A

## Relevant Screenshots/GIFs:
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/bf2f39d8-6940-49eb-ad5a-2a753d3aaa1e)

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
