### PR TITLE
DCP-195: Fix SERP Search and Filter Button Styling

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field-dr-finder.scss
@@ -43,7 +43,7 @@
   border-radius: 25px;
   align-self: flex-end;
   background-color: $purple;
-  padding: 8px 20px;
+  padding: 13px 20px;
   color: $white;
   font-size: 18px;
   line-height: 1.4;

--- a/styleguide/source/assets/scss/02-molecules/_dr_finder-filter-buttons.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr_finder-filter-buttons.scss
@@ -24,10 +24,14 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    padding: 0 20px 1px 28px;
 
     svg {
       fill: $purple;
       width: 10px;
+      height: 9px;
+      margin-right: 9px;
+      margin-top: 2px;
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[DCP-195: Filter condition buttons on SERP page not displaying as expected](https://issues.ama-assn.org/browse/DCP-195)

## Description:
The search and filter condition buttons on the SERP are not styled per the zeplins.  This PR adjusts the styling to match the zeplins.

Desktop https://zpl.io/mDqwWP3
Mobile https://zpl.io/O0Y4Bp1 (**waiting for business to verify if the filter buttons are supposed to show on mobile**)

## To Test:

**Setup**
- Start up local Dr. Finder environment
- Pull branch [bugfix/DCP-195-fix-filter-button-styling](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/DCP-195-fix-filter-button-styling)
- Serve and link SG
- Go http://drfinder.lndo.site
- Conduct a search that produces results (on local you can search for Name=Park and City/State = Chicago, IL)
- Select an option from one of the three filter dropdowns (Specialty, Member Status, Degree Type) and click view results to filter the SERP
- Verify the styling of the filter condition buttons matches the zeplins
- Verify the search button at the top of the page matches the zeplins

## Automated Test:
N/A

## Relevant Screenshots/GIFs:

### **BEFORE**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/7c1ece2c-15fa-43df-82f9-5d8f0c733b76)

### **AFTER**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/f15a6ecd-e826-43e7-a35c-12393878aa76)

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
