### PR TITLE
DCP-106: Revert to Specialty Description Variable

### DIFF
--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -86,6 +86,6 @@
   <p class="dr-finder-profile-header__aside__claim__heading">Don't have an AMA Sign In account?</p>
   <p><a href="/login?destination={{ drFinderProfileHeader.pathCurrent }}">Create your free account account and claim your page</a></p>
   <p>No, I am a designated administrator or medical staff professional for my organization looking to verify credentials for Dr. {{ drFinderProfileHeader.data.formatName }} or in accordance with accreditation standards such as Joint Commission or NCQA. <a href="https://amacredentialingservices.org/credentialing/Physician-Professional-data%E2%84%A2">Click here to visit AMA Credentialing Services.</a></p>
-  <p>No, I am looking for other physicians specializing in {{ drFinderProfileHeader.data.specialtyCategory }}. <a href="/">Search Find a Doctor for physicians by name and location.</a></p>
+  <p>No, I am looking for other physicians specializing in {{ drFinderProfileHeader.data.formatSpecialty }}. <a href="/">Search Find a Doctor for physicians by name and location.</a></p>
 {% endif %}
 </div>


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[DCP-196:Create enhanced claim text for physicians on unclaimed Find a Doctor pages](https://issues.ama-assn.org/browse/DCP-196)

## Description:
SpecialtyBroadCategory variable not available fin Profile Data received from API service, only in mock API fixture data.  Removing variable and reverting to use specialtyDescription variable.

## To Test:

**Setup**
- Pull SG branch [bugfix/revert-specialty-variable-claim-text](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/revert-specialty-variable-claim-text) into SG directory
- Serve and link SG
- Pull branch [bugfix/remove-specialty-category-variable](https://github.com/AmericanMedicalAssociation/dr-finder/tree/bugfix/remove-specialty-category-variable) into root directory
- Run `lando drush @drfinder.local cr`
- Confirm you have the secrets.settings.ddev.php file in place (docroot/sites/default)
- Run 'lando drush @drfinder.local pm:uninstall ama_drfinder_mock_api` to enable real API
- Access http://drfinder.lndo.site/ as anonymous user and conduct a search
- Click on a few of the physician results to view their profiles
- Verify the specialty Description is present in the last paragraph of the claim text:

_ex. No, I am looking for other physicians specializing in Orthopedic Surgery._

![image](https://github.com/AmericanMedicalAssociation/dr-finder/assets/112415930/d6e80dd7-64da-40fe-a8d0-a27ed780fcca)

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)

