### PR TITLE
EWL-10055: Update membership block image ratio.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -402,13 +402,12 @@ a.ama__membership {
       @include breakpoint($bp-small) {
         margin-left: 17px;
         flex: .66;
+        img {
+          float: right;
+        }
       }
       @include breakpoint($bp-med) {
         margin-left: auto;
-      }
-      img {
-        width: 100%;
-        height: auto;
       }
     }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

## JIRA Ticket(s)
- [EWL-10055: Membership Custom Block | Image Aspect Ratio](https://issues.ama-assn.org/browse/EWL-10055)


## Description:
Adjust image style used within membership custom blocks to set a 3:2 image aspect ratio.


## To Test:
- checkout ama-d8 PR locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4490
- import latest config
- load page with a membership block with image (ex: https://ama-one.lndo.site/education)
- **NOTE** might need to hard reload browser to see updated image
- confirm image ratio is 3:2 (680px x 452px) and matches the following zeplin on desktop: https://app.zeplin.io/project/63bda76d34cc000c4febbb66/screen/63cff72f2f26937a5807be41


## Automated Test:
Add a link to the .feature file and also add to the ticket in the Automated Testing field on the JIRA ticket **OR** note why this can not be tested with behat.


## Relevant Screenshots/GIFs:
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
