### PR TITLE
EWL-10195: reduced event size when there is no image. Commented out clickable ad…

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -277,7 +277,7 @@
         min-width: 100%;
         flex: 1;
         &:hover {
-          background-color: $hoverPurple;
+          //background-color: $hoverPurple;
         }
         @include breakpoint($bp-small) {
           min-width: 280px;
@@ -334,11 +334,11 @@
           background-image: url("../icons/svg/event-header-icons/LocateOnGoogleMapsIcon.svg");
         }
         &:hover::before {
-          background-image: url("../icons/svg/event-header-icons/LocateOnGoogleMapsIconHover.svg");
+          //background-image: url("../icons/svg/event-header-icons/LocateOnGoogleMapsIconHover.svg");
         }
         &:hover {
-          text-decoration: underline;
-          cursor: pointer;
+          //text-decoration: underline;
+          //cursor: pointer;
         }
       }
     }
@@ -346,6 +346,9 @@
       .article-event-details {
         flex: 1;
         padding-left: 0;
+        @include breakpoint($bp-small) {
+          flex: .8;
+        }
       }
       .article-event-info-wrapper {
         @include breakpoint($bp-small) {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-10195: Ticket Title](https://issues.ama-assn.org/browse/EWL-10195)

## Description
reduced width of event header when there is no image
commented out clickable address styling.


## To Test
- [ ] pull and serve
- [ ] verify that the display matches the zeplin https://app.zeplin.io/project/6455149a09779f23db97e23e/screen/6477a5d669b6101cbec5ce8f

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
