### PR TITLE
EWL-10395: Hub Page Hero Bullet Spacing Fix

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
@@ -163,7 +163,11 @@
       }
       display: flex;
       flex-direction: column;
-
+      .subheading {
+        ul {
+          margin-left: 18px;
+        }
+      }
       //  This CTA container is hidden on Mobile.
       .cta-container {
         padding-top: calc($gutter * 1.75);


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10395: Hub Page Hero: New WYSIWYGs](https://issues.ama-assn.org/browse/EWL-10395)

## Description:
ISSUE: List bullets in the Subheading field are outside the margins when the page is viewed.

SOLUTION: Add left margin to align bullets as intended.

## To Test:

**Setup**
- Pull branch [bugfix/EWL-10395-Hub-Page-Hero-Bullet-Spacing](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-10395-Hub-Page-Hero-Bullet-Spacing)
- Serve and link SG
- Go http://ama-one.lndo.site and login as authenticated user
- Create a Hub Page Hero block (or use existing) with a bullet list in the Subheading field.
- Add the block to a Hub Page (or use existing page with existing block)
- Verify the bullets are aligned properly with the heading (see screenshot) when the page is displayed.

## Automated Test:
N/A

## Relevant Screenshots/GIFs:
**BEFORE**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/eaf41262-d5fc-48aa-9ec0-afec7f54cab1)

**AFTER**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/500b1ac7-95b4-4a8f-bbca-c5f95122f8b1)

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
