### PR TITLE
EWL-10386: Fix overlap of hub page header banner.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -196,6 +196,12 @@
 }
 
 .ama__hub {
+  .sticky-wrapper {
+    height: 96px !important;
+    @include breakpoint($bp-med) {
+      height: 117px !important;
+    }
+  }
   .ama__main-navigation {
     background: $white;
     border-bottom: none;

--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -1,5 +1,18 @@
 .ama__hub,
 .hub-container {
+  // Offset for hub hero row
+  .ama__hub-hero-row {
+    margin-top: 20px;
+    @include breakpoint($bp-med) {
+      margin-top: 56px;
+    }
+  }
+  &.toolbar-icon-9 .ama__hub-hero-row {
+    margin-top: 34px;
+    @include breakpoint($bp-large) {
+      margin-top: 56px;
+    }
+  }
   // Offset for sticky banner
   .ama__footer.has_banner {
     margin-top: 0;

--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -1,18 +1,5 @@
 .ama__hub,
 .hub-container {
-  // Offset for hub hero row
-  .ama__hub-hero-row {
-    margin-top: 20px;
-    @include breakpoint($bp-med) {
-      margin-top: 56px;
-    }
-  }
-  &.toolbar-icon-9 .ama__hub-hero-row {
-    margin-top: 34px;
-    @include breakpoint($bp-large) {
-      margin-top: 56px;
-    }
-  }
   // Offset for sticky banner
   .ama__footer.has_banner {
     margin-top: 0;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10386: Minimal Hub Page Header](https://issues.ama-assn.org/browse/EWL-10386)

## Description
Add styling to account for minimal header with and without admin bar to prevent overlap with hub page hero.


## To Test
- link styleguide locally
- clear caches
- on any hubpage add a hub page banner, confirm while at top of page that header does not overlap hub page hero
- confirm no overlap while logged in as admin, editor etc.
- confirm no overlap on both tablet and mobile

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
