### PR TITLE
DCP-192: Add SEO Canned Text to Physician Pages

### DIFF
--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -3,79 +3,81 @@
   AMA Dr Finder profile header.
 #}
 <div class="dr-finder-profile-header {{ drFinderProfileHeader.verified ? "verified" : "" }} {{ drFinderProfileHeader.member ? "member" : "" }} {{ drFinderProfileHeader.claimed ? "claimed" : "" }}">
-  <div class="dr-finder-profile-header__image-column">
-    <div class="dr-finder-profile-header__image-verified-container">
-      <div class="dr-finder-profile-header__image-url {{ drFinderProfileHeader.imageUrl ? "with-image": "" }}">
-        {% if drFinderProfileHeader.imageUrl %}
-          <img src="{{ drFinderProfileHeader.imageUrl }}" alt="{{ drFinderProfileHeader.data.name }}"/>
-        {% else %}
-          {% if drFinderProfileHeader.avatar %}
-            <img src="{{ drFinderProfileHeader.avatar }}" alt="avatar">
+  <div class="dr-finder-profile-header__details">
+    <div class="dr-finder-profile-header__image-column">
+      <div class="dr-finder-profile-header__image-verified-container">
+        <div class="dr-finder-profile-header__image-url {{ drFinderProfileHeader.imageUrl ? "with-image": "" }}">
+          {% if drFinderProfileHeader.imageUrl %}
+            <img src="{{ drFinderProfileHeader.imageUrl }}" alt="{{ drFinderProfileHeader.data.name }}"/>
+          {% else %}
+            {% if drFinderProfileHeader.avatar %}
+              <img src="{{ drFinderProfileHeader.avatar }}" alt="avatar">
+            {% endif %}
           {% endif %}
-        {% endif %}
-        {% if drFinderProfileHeader.verified %}
-          {% include '@atoms/media/icons/svg/icon-verified.twig' %}
-        {% endif %}
+          {% if drFinderProfileHeader.verified %}
+            {% include '@atoms/media/icons/svg/icon-verified.twig' %}
+          {% endif %}
+        </div>
       </div>
-    </div>
-    {% if drFinderProfileHeader.member %}
-      {% include '@atoms/dr-finder-badge/dr-finder-badge.twig' %}
-    {% endif %}
+      {% if drFinderProfileHeader.member %}
+        {% include '@atoms/dr-finder-badge/dr-finder-badge.twig' %}
+      {% endif %}
 
-    {% if drFinderProfileHeader.edit %}
-      <div class="dr-finder-profile-header__upload-actions">
-        {% for button in drFinderProfileHeader.imageActions %}
-          <div>{% include '@atoms/button/button.twig' with { "button" : button } %}</div>
+      {% if drFinderProfileHeader.edit %}
+        <div class="dr-finder-profile-header__upload-actions">
+          {% for button in drFinderProfileHeader.imageActions %}
+            <div>{% include '@atoms/button/button.twig' with { "button" : button } %}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+    <div class="dr-finder-profile-header__doctor-info">
+      {% if drFinderProfileHeader.data.name %}
+        <h2 class="dr-finder-profile-header__doctor-info__name ama__h2">{{ drFinderProfileHeader.data.name|raw }}</h2>
+      {% endif %}
+      {% if drFinderProfileHeader.data.pronouns %}
+        <div class="dr-finder-profile-header__doctor-info__pronouns">{{ drFinderProfileHeader.data.pronouns|raw }}</div>
+      {% endif %}
+      {% if drFinderProfileHeader.data.phoneNumber %}
+        <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
+      {% endif %}
+      {% if drFinderProfileHeader.data.address %}
+        {% set isMulti = drFinderProfileHeader.data.address|length > 1 %}
+        {% for item in drFinderProfileHeader.data.address %}
+          <div class="dr-finder-profile-header__doctor-info__address {{ isMulti ? 'multiadress'  : '' }}">{{ item|raw }}</div>
         {% endfor %}
-      </div>
-    {% endif %}
-  </div>
-  <div class="dr-finder-profile-header__doctor-info">
-    {% if drFinderProfileHeader.data.name %}
-      <h2 class="dr-finder-profile-header__doctor-info__name ama__h2">{{ drFinderProfileHeader.data.name|raw }}</h2>
-    {% endif %}
-    {% if drFinderProfileHeader.data.pronouns %}
-      <div class="dr-finder-profile-header__doctor-info__pronouns">{{ drFinderProfileHeader.data.pronouns|raw }}</div>
-    {% endif %}
-    {% if drFinderProfileHeader.data.phoneNumber %}
-      <div class="dr-finder-profile-header__doctor-info__phone">{{ drFinderProfileHeader.data.phoneNumber }}</div>
-    {% endif %}
-    {% if drFinderProfileHeader.data.address %}
-      {% set isMulti = drFinderProfileHeader.data.address|length > 1 %}
-      {% for item in drFinderProfileHeader.data.address %}
-        <div class="dr-finder-profile-header__doctor-info__address {{ isMulti ? 'multiadress'  : '' }}">{{ item|raw }}</div>
-      {% endfor %}
-    {% endif %}
-    {% if drFinderProfileHeader.data.specialty %}
-      <div class="dr-finder-profile-header__doctor-info__specialty">{{ drFinderProfileHeader.data.specialty|raw }}</div>
-    {% endif %}
-    {% if drFinderProfileHeader.member %}
-      {% include '@atoms/dr-finder-badge/dr-finder-badge.twig' %}
-    {% endif %}
-    {% if drFinderProfileHeader.service %}
-      <div class="dr-finder-profile-header__doctor-info__service">Accepting new patients</div>
-    {% endif %}
-    {% if drFinderProfileHeader.data.url %}
-      <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
-    {% endif %}
-    {% if drFinderProfileHeader.claimed %}
-      <div class="dr-finder-profile-header__edit-actions">
-        {% for button in drFinderProfileHeader.editActions %}
-          <div>{% include '@atoms/button/button.twig' with { "button" : button } %}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
+      {% endif %}
+      {% if drFinderProfileHeader.data.specialty %}
+        <div class="dr-finder-profile-header__doctor-info__specialty">{{ drFinderProfileHeader.data.specialty|raw }}</div>
+      {% endif %}
+      {% if drFinderProfileHeader.member %}
+        {% include '@atoms/dr-finder-badge/dr-finder-badge.twig' %}
+      {% endif %}
+      {% if drFinderProfileHeader.service %}
+        <div class="dr-finder-profile-header__doctor-info__service">Accepting new patients</div>
+      {% endif %}
+      {% if drFinderProfileHeader.data.url %}
+        <div class="dr-finder-profile-header__doctor-info__url">{{ drFinderProfileHeader.data.url|raw }}</div>
+      {% endif %}
+      {% if drFinderProfileHeader.claimed %}
+        <div class="dr-finder-profile-header__edit-actions">
+          {% for button in drFinderProfileHeader.editActions %}
+            <div>{% include '@atoms/button/button.twig' with { "button" : button } %}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
   </div>
   <div class="dr-finder-profile-header__info__summary">
-    {% if drFinderProfileHeader.data.specialtyText is not null and drFinderProfileHeader.data.locationText is not null %}
+    {% if drFinderProfileHeader.data.specialtyText is not null or drFinderProfileHeader.data.locationText is not null %}
       <p>Dr. {{ drFinderProfileHeader.data.labelName }} {{ drFinderProfileHeader.data.specialtyText }}{{ drFinderProfileHeader.data.locationText }}.</p>
     {% endif %}
       <p>Physician data used in Find a Doctor is sourced from the American Medical Association's Physician Professional Data. Formerly known as the AMA Physician Masterfile, this collection was established by the AMA in 1906 in response to the need for a comprehensive biographic record of all US physicians. The AMA Physician Professional Data includes information on both AMA members and non-members and international medical graduates to practice or reside in the United States. Each physician record includes educational and demographic information such as name, address, educational history, practice type and specialty.</p>
   </div>
+</div>
+<div class="dr-finder-profile-header__aside__claim">
+{% if not drFinderProfileHeader.claimed %}
   {# If this account has not been claimed and is eligable to be claimed, show claim button. #}
-  {% if not drFinderProfileHeader.claimed %}
-    <div class="dr-finder-profile-header__claim">
-      {% include '@molecules/dr-finder-claim/dr-finder-claim.twig' with { "drFinderClaim" : drFinderProfileHeader.drFinderClaim } %}
-    </div>
-  {% endif %}
+  {% include '@molecules/dr-finder-claim/dr-finder-claim.twig' with { "drFinderClaim" : drFinderProfileHeader.drFinderClaim } %}
+{% endif %}
 </div>

--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -66,6 +66,12 @@
       </div>
     {% endif %}
   </div>
+  <div class="dr-finder-profile-header__info__summary">
+    {% if drFinderProfileHeader.data.specialtyText is not null and drFinderProfileHeader.data.locationText is not null %}
+      <p>Dr. {{ drFinderProfileHeader.data.labelName }} {{ drFinderProfileHeader.data.specialtyText }}{{ drFinderProfileHeader.data.locationText }}.</p>
+    {% endif %}
+      <p>Physician data used in Find a Doctor is sourced from the American Medical Association's Physician Professional Data. Formerly known as the AMA Physician Masterfile, this collection was established by the AMA in 1906 in response to the need for a comprehensive biographic record of all US physicians. The AMA Physician Professional Data includes information on both AMA members and non-members and international medical graduates to practice or reside in the United States. Each physician record includes educational and demographic information such as name, address, educational history, practice type and specialty.</p>
+  </div>
   {# If this account has not been claimed and is eligable to be claimed, show claim button. #}
   {% if not drFinderProfileHeader.claimed %}
     <div class="dr-finder-profile-header__claim">

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -5,6 +5,36 @@
     padding-top: $gutter;
     margin-top: $gutter;
     display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+  &__details {
+    display: flex;
+    @include breakpoint($bp-small max-width) {
+      flex-direction: column;
+    }
+  }
+  &__info__summary {
+    padding-top: $gutter;
+  }
+  &__aside {
+    &__claim {
+      @include breakpoint($bp-small max-width) {
+        border-top: solid 1px $gray-30;
+        padding-top: $gutter;
+      }
+      @include breakpoint($bp-small) {
+        min-width: 400px;
+        padding-left: 120px;
+      }
+      &__heading {
+        font-weight: 600;
+      }
+      a {
+        color: $blue;
+      }
+    }
   }
 }
 

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile.scss
@@ -1,3 +1,11 @@
+.ama-drfinder-profile {
+  &.container {
+    @include breakpoint($bp-small) {
+      display: flex;
+    }
+  }
+}
+
 .dr-finder-profile__actions .ama__button {
     padding: 5px 21px;
   }

--- a/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
+++ b/styleguide/source/assets/scss/03-organisms/_dr-finder-search.scss
@@ -11,4 +11,12 @@
 
 .dr-finder-search__cta {
   padding-top: $gutter;
+  &.container {
+    &.profile {
+      @include breakpoint($bp-small) {
+        max-width: 66%;
+        margin-left: 0;
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[DCP-192: Create SEO canned text field for physician pages](https://issues.ama-assn.org/browse/DCP-192)

## Description:
Styling for [feature/DCP-192-add-SEO-canned-text-to-physician-pages](https://github.com/AmericanMedicalAssociation/dr-finder/tree/feature/DCP-192-add-SEO-canned-text-to-physician-pages)

## To Test:
Following testing instructions for https://github.com/AmericanMedicalAssociation/dr-finder/pull/277.

Verify the text placement matches the provide Zeplins:
Desktop https://zpl.io/zwkOnK7 / https://zpl.io/AOjwEen / https://zpl.io/kKO9ngG 
Mobile https://zpl.io/wyLw1EJ / https://zpl.io/gge5NlO / https://zpl.io/RmrKPlz 

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
