### PR TITLE
EWL-10297: Make buttons not bold. Underline ctas in sticky banner

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
@@ -189,6 +189,7 @@
         }
         .ama__button {
           color: $purple;
+          font-weight: $font-weight-regular;
           flex: .4;
           @include breakpoint($bp-large) {
             flex: .3;
@@ -256,6 +257,7 @@
     flex: 1;
     width: 100%;
     margin-top: calc($gutter * .5);
+    font-weight: $font-weight-regular;
     &:hover {
       color: $gray-64;
       border-color: $hoverComplementary;

--- a/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
@@ -114,11 +114,15 @@
           flex: .6;
         }
         .cta-container {
+          display:none;
+          @include breakpoint($bp-med) {
+            display: flex;
+          }
           .ama__button {
             max-width: 291px;
             flex: .5;
             @include breakpoint($bp-med) {
-              max-width: 280px;
+              max-width: 325px;
             }
           }
         }
@@ -168,49 +172,49 @@
           margin-left: 18px;
         }
       }
-      //  This CTA container is hidden on Mobile.
-      .cta-container {
-        padding-top: calc($gutter * 1.75);
-        flex-direction: row;
-        display: none;
-        @include breakpoint($bp-small) {
-          display: flex;
-        }
-        @include breakpoint($bp-large) {
-          padding-top: calc($gutter * 2);
-        }
-        &.center {
-          align-items: center;
-          justify-content: center;
-        }
-        &.left {
-          align-items: flex-start;
-          justify-content: left;
-        }
-        .ama__button {
-          color: $purple;
-          font-weight: $font-weight-regular;
-          flex: .4;
-          @include breakpoint($bp-large) {
-            flex: .3;
-          }
-          &:hover {
-            color: $gray-64;
-            border-color: $hoverComplementary;
-            background-color: $hoverComplementary;
-          }
-          &:first-child {
-            margin-right: calc($gutter * .5);
-          }
-          &:last-child {
-            margin-right: 0;
-          }
-          &.ama__button--complementary {
-            color: $black;
-            &:hover {
-              color: $gray-64;
-            }
-          }
+    }
+  }
+  //  This CTA container is hidden on Mobile.
+  .cta-container {
+    padding-top: calc($gutter * 1.75);
+    flex-direction: row;
+    display: none;
+    @include breakpoint($bp-small) {
+      display: flex;
+    }
+    @include breakpoint($bp-large) {
+      padding-top: calc($gutter * 2);
+    }
+    &.center {
+      align-items: center;
+      justify-content: center;
+    }
+    &.left {
+      align-items: flex-start;
+      justify-content: left;
+    }
+    .ama__button {
+      color: $purple;
+      font-weight: $font-weight-regular;
+      flex: .4;
+      @include breakpoint($bp-large) {
+        flex: .3;
+      }
+      &:hover {
+        color: $gray-64;
+        border-color: $hoverComplementary;
+        background-color: $hoverComplementary;
+      }
+      &:first-child {
+        margin-right: calc($gutter * .5);
+      }
+      &:last-child {
+        margin-right: 0;
+      }
+      &.ama__button--complementary {
+        color: $black;
+        &:hover {
+          color: $gray-64;
         }
       }
     }
@@ -229,7 +233,15 @@
     }
   }
 }
-
+.tablet-cta {
+  display: none;
+  @include breakpoint($bp-small) {
+    display: block;
+  }
+  @include breakpoint($bp-med) {
+    display: none;
+  }
+}
 //  Style the CTAs that will only appear on mobile.
 .cta-container-mobile {
   display: flex;

--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -40,6 +40,9 @@
         }
         a.hub_banner_link {
           color: $black;
+          &:hover {
+            text-decoration: underline;
+          }
         }
       }
       &:nth-child(2) {
@@ -58,6 +61,9 @@
         padding: 12px 75px;
         @include breakpoint($bp-med) {
           padding: 12px 85px;
+        }
+        &:hover {
+          text-decoration: underline;
         }
       }
     }


### PR DESCRIPTION
## Description
make font in buttons regular weight
add underling on hover to sticky banner
Added alternate display for tablet view. If there is media, the ctas now expand full width beneath.

## To Test
- see d8 pr https://github.com/AmericanMedicalAssociation/ama-d8/pull/4314
- [ ] inspect code
- [ ] verify that ctas are under text and image on tablet and look correct otherwise


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
