### PR TITLE
EWL-10627: Fix search connector block display on mobile.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
@@ -1,4 +1,8 @@
 .ama-search-connector-container {
+  @include breakpoint($bp-med max-width) {
+    padding-top: calc($gutter/2);
+    border-top: 1px solid $gray-20;
+  }
   a {
     margin-bottom: calc($gutter/2);
     text-decoration: none;
@@ -15,8 +19,9 @@
       width: 49vh;
       height: 190px;
 
-      @include breakpoint(359px max-width) {
-        width: 46vh;
+      @include breakpoint($bp-med max-width) {
+        max-width: 280px;
+        margin-right: 20px;
       }
       @include breakpoint($bp-xs max-width) {
         width: 47vh;
@@ -55,6 +60,10 @@
   }
   .search-connector-header {
     font-family: $myriad-pro;
+
+    @include breakpoint($bp-med max-width) {
+      display: none;
+    }
     @include font-size($p-font-sizes);
     .title {
       text-transform: uppercase;

--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
@@ -1,8 +1,4 @@
 .ama-search-connector-container {
-  display:none;
-  @include breakpoint($bp-med) {
-    display: block;
-  }
   a {
     margin-bottom: calc($gutter/2);
     text-decoration: none;
@@ -91,6 +87,18 @@
         padding-right: 0;
         height: 0;
       }
+    }
+
+    > a:first-of-type {
+      @include breakpoint($bp-med min-width) {
+        display: none !important;
+      }
+    }
+  }
+
+  &.desktop {
+    @include breakpoint($bp-med max-width) {
+      display: none !important;
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

## JIRA Ticket(s)
- [EWL-10627: HOD Search | Move Policy card from Search Connector above facets in left nav on search page](https://issues.ama-assn.org/browse/EWL-10627)


## Description:
Adjust script and styling to display Search Policy block at top of left hand rail on desktop and within horizontal scroll container on mobile.


## To Test:
- checkout and link ama-d8 PR locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4661
- clear caches
- navigate to search page on desktop, confirm Search Policy displays on top of left hand rail and matches the following zeplin: https://app.zeplin.io/project/65b81329412f19edef5818cd/screen/65b813d78630531225afe80b
- on mobile confirm the Search Policy block appears first within the horizontal mobile treatment and matches the following zeplin: https://app.zeplin.io/project/65b81329412f19edef5818cd/screen/65b813d88d855bd8eaf81059

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
