### PR TITLE
EWL-10779: Update focus states to use focus-visibility for better usa…

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button-base.scss
@@ -13,7 +13,7 @@
   vertical-align: middle;
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     border-color: $purple;
     background-color: $hoverPurple;
     color: $white;
@@ -21,14 +21,14 @@
 }
 
 @mixin button_focus_outline_light {
-  &:focus {
+  &:focus-visible {
     outline: 2px solid $pg-lt-blue;
     outline-offset: 3px;
   }
 }
 
 @mixin button_focus_outline {
-  &:focus {
+  &:focus-visible {
     outline: 2px solid $blue;
     outline-offset: 3px;
   }

--- a/styleguide/source/assets/scss/01-atoms/_site_logo.scss
+++ b/styleguide/source/assets/scss/01-atoms/_site_logo.scss
@@ -1,7 +1,7 @@
 .ama__site-logo {
   height: 45px;
 
-  &:focus {   
+  &:focus-visible {   
     .logo {
       outline: 2px solid $pg-lt-blue;
       outline-offset: 3px;

--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -130,7 +130,7 @@
       background-color: $hoverPurple;
     }
 
-    &:focus {
+    &:focus-visible {
       outline: 2px solid $pg-lt-blue;
       outline-offset: 3px;
     }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -136,7 +136,7 @@
 
   @at-root {
     a:hover#{&},
-    a:focus#{&} {
+    a:focus-visible#{&} {
       background-color: darken($gray-7, 10%);
     }
   }

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-form.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-form.scss
@@ -107,7 +107,7 @@
         &.error {
           background: none;
         }
-        &:focus {
+        &:focus-visible {
           border: 2px solid $tab-focus-blue;
         }
       }
@@ -138,7 +138,7 @@
         padding: 5.5px 14px;
         font-weight: normal;
     
-        &:focus {
+        &:focus-visible {
           outline: 2px solid $tab-focus-blue;
           outline-offset: 3px;
         }

--- a/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_hub_page_hero.scss
@@ -35,7 +35,7 @@
     color: $black;
     text-decoration: none;
     &:hover,
-    &:focus {
+    &:focus-visible {
       text-decoration: underline;
     }
   }
@@ -227,7 +227,7 @@
         flex: .3;
       }
       &:hover,
-      &:focus {
+      &:focus-visible {
         color: $gray-64;
         border-color: $hoverComplementary;
         background-color: $hoverComplementary;
@@ -299,7 +299,7 @@
     margin-top: calc($gutter * .5);
     font-weight: $font-weight-regular;
     &:hover,
-    &:focus {
+    &:focus-visible {
       color: $gray-64;
       border-color: $hoverComplementary;
       background-color: $hoverComplementary;
@@ -307,7 +307,7 @@
     &.ama__button--complementary {
       margin-top:0;
       &:hover,
-      &:focus {
+      &:focus-visible {
         color: $gray-64;
       }
     }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -158,7 +158,7 @@
   .ama__sign-in-dropdown {
     background-color: transparent;
     z-index: 500;
-    &:focus-within {
+    &:focus-visible {
       outline: 2px solid $pg-lt-blue;
       outline-offset: 3px;
     }
@@ -273,7 +273,7 @@
       &:hover {
         text-decoration: underline;
       }
-      &:focus {
+      &:focus-visible {
         outline: 2px solid $pg-lt-blue;
         outline-offset: 3px;
       }

--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -41,7 +41,7 @@
           background: $complementary;
           color: $black;
           &:hover,
-          &:focus {
+          &:focus-visible {
             text-decoration: underline;
           }
         }
@@ -61,7 +61,7 @@
           padding: 12px 85px;
         }
         &:hover,
-        &:focus {
+        &:focus-visible {
           text-decoration: underline;
           color: $gray-64;
           background: $hoverComplementary;


### PR DESCRIPTION
…bility.

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10779: Accessibility - Change focus states](https://issues.ama-assn.org/browse/EWL-10779)

## Description
Adjust focus states to use focus-visible to prevent focus states from appearing when clicking on elements and ensure they only appear when tabbing through elements.


## To Test
- link styleguide locally
- clear caches
- on main navigation confirm all focus states appear as expected while tabbing through content
- repeat for hub pages

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
