### PR TITLE
EWL-10818: Cat/Org Menu Feedback

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -43,6 +43,30 @@
       align-items: center;
       border-bottom: .5px solid $purple;
       justify-content: space-between;
+      padding: 0 40px;
+      padding-top: 18px;
+    }
+    @include breakpoint($bp-large) {
+      padding: 0;
+      padding-top: 18px;
+    }
+    @media screen and (min-width: 900px) and (max-width: 992px){
+      padding: 0 20px;
+      padding-top: 18px;
+
+      .ama__org-nav {
+        flex-shrink: 1.2;
+
+        ul {
+          display: block;
+          text-align: left;
+        }
+      }
+
+      ul {
+        justify-content: flex-start;
+      }
+
     }
   }
 


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-10818: Cat/Org Menu Feedback](https://issues.ama-assn.org/browse/EWL-10818)

## Description
Styles for lonely breakpoint and add padding to replace removed div


## To Test
- [ ] Pull this branch and amad8 branch
- [ ] https://github.com/AmericanMedicalAssociation/ama-d8/pull/4867
- [ ] Serve styleguide and `lando drush @one.local cr`
- [ ] Verify the changes to the cat/org nav on the homepage has the following issues addressed

Blue box is removed and padding is appropriate.
![image (3)](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/43501792/a02f90dd-9772-418b-bb5f-8ecd6fa2ed27)

Spacing between items on the right is fixed on the 900 - 992 breakpoint
<img width="978" alt="Screenshot 2024-06-17 at 3 16 59 PM" src="https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/43501792/e109d786-6581-4592-a5ce-1feca2e622c9">



Zeplins:
Hi Fi Designs
**Desktop**
https://zpl.io/EdqzG6n
**Tablet**
N/A because tablet and desktop are the same.
**Mobile**
Current and future display are same (no change via this ticket) – "Organizational Nav" & "Home Page Category Navigation" does not display on mobile.
**Edge Case**
https://zpl.io/KEp59RJ
https://zpl.io/0PenO3o
https://zpl.io/6JZOWrW
https://zpl.io/ggeyEAD
https://zpl.io/DpGR3Ll

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
