### PR TITLE
adjust margins for article block placement

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -23,7 +23,6 @@
       @include breakpoint($bp-small max-width) {
         margin-top: $gutter;
       }
-      flex-basis: 35%;
       h2 {
         font-size: 2em;
         line-height: 42px;
@@ -111,17 +110,20 @@
     .image-container {
       position: relative;
       overflow: hidden;
-      @include breakpoint($bp-med) {
+      @include breakpoint($bp-small) {
         padding-bottom: 66.67%;
+      }
+      @include breakpoint($bp-small $bp-med) {
+        min-height: 480px;
       }
     }
 
     .image-container img {
-      @include breakpoint($bp-med) {
+      width: 100%;
+      @include breakpoint($bp-small) {
         position: absolute;
         top: 0;
         left: 0;
-        width: 100%;
         height: 100%;
         object-fit: cover;
       }
@@ -168,7 +170,21 @@
     text-decoration: none;
   }
 
+  // Article Embed Styles
   .thirty-seventy-block-embed {
     border-top: 1px solid $gray-7;
     padding-top: $gutter;
+    .thirty-seventy-block {
+      &__aside {
+        @include breakpoint($bp-med) {
+          padding-right: $gutter;
+          max-width: 405px;
+        }
+      }
+      &__background {
+        @include breakpoint($bp-med) {
+          margin-left: 0;
+        }
+      }
+    }
   }

--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -23,6 +23,7 @@
       @include breakpoint($bp-small max-width) {
         margin-top: $gutter;
       }
+      flex-basis: 35%;
       h2 {
         font-size: 2em;
         line-height: 42px;
@@ -176,14 +177,19 @@
     padding-top: $gutter;
     .thirty-seventy-block {
       &__aside {
-        @include breakpoint($bp-med) {
-          padding-right: $gutter;
-          max-width: 405px;
+        &.double-button {
+          @include breakpoint($bp-med) {
+            padding-right: $gutter;
+            max-width: 405px;
+            flex-basis: 60%;
+          }
         }
       }
       &__background {
-        @include breakpoint($bp-med) {
-          margin-left: 0;
+        &.double-button {
+          @include breakpoint($bp-med) {
+            margin-left: 0;
+          }
         }
       }
     }

--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -176,19 +176,19 @@
     border-top: 1px solid $gray-7;
     padding-top: $gutter;
     .thirty-seventy-block {
-      &__aside {
-        &.double-button {
-          @include breakpoint($bp-med) {
-            padding-right: $gutter;
-            max-width: 405px;
-            flex-basis: 60%;
+      &.double-button {
+        .thirty-seventy-block {
+          &__aside {
+            @include breakpoint($bp-med) {
+              padding-right: $gutter;
+              max-width: 405px;
+              flex-basis: 60%;
+            }
           }
-        }
-      }
-      &__background {
-        &.double-button {
-          @include breakpoint($bp-med) {
-            margin-left: 0;
+          &__background {
+            @include breakpoint($bp-med) {
+              margin-left: 0;
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Description:
When 30/70 block is placed on an Article page (embedded into body field), the buttons collapse when the character limit is pushed to 20 due to not enough space on the left side of the block.  This PR adjusts the spacing between the buttons and image in order to allow the character limit.

**BEFORE**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/16063fb7-1bdb-4d94-8942-b22685e523af)

**AFTER**
![article-placement-adjusted-1](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/3581468f-3581-4c86-9f53-33a400140b9b)


## To Test:

**Setup**
- Pull branch [feature/EWL-10626-adjust-margin-article-placement](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-10626-adjust-margin-article-placement) in the SG directory
- Serve and link local SG
- Go to http://ama-one.lndo.site and login as admin
- Place a 30/70 block in an article page


## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:

**BEFORE**

**AFTER**



## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
