### PR TITLE
EWL-10133: remove purple border and top padding from article body.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -156,10 +156,6 @@
         border-top: none;
         padding-top: 0;
         margin-top: 0;
-        @include breakpoint($bp-small) {
-          border-top: 8px solid $purple;
-          padding-top: calc($gutter / 2);
-        }
       }
 
       &.border-none {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-10133: Ticket Title](https://issues.ama-assn.org/browse/EWL-10133)

## Description
remove padding and thick purple top border from article body


## To Test
- [ ] pull and serve
- [ ] verify that top border is gone

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
