### PR TITLE
EWL-10355: My Bookmark Index Read Time Spacing Issue

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-result.scss
@@ -63,10 +63,11 @@
     font-size: 14px;
     font-weight: $font-weight-bold;
     color: $gray-50;
-    padding-left: 1px;
-    padding-right: 1px;
+    padding-left: 4px;
+    padding-right: 4px;
     position: relative;
     bottom: 0px;
+    margin-left: -4px;
   }
   .read_time {
     font-weight: $font-weight-regular;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10355: Space between dot and read time on My Bookmark index removed/too close together](https://issues.ama-assn.org/browse/EWL-10355)

## Description:
ISSUE: The space between the dot and the read time on My Bookmarks index has been removed.

SOLUTION: Added negative left margin to remove spacing between inline blocks and adjusted padding to provide more space before and after dot.

## To Test:

**Setup**
- Pull branch [bugfix/EWL-10355-my-bookmark-index-spacing-issue](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-10355-my-bookmark-index-spacing-issue)
- Serve and link SG
- Go http://ama-one.lndo.site and login as authenticated user
- Go to http://ama-one.lndo.site/my-bookmarks
- Verify spacing between dot and read time on index entries
  - Dot not butted up against read time
  - Dot centered between date and read time

Zepelin: https://zpl.io/xmynXOk

## Automated Test:
N/A

## Relevant Screenshots/GIFs:

### **BEFORE**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/3e3141c4-5f1a-4bad-bd5b-f512bcd23675)

### **AFTER**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/813a09ed-bd16-449e-ab04-fda5aee73334)

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
