### PR TITLE
Restore Dr. Finder Main Navigation Styles

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -115,6 +115,7 @@
         padding: 2px calc($gutter/2);
       }
     }
+
     a {
       @include button_focus_outline_light;
     }

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -115,7 +115,6 @@
         padding: 2px calc($gutter/2);
       }
     }
-    
     a {
       @include button_focus_outline_light;
     }
@@ -192,6 +191,12 @@
     .ama__main-navigation__join--links {
       flex-grow: 1;
     }
+  }
+
+  &--dr-finder {
+    border-bottom: 1px solid $gray-50;
+    background-color: $purple;
+    color: $white;
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
N/A

## Description:
AMA Main Navigation styles were removed from AMA One in the most recent SG tag, but Dr. Finder is dependent on these styles. This PR restores the styles, but name spaced to Dr. Finder to prevent regression with AMA One. 

## To Test:
  **Setup**
- Pull branch [bugfix/restore-ama-navigation-dependent-styles](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/restore-ama-navigation-dependent-styles)
- Link and serve SG
- Access https://drfinder.lndo.site
- Verify the main navigation displays as expected

## Automated Test:
N/A

## Relevant Screenshots/GIFs:
**Before**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/4fb64a88-e865-48c6-9b10-bab887659574)

**After**
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/112415930/3bd87779-1841-4e20-a30b-16794a4afe01)


## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
