### PR TITLE
EWL-10766: Update Contextual Link Hover/Click Highlight Color

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_social-share.scss
+++ b/styleguide/source/assets/scss/03-organisms/_social-share.scss
@@ -271,8 +271,7 @@ a.index-page  {
       display: block;
     }
     &:hover, &:active {
-      background-color: #46166b;
-      opacity: 0.2;
+      background-color: #46166b33;
     }
     &:focus-visible {
       outline: 2px solid #80d4f5;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10766: Article | Add contextual link to mobile sticky share bar(https://issues.ama-assn.org/EWL-10766)

## Description:
Fix hover/click background style for contextual link so text is not hidden.

## To Test:
  **Setup**
- Pull branch [bugfix/EWL-10766-contextual-link-feedback-fix](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-10766-contextual-link-feedback-fix)
- Link and serve SG
- Access https://ama-one.lndo.site and login as administrator
- Create an instance of the Contextual Link Block (or use existing)
- Visit any article page in mobile display
- Verify the hover/click state of the contextual link in the share bar is displayed as per the zeplin (screenshot attached)
  - https://app.zeplin.io/project/6455149a09779f23db97e23e/screen/6605990eac09c86957c0066c

## Automated Test:
N/A

## Relevant Screenshots/GIFs:
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/67a2d36a-69f5-4d2a-823f-808326b57243)

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
