### PR TITLE
EWL-10626: Remove Text Underline on Hover

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -161,10 +161,6 @@
     text-decoration: none;
   }
 
-  .thirty-seventy-block a:hover:not(.ama__button) {
-    text-decoration: underline;
-  }
-
   .thirty-seventy-block-embed {
     border-top: 1px solid $gray-7;
     padding-top: $gutter;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Description:
Zeplins did not show text underlines on hover of block elements, but was added to be consistent with other blocks.  Verified with design team and text SHOULD NOT be underlined on hover of block elements.  This PR removes the text-underline CSS.

## To Test:

**Setup**
- Pull branch [feature/EWL-10626-remove-text-underline-on-hover](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-10626-remove-text-underline-on-hover) in the SG directory
- Serve and link local SG
- Go to http://ama-one.lndo.site and login as admin
- Place a 30/70 block in an article or index (category/subcategory) page or the home page
- Verify that the text elements do not show underline on hover.

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
