### PR TITLE
EWL-10245: display 3-up blockat 75% width

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -457,7 +457,7 @@
           padding-right: 0;
           border-right: none;
           @include breakpoint($bp-med) {
-            width: 25%;
+            width: 27.3%;
             padding-right: 2.1%;
             border-right: 1px solid $border-gray;
           }

--- a/styleguide/source/assets/scss/02-molecules/_article-stub.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-stub.scss
@@ -448,6 +448,21 @@
     .grid-container {
       margin-top: 0;
       margin-bottom: 0;
+      &[data-count="3"] {
+        width: 100%;
+        @include breakpoint($bp-med) {
+          width: 75%;
+        }
+        .ama__article-stub.ama__article-stub--category:last-child {
+          padding-right: 0;
+          border-right: none;
+          @include breakpoint($bp-med) {
+            width: 25%;
+            padding-right: 2.1%;
+            border-right: 1px solid $border-gray;
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
**Jira Ticket**
- [EWL-10245: Ticket Title](https://issues.ama-assn.org/browse/EWL-10245)

## Description
If there are 3 articles in an article stub list on the article or press release pages, the block should display 75% width.


## To Test
- [ ] pull and serve
- [ ] go to an article and press release. Verify that 3-up article stub lists display at 75% width and 4-up display 100% width.
- [ ] Verify that breakpoints are correct and match the breakpoints of the subcat block

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
