### PR TITLE
EWL-10055: Fix category promo blocks image aspect ratio.

### DIFF
--- a/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-menu-open.twig
+++ b/styleguide/source/_patterns/01-atoms/media/icons/svg/icon-menu-open.twig
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="33px" height="34px" viewBox="0 0 33 34" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Hamburger Icon - Menu Open</title>
+    <g id="Hamburger-Icon---Menu-Open" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <g id="Icons-/-Hamburger-X-Out" transform="translate(1.5, 2)" fill="#FFFFFF" fill-rule="nonzero" stroke="#FFFFFF" stroke-width="2">
+            <path d="M27.3212336,2.30926389e-14 L30,2.67876642 L17.688,14.991 L30.0182065,27.3212336 L27.3394401,30 L26.0000569,28.6606168 L15.009,17.669 L2.67876642,30 L0,27.3212336 L1.33938321,25.9818504 L12.33,14.99 L1.35758969,4.01814963 L0.0182064799,2.67876642 L2.6969729,0 L4.03635611,1.33938321 L15.009,12.312 L25.9818504,1.33938321 L27.3212336,2.30926389e-14 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -86,8 +86,10 @@
     padding: 0;
     flex: 1;
     @include breakpoint($bp-small) {
-      margin-right: calc($gutter * .75);
-      flex: .34;
+      flex: .4;
+    }
+    @include breakpoint($bp-med) {
+      padding-right: 119px;
     }
     h2.ama__h2 {
       color: $blue;
@@ -117,7 +119,7 @@
     flex: 1;
     @include breakpoint($bp-small) {
       margin-left: 17px;
-      flex: .66;
+      flex: .6;
     }
     @include breakpoint($bp-med) {
       margin-left: auto;

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -298,7 +298,10 @@
     padding: 0;
     flex: 1;
     @include breakpoint($bp-small) {
-      flex: .34;
+      flex: .4;
+    }
+    @include breakpoint($bp-med) {
+      padding-right: 119px;
     }
   }
   .ama__subscribe-promo--media {
@@ -308,11 +311,7 @@
     padding: 0;
     margin: 0 0 28px 0;
     @include breakpoint($bp-small) {
-      padding-left: calc($gutter * .75);
-      flex: .66;
-    }
-    @include breakpoint($bp-med) {
-      padding-left: calc($gutter * 4.25);
+      flex: .6;
     }
   }
   .ama__subscribe-promo__subject-title {

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -334,10 +334,14 @@ a.ama__membership {
       padding: 0;
       flex: 1;
       @include breakpoint($bp-small) {
-        flex: .34;
+        flex: .4;
       }
       @include breakpoint($bp-med) {
-        margin-right: 17px;
+        padding-right: 119px;
+      }
+
+      .membership-content {
+        padding-left: 0;
       }
 
       .ama__membership_title_container,
@@ -401,7 +405,7 @@ a.ama__membership {
       flex: 1;
       @include breakpoint($bp-small) {
         margin-left: 17px;
-        flex: .66;
+        flex: .6;
         img {
           float: right;
         }
@@ -415,7 +419,6 @@ a.ama__membership {
 // Index Entry slot styling
 .index-page .index-promo .ama__membership,
 .index-page .no-results .ama__membership {
-  //border-bottom: solid 2px $gray-20;
   @include breakpoint($bp-small max-width) {
     margin: 0;
   }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10055: Membership Custom Block | Image Aspect Ratio](https://issues.ama-assn.org/browse/EWL-10055)

## Description
Adjust display of images on membership, partner and subscribe promos to align images with other page content.


## To Test
- run lando gulp serve
- link styleguide locally
- clear caches
- load example page: http://ama-one.lndo.site/delivering-care
- confirm images for membership, partner and subscribe promos align with category theme blocks (right hand column) as per the following zeplins: https://app.zeplin.io/project/63bda76d34cc000c4febbb66/screen/63bdaaac6377ad0cac611496

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
