### PR TITLE
EWL-10354: Adjust icon sizing and hover in locker icons.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_locker-navigation.scss
@@ -106,13 +106,15 @@
       padding-bottom: 5px;
       &::before {
         width: 24px;
-        height: 20px;
+        height: 22px;
         margin-right: 6px;
         background-image: url('../icons/svg/locker-menu-icons/icon-locker-subscriptions.svg');
       }
       &:hover {
         &::before {
           background-image: url('../icons/svg/locker-menu-icons/icon-locker-subscriptions-hover.svg');
+          background-position: -4px -4px;
+          background-size: initial;
         }
       }
       @include breakpoint($bp-small) {
@@ -129,6 +131,8 @@
       &:hover {
         &::before {
           background-image: url('../icons/svg/locker-menu-icons/icon-locker-topics-hover.svg');
+          background-position: -5px -5px;
+          background-size: initial;
         }
       }
       @include breakpoint($bp-small) {
@@ -145,6 +149,8 @@
       &:hover {
         &::before {
           background-image: url('../icons/svg/locker-menu-icons/icon-locker-bookmarks-hover.svg');
+          background-position: -4px -4px;
+          background-size: initial;
         }
       }
       @include breakpoint($bp-small) {


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10354: Locker UI: Hover state icons much smaller, different than the new icons](https://issues.ama-assn.org/browse/EWL-10354)

- [EWL-10353: Locker UI: subscriptions icon getting cut off at bottom](https://issues.ama-assn.org/browse/EWL-10353)


## Description
Adjust styling on locker icons to fix display on hover, adjust bookmark icon sizing to prevent icon cutting off. **NOTE** this PR covers the work for both tickets listed above.


## To Test
- link styleguide locally
- on any article page confirm bookmark icon does not cut off at bottom
- on hover confirm hover icon appears same size as inactive icon

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
