### PR TITLE
Add Dr. Finder Specific Alert Banner Styling

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
@@ -1,89 +1,89 @@
 .dr-finder__alert {
     display: flex;
-  background-color: $homepagePurple;
-  padding: calc($gutter / 2);
-  color: $white;
-  width: 100%;
-  align-items: center;
-  flex-direction: column;
-  background-image: url('../icons/svg/icon-homepage-alert.svg');
-  background-repeat: no-repeat;
-  background-position: 20px 50%;
-  position: relative;
-
-  @include breakpoint($bp-small) {
-    flex-direction: row;
-  }
-
-  &__wrap {
-    opacity: 0;
-    min-height: unset;
-  }
-
-  &__text {
-    font-weight: $font-weight-bold;
-    margin-bottom: 0;
-    margin-right: 25px;
-
-    &.mobile {
-      padding-left: 40px;
-      a {
-        color: $white;
-      }
-    }
+    background-color: $homepagePurple;
+    padding: calc($gutter / 2);
+    color: $white;
+    width: 100%;
+    align-items: center;
+    flex-direction: column;
+    background-image: url('../icons/svg/icon-homepage-alert.svg');
+    background-repeat: no-repeat;
+    background-position: 20px 50%;
+    position: relative;
 
     @include breakpoint($bp-small) {
-      margin-right: 0;
-      margin-left: 50px;
-      flex: 1;
+        flex-direction: row;
+    }
 
-      &.mobile {
+    &__wrap {
+        opacity: 0;
+        min-height: unset;
+    }
+
+    &__text {
+        font-weight: $font-weight-bold;
+        margin-bottom: 0;
+        margin-right: 25px;
+
+        &.mobile {
+            padding-left: 40px;
+            a {
+                color: $white;
+            }
+        }
+
+        @include breakpoint($bp-small) {
+            margin-right: 0;
+            margin-left: 50px;
+            flex: 1;
+
+            &.mobile {
+                display: none;
+            }
+        }
+
+        @include breakpoint($bp-small max-width) {
+            &.desktop {
+                display: none
+            }
+        }
+    }
+
+    .ama__button {
+        text-transform: uppercase;
+        font-weight: $font-weight-bold;
+        margin: 0 auto;
         display: none;
-      }
+
+        @include breakpoint($bp-small) {
+            align-self: flex-end;
+        }
+
+        @include breakpoint($bp-small) {
+            display: block;
+        }
     }
 
-    @include breakpoint($bp-small max-width) {
-      &.desktop {
-        display: none
-      }
+    &__close {
+        height: 22px;
+        width: 22px;
+        overflow: hidden;
+        margin-left: 25px;
+        position: absolute;
+        top: 10px;
+        right: 5px;
+
+        svg {
+            fill: $white;
+            vertical-align: inherit;
+        }
+
+        @include breakpoint($bp-small) {
+            position: static;
+        }
+
+        @include breakpoint($bp-small max-width) {
+            top: 35%;
+        }
     }
-  }
-
-  .ama__button {
-    text-transform: uppercase;
-    font-weight: $font-weight-bold;
-    margin: 0 auto;
-    display: none;
-
-    @include breakpoint($bp-small) {
-      align-self: flex-end;
-    }
-
-    @include breakpoint($bp-small) {
-      display: block;
-    }
-  }
-
-  &__close {
-    height: 22px;
-    width: 22px;
-    overflow: hidden;
-    margin-left: 25px;
-    position: absolute;
-    top: 10px;
-    right: 5px;
-
-    svg {
-      fill: $white;
-      vertical-align: inherit;
-    }
-
-    @include breakpoint($bp-small) {
-      position: static;
-    }
-
-    @include breakpoint($bp-small max-width) {
-      top: 35%;
-    }
-  }
   }

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
@@ -1,0 +1,89 @@
+.dr-finder__alert {
+    display: flex;
+  background-color: $homepagePurple;
+  padding: calc($gutter / 2);
+  color: $white;
+  width: 100%;
+  align-items: center;
+  flex-direction: column;
+  background-image: url('../icons/svg/icon-homepage-alert.svg');
+  background-repeat: no-repeat;
+  background-position: 20px 50%;
+  position: relative;
+
+  @include breakpoint($bp-small) {
+    flex-direction: row;
+  }
+
+  &__wrap {
+    opacity: 0;
+    min-height: unset;
+  }
+
+  &__text {
+    font-weight: $font-weight-bold;
+    margin-bottom: 0;
+    margin-right: 25px;
+
+    &.mobile {
+      padding-left: 40px;
+      a {
+        color: $white;
+      }
+    }
+
+    @include breakpoint($bp-small) {
+      margin-right: 0;
+      margin-left: 50px;
+      flex: 1;
+
+      &.mobile {
+        display: none;
+      }
+    }
+
+    @include breakpoint($bp-small max-width) {
+      &.desktop {
+        display: none
+      }
+    }
+  }
+
+  .ama__button {
+    text-transform: uppercase;
+    font-weight: $font-weight-bold;
+    margin: 0 auto;
+    display: none;
+
+    @include breakpoint($bp-small) {
+      align-self: flex-end;
+    }
+
+    @include breakpoint($bp-small) {
+      display: block;
+    }
+  }
+
+  &__close {
+    height: 22px;
+    width: 22px;
+    overflow: hidden;
+    margin-left: 25px;
+    position: absolute;
+    top: 10px;
+    right: 5px;
+
+    svg {
+      fill: $white;
+      vertical-align: inherit;
+    }
+
+    @include breakpoint($bp-small) {
+      position: static;
+    }
+
+    @include breakpoint($bp-small max-width) {
+      top: 35%;
+    }
+  }
+  }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
N/A

## Description:
Recent AMA One Alert Banner Redesign (https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/1627) removed styling from Dr. Finder.  This PR adds Dr. Finder specific styling to the alert banner on the site.
 
## To Test:

**Setup**
- Pull SG branch [bugfix/restore-ama-alert-dependent-styling](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/restore-ama-alert-dependent-styling) into the SG directory
- Serve SG
- Pull branch [bugfix/restore-ama-alert-dependent-styles](https://github.com/AmericanMedicalAssociation/dr-finder/tree/bugfix/restore-ama-alert-dependent-styles)
- Link SG
- Run `lando drush @drfinder.local cr`
- Go to http://drfinder.lndo.site
- Verify the alert banner is display as expected (see screenshot)
- Verify the close button closes the banner

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
**Before**
![image](https://github.com/AmericanMedicalAssociation/dr-finder/assets/112415930/1d3f92e3-e411-4da4-a50f-2b8cc985d923)

**After**
![image](https://github.com/AmericanMedicalAssociation/dr-finder/assets/112415930/a56ea49c-8c3f-4eb2-a597-9eab60eb5c85)

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
