### PR TITLE
EWL-10214: Locker UI Mobile Issue

### DIFF
--- a/styleguide/source/assets/js/locker-menu.js
+++ b/styleguide/source/assets/js/locker-menu.js
@@ -16,24 +16,28 @@
         function lockerMenu() {
             // Open menu on trigger click.
             $trigger.once('click-to-show').on('click', function (e) {
-                $menu.toggleClass('hidden');
+                $menu.addClass('expanded');
                 $catcher.toggleClass('hidden');
                 $body.css({"overflow":"hidden"});
             });
             // Close menu on background click.
             $catcher.once('click-to-hide').on('click', function () {
                 $catcher.toggleClass('hidden');
-                $menu.toggleClass('hidden');
+                $menu.removeClass('expanded');
                 $body.css({"overflow":"auto"});
             });
             // Update sticky state on window resize.
             $window.resize(function(){
                 if($window.width() < 600) {
-                    $menu.unstick().addClass('hidden');
+                    if($menu.hasClass('expanded')) {
+                        $menu.removeClass('expanded');
+                    }
+                    $menu.unstick();
                     $trigger.sticky({zIndex: 501, topSpacing: 62});
                 } else {
+                    $menu.removeClass('expanded');
                     $trigger.unstick();
-                    $menu.sticky({zIndex: 501, topSpacing: 60}).removeClass('hidden');
+                    $menu.sticky({zIndex: 501, topSpacing: 60});
                 }
             });
         }
@@ -46,7 +50,7 @@
                 $('.ama_locker_navigation').unstick();
             return;
             } else if($window.width() < 600) {
-                $menu.unstick().addClass('hidden');
+                $menu.unstick();
                 $trigger.sticky({zIndex: 501, topSpacing: 62});
             } else if($('.toolbar-tray').hasClass('toolbar-tray-horizontal')) {
                 $menu.sticky({ zIndex: 501, topSpacing: 132 });

--- a/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
@@ -1,15 +1,12 @@
 // Flag/bookmark styling
 .ama_locker_navigation {
-  display: flex;
+  display: none;
   flex-direction: column-reverse;
   align-items: flex-end;
   justify-content: flex-end;
   position: fixed;
-  &.hidden {
-    display: none;
-  }
-  @include breakpoint($bp-small max-width) {
-    //display: none;
+  &.expanded {
+    display: flex;
     top: 0;
     right: 0;
     z-index: 999;
@@ -17,6 +14,7 @@
     border: 0.5px solid $black;
   }
   @include breakpoint($bp-small) {
+    display: flex;
     flex-direction: row;
     position: relative;
     padding-right: 12px;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10214: Article Header | Locker UI Changes](https://issues.ama-assn.org/browse/EWL-10214)

## Description:
On mobile devices, a bug was reported that when the page is loading, the popup menu of the Locker UI displays briefly before reverting to the kebab (three horizontal dots).  The popup menu should be suppressed until the user click on the three dots.

## To Test:

**Setup**
- Pull branch [EWL-10214-fix-mobile-popup-issue](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/EWL-10214-fix-mobile-popup-issue)
- Serve and link SG
- Visit any page that contains the locker navigation on a mobile device
- Verify that the popup menu does not show on page load or page refresh until the kebab is clicked

## Automated Test:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
