### PR TITLE
EWL-10236: Fixes display of membership promos

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -5,6 +5,13 @@
   display: flex;
   flex-direction: column;
 
+  .membership-content {
+    display: flex;
+    flex: auto;
+    margin-top: 0;
+    align-items: center;
+  }
+
   &.bottom-margin {
     @include gutter($margin-bottom-full...);
   }

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -5,13 +5,6 @@
   display: flex;
   flex-direction: column;
 
-  .membership-content {
-    display: flex;
-    flex: auto;
-    margin-top: 0;
-    align-items: center;
-  }
-
   &.bottom-margin {
     @include gutter($margin-bottom-full...);
   }
@@ -113,6 +106,13 @@ a.ama__membership {
     flex-wrap: nowrap;
     align-items: center;
     margin: 0;
+  }
+
+  .membership-content {
+    display: flex;
+    flex: auto;
+    margin-top: 0;
+    align-items: center;
   }
 
   // Remove margins on child elements so that we can set consistent spacing elsewhere.


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-10236: Ticket Title](https://issues.ama-assn.org/browse/EWL-10236)

## Description
Fixes display of membership promos


## To Test
- [ ] Pull this branch and develop on d8
- [ ] Serve local SG
- [ ] Go to a subcategory page(http://ama-one.lndo.site/delivering-care/public-health) and the homepage(http://ama-one.lndo.site/)
- [ ] Verify the display of the member promos are correct
- [ ] Add a member promo to a news article and verify the display is correct.

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
