### PR TITLE
EWL-10170: Update search page form to fix tab order

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_search-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-header.scss
@@ -17,7 +17,6 @@
   &__results-num {
     white-space: nowrap;
     text-align: center;
-    order: 2;
     flex: 1;
 
     @include breakpoint($bp-small) {
@@ -41,7 +40,6 @@
   &__options,
   .form-item.js-form-item-sort-by {
     margin: 0;
-    order: 4;
 
     .ama__form-group {
       margin: 0;
@@ -69,7 +67,6 @@
 
     @include breakpoint($bp-small) {
       @include gutter($margin-left-full...);
-      order: 4;
     }
 
     label {
@@ -86,7 +83,6 @@
       position: relative;
       top: 0;
       right: 0;
-      order: 2;
     }
   }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10170: Keyboard focus order is not logical](https://issues.ama-assn.org/browse/EWL-10170)

## Description
Add form to update element positioning of on page search form in order to fix tab order.


## To Test
- checkout ama-d8 PR locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4257
- link styleguide PR
- clear caches
- navigate to search page, confirm styling and functionality of on page search form still works as expected
- click into search input, confirm tabbing highlights the search icon, confirm tabbing again focuses on the sort by dropdown

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
