### PR TITLE
EWL-10750: Restore breadcrumbs to articles.

### DIFF
--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -31,8 +31,30 @@
               }
             }
 
-            // jQueryUI selectmenu method
-            $('.ama__select-menu__select').selectmenu();
+          // jQueryUI selectmenu method to initiate custom dropdown menu
+          $('.ama__select-menu__select').selectmenu();
+
+          // Wait for a short delay to ensure the menu is fully loaded and initialized
+          setTimeout(function() {
+            // Set aria-label on selectmenu button
+            var inititalSelectedOptionText = $('.ui-selectmenu-menu').find('div.ui-state-active').text();
+            $('.ui-selectmenu-menu').find('div.ui-state-active').attr('aria-label', 'Sort by ' + inititalSelectedOptionText);
+          }, 100);
+
+          // Set aria-label on selectmenu button when an option is selected
+          $('.ama__select-menu__select').selectmenu({
+            change: function(event, ui) {
+              // Get the text of the currently selected option
+              var selectedOptionText = $(this).find('option:selected').text();
+              
+              // Set the aria-label attribute to the text of the selected option
+              $('.ama__select-menu__select').next('.ui-selectmenu-button').find('.ui-selectmenu-text').attr('aria-label', 'Sorty by ' + selectedOptionText);
+              $('.ui-selectmenu-menu').find('.ui-menu-item div.ui-state-active').attr('aria-label', 'Sort by ' + selectedOptionText);
+            }
+            });
+
+          // Refresh menu to set changes
+          $('.ama__select-menu__select').selectmenu('refresh');
 
             // If focus is on the select menu
             // Only submit after hitting enter


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

## JIRA Ticket(s)
- [EWL-10672: Search results ARIA input fields must have an accessible name](https://issues.ama-assn.org/browse/EWL-10672)


## Description:
Programmatically set aria labels on Search sort by dropdown menu to set more coherent text for screen readers.


## To Test:
- checkout ama-d8 pr: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4721
- run and link styleguide locally
- clear caches
- using a screen reader (tested w/ [chrome vox](https://chromewebstore.google.com/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn?pli=1) on chrome browser) run a search to navigate to search page
- click into on page search form, tab until the sort menu is highlighted
- confirm screen reader reads out "Search by" then the name of the current selection
- **NOTE** after this is read there will be an additional message "[Current Selection], chromebox" this is generated by the Jquery library creating the menu and can not be changed
- using keyboard arrows, switch Sort menu option, confirm screen reader reads "Sort by [Current Selection]"
- confirm you can hit enter and search page updates with selected filter

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
