### PR TITLE
EWL-10329: Hub page sticky banner fixes.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -3,6 +3,10 @@
   // Offset for sticky banner
   .ama__footer.has_banner {
     margin-top: 0;
+    margin-bottom: 175px;
+    @include breakpoint($bp-med) {
+      margin-bottom: 110px;
+    }
   }
   .ama__hub-banner {
     background: $purple;
@@ -11,7 +15,7 @@
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    position: sticky;
+    position: fixed;
     bottom: 0;
     width: 100%;
     z-index: 1;
@@ -39,7 +43,7 @@
           margin-bottom: 0;
         }
       }
-      &:last-of-type {
+      &:nth-child(2) {
         background: $white;
       }
       &:hover,


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10329: Hub Page | Sticky Banner Bottom of Screen](https://issues.ama-assn.org/browse/EWL-10329)

## Description
Adjust placement of sticky banner to rest below footer after scroll. Fix treatment of CTA when only one is used.


## To Test
- link styleguide locally
- clear caches
- add a hub banner to a hub page
- confirm the banner is fixed to the bottom of the screen and after scrolling the length of the page, the banner rests below the footer
- edit current banner to only have one CTA link
- confirm single CTA appears with gold/yellow background

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
![Screenshot 2023-09-22 at 12 43 13 PM](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/67962801/14518226-238c-4213-abaa-02a8b149db04)
![Screenshot 2023-09-22 at 12 43 56 PM](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/67962801/87246449-e620-482d-b1a9-afeb1b70da28)



## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
