### PR TITLE
EWL-10397: updating hub page hero to be able to be placed in the paragraph column

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-hero.scss
@@ -1,3 +1,8 @@
+.hub-page {
+  .ama__hub-hero {
+    margin-bottom: calc($gutter * .5);
+  }
+}
 .ama__hub-hero {
   width: 100%;
   min-height: 400px;

--- a/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
@@ -1,5 +1,36 @@
+//  We need the container for the hero block. Keep it from getting double padding when placed in another container.
+.container {
+  .background-wrapper {
+    width: calc(99.9vw - 17px);
+    margin-left: calc(((100% - 100vw) / 2) + 8px);
+    @include breakpoint($bp-med) {
+      width: calc(99.9vw - 15px);
+      margin-left: calc(((100% - 100vw) / 2) + 7px);
+    }
+    .hub-page-hero {
+      padding: calc($gutter * .5) 15px calc($gutter * 1.25);
+      @include breakpoint($bp-small) {
+        padding: calc($gutter * 1.25) 15px calc($gutter * .75);
+      }
+      @include breakpoint($bp-med) {
+        padding: calc($gutter * 1.25) 14px calc($gutter * 1.25) 17px;
+      }
+    }
+  }
+  .hub-page-mobile {
+    &.media {
+      max-width: unset;
+      margin: 0 -15px;
+    }
+  }
+  .cta-container-mobile {
+    padding: calc($gutter * .5) 0px;
+    margin: calc($gutter * .5) 0px;
+  }
+}
 .background-wrapper {
   color: $black;
+  margin-bottom: calc($gutter * .5);
   a {
     color: $black;
     text-decoration: none;
@@ -157,6 +188,9 @@
     @include breakpoint($bp-small) {
       display: none;
     }
+    img {
+      margin-bottom: -7px;
+    }
   }
 }
 
@@ -164,8 +198,8 @@
 .cta-container-mobile {
   display: flex;
   flex-direction: column;
-  padding: calc($gutter * .5) 15px;
-  margin: calc($gutter * .5) 0;
+  padding: calc($gutter * .5) 0;
+  margin: calc($gutter * .5) 15px;
   border-top: 1px solid $purple;
   border-bottom: 1px solid $purple;
   @include breakpoint($bp-small) {

--- a/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
@@ -57,6 +57,43 @@
     padding: calc($gutter * 1.25) 15px;
   }
 
+  h1,
+  h2,
+  h3 {
+    &.hub_hero_heading {
+      margin-bottom: calc($gutter * .5);
+      &.large {
+        font-size: 28px;
+      }
+      &.medium {
+        font-size: 22px;
+      }
+      &.small {
+        font-size: 20px;
+      }
+      @include breakpoint($bp-med) {
+        &.large {
+          font-size: 48px;
+        }
+        &.medium {
+          font-size: 38px;
+        }
+        &.small {
+          font-size: 26px;
+        }
+      }
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+  .heading {
+    h1 {
+      &.hub_hero_heading {
+        margin-bottom: 0;
+      }
+    }
+  }
   //  If the block has media, it becomes a 60/40 block.
   &.has-media {
     .heading {
@@ -105,18 +142,12 @@
     flex: 1;
     width: 100%;
     display: block;
-    padding-bottom: 0;
+    padding-bottom: calc($gutter * .5);
     @include breakpoint($bp-small) {
       padding-bottom: calc($gutter * 1.25);
     }
     @include breakpoint($bp-med) {
       padding-bottom: calc($gutter * .75);
-    }
-    p {
-      margin-bottom : 0;
-    }
-    h1 {
-      margin-bottom : 0;
     }
   }
   .body {


### PR DESCRIPTION
**Jira Ticket**
- [EWL-10397: Ticket Title](https://issues.ama-assn.org/browse/EWL-10397)

## Description
If you add an old hero paragraph, or a new hub hero paragraph to the hub page body, if it is purple, it should display full width.
On mobile, the buttons should have 15px margins, the media and text are edge to edge
There is a 14px gap between each block when placed together.


## To Test
- [ ] pull and serve
- [ ] see further directions in SG PR https://github.com/AmericanMedicalAssociation/ama-d8/pull/4302

## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
