### PR TITLE
EWL-10393: Set offset for hub page sticky banner.

### DIFF
--- a/styleguide/source/assets/js/hub-banner.js
+++ b/styleguide/source/assets/js/hub-banner.js
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Adds offset to footer to account for sticky hub banner.
+ *
+ * JavaScript should be made compatible with libraries other than jQuery by
+ * wrapping it with an "anonymous closure". See:
+ * - https://drupal.org/node/1446420
+ * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
+ */
+(function ($, Drupal) {
+  Drupal.behaviors.hubBanner = {
+    attach: function(context, settings) {
+
+      $(function() {
+        if ($('.ama__footer.has_banner').length) {
+          function setbannerOffset() {
+            // get hub banner height, minus one to account for white space below footer
+            var hubBanner = $('.ama__hub-banner').outerHeight() - 1;
+
+            // take height and set as margin-bottom on footer
+            $('.ama__footer.has_banner').css('margin-bottom', hubBanner + 'px');
+          }
+
+          // on load, set offset
+          setbannerOffset();
+
+          // on resize, recalculate
+          $(window).resize(function() {
+            setbannerOffset();
+          });
+        }
+      });
+    }
+  };
+})(jQuery, Drupal);

--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -3,10 +3,6 @@
   // Offset for sticky banner
   .ama__footer.has_banner {
     margin-top: 0;
-    margin-bottom: 175px;
-    @include breakpoint($bp-med) {
-      margin-bottom: 110px;
-    }
   }
   .ama__hub-banner {
     background: $purple;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

## JIRA Ticket(s)
- [EWL-10392: Sticky banner fix](https://issues.ama-assn.org/browse/EWL-10392)

## Description:
Adds script to dynamically set offset on footer when a hub page sticky banner is present.

## To Test:
- amd-d8 PR: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4312
- link styleguide locally
- clear caches
- confirm js file (js/hub-banner.js) is loaded into the dom
- on hub page with sticky hub banner, confirm on scroll banner ends below footer with no white space showing and no links being clipped

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
