### PR TITLE
Fix Dr. Finder once() Implementations

### DIFF
--- a/styleguide/source/assets/js/dr-finder-filter-buttons.js
+++ b/styleguide/source/assets/js/dr-finder-filter-buttons.js
@@ -7,20 +7,20 @@
  * - https://drupal.org/node/1446420
  * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
  */
-(function ($, Drupal) {
+(function ($, Drupal, once) {
 
   Drupal.behaviors.filterResultsDrFinder = {
-    attach: function (context, settings) {
+    attach: function (context) {
       // All Filters button for mobile.
-      $('.dr-finder-filter-buttons__filters-mobile').once().on('click', function (e) {
+      $(once('mobile-filter', '.dr-finder-filter-buttons__filters-mobile', context)).on('click', function (e) {
         e.stopPropagation();
         $('.dr-finder-filter-list').toggleClass('is-active');
       });
       // X button for mobile.
-      $('.dr-finder-filter-list-mobile-heading svg').once().on('click', function (e) {
+      $(once('mobile-close', '.dr-finder-filter-list-mobile-heading svg', context)).on('click', function (e) {
         e.stopPropagation();
         $('.dr-finder-filter-list').toggleClass('is-active');
       });
     }
   };
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/styleguide/source/assets/js/dr-finder-filter-list.js
+++ b/styleguide/source/assets/js/dr-finder-filter-list.js
@@ -7,16 +7,15 @@
  * - https://drupal.org/node/1446420
  * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
  */
-(function ($, Drupal) {
+(function ($, Drupal, once) {
 
   Drupal.behaviors.filterListDrFinder = {
-    attach: function (context, settings) {
+    attach: function (context) {
 
       $('.dr-finder-filter-list .fieldgroup', context).each(function () {
         const class_active = 'is-active';
         const openMenu = $('.fieldset-wrapper');
-
-        $(this).find('.fieldset-legend').once().on('click', function(e) {
+        $(once('filter-legend', '.fieldset-legend', this)).on('click', function(e) {
           e.stopPropagation();
           // Unfocus on the dropdown.
           $(this).blur();
@@ -36,4 +35,4 @@
       });
     }
   };
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)

**Github Issue**
N/A

**Jira Ticket**
N/A

## Description
Fix D10 deprecated once() implementations causing search filters to not function.

![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/4ab3d02a-b6c0-41fc-b7ad-42a53594d041)

## To Test
**Setup**
- Change into the root styleguide directory
- Pull branch [bugfix/fix-drfinder-once-implementations](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/fix-drfinder-once-implementations)
- Serve and link SG
- Go to http://drfinder.lndo.site/
- Open Dev Tools console
- Conduct a search and view console on search results page load
- Verify there are no JS once() related errors

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
N/A

## Remaining Tasks
N/A

## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
