### PR TITLE
EWL-10626: Remove Bottom Border from Block When Placed in Index Page

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -148,6 +148,13 @@
     }
   }
 
+  .layout.section.ama__category__row .thirty-seventy-block {
+    border-bottom: none;
+    @include breakpoint($bp-med) {
+      padding-bottom: 0;
+    }
+  }
+
   .ama__layout--two-col-right--75-25__top {
     .thirty-seventy-block {
       @include breakpoint($bp-small) {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Description:
When 30/70 block is placed on an Index page (category/subcategory), there is a double bottom border.  The bottom border for the block is not needed.  This PR removes the bottom border when placed on an Index page, but keeps the border for placement on the Home page and Article pages.

## To Test:

**Setup**
- Pull branch [feature/EWL-10626-adjust-block-bottom-border](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-10626-adjust-block-bottom-border) in the SG directory
- Serve and link local SG
- Go to http://ama-one.lndo.site and login as admin
- Place a 30/70 block in an article page, on an Index (category/subcategory) page, and on the home page
- Verify that the there is no double bottom border for the block on the Index page and that the border still shows on the Home page and the Article page.

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:

**BEFORE**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/57899730-b5ce-4aa4-a08d-03491cf9a519)

**AFTER**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/55457cea-ce72-4464-8cd3-770f58899dbb)


## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
