### PR TITLE
DCP-106: Update Styling for Claim Box on Profile Page

### DIFF
--- a/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-profile-header/dr-finder-profile-header.twig
@@ -75,7 +75,7 @@
       <p>Physician data used in Find a Doctor is sourced from the American Medical Association's Physician Professional Data. Formerly known as the AMA Physician Masterfile, this collection was established by the AMA in 1906 in response to the need for a comprehensive biographic record of all US physicians. The AMA Physician Professional Data includes information on both AMA members and non-members and international medical graduates to practice or reside in the United States. Each physician record includes educational and demographic information such as name, address, educational history, practice type and specialty.</p>
   </div>
 </div>
-<div class="dr-finder-profile-header__aside__claim">
+<div class="dr-finder-profile-header__aside__claim {{ not logged_in ? 'profile-public' : ''}}">
 {% if not drFinderProfileHeader.claimed %}
   {# If this account has not been claimed and is eligable to be claimed, show claim button. #}
   {% include '@molecules/dr-finder-claim/dr-finder-claim.twig' with { "drFinderClaim" : drFinderProfileHeader.drFinderClaim } %}

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-claim.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-claim.scss
@@ -5,6 +5,10 @@
   border: 1px solid $black;
   padding: $gutter;
   margin: $gutter 0;
+  section {
+    width: 100%;
+    margin:0 8px;
+  }
 }
 
 .dr-find-claim-benefits {

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-profile-header.scss
@@ -26,13 +26,18 @@
       }
       @include breakpoint($bp-small) {
         min-width: 400px;
-        padding-left: 120px;
+        padding-left: 100px;
       }
       &__heading {
         font-weight: 600;
       }
       a {
         color: $blue;
+      }
+      &.profile-public {
+        @include breakpoint($bp-small) {
+          padding-left: 120px;
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[DCP-196:Create enhanced claim text for physicians on unclaimed Find a Doctor pages](https://issues.ama-assn.org/browse/DCP-196)

## Description:
Fix the following styling/layout issues in regards to the original PR (https://github.com/AmericanMedicalAssociation/dr-finder/pull/275):

- When user is logged in and their profile is unclaimed then the claim button/text is not displayed in the right column as expected

![image](https://github.com/AmericanMedicalAssociation/dr-finder/assets/112415930/d2f04e77-c573-436e-b7b5-e74b2d00ba3e)

- When editing the profile, the image and info columns are not displayed correctly.  They are displayed full width and vertically stacked instead of as horizontal columns.

![image](https://github.com/AmericanMedicalAssociation/dr-finder/assets/112415930/a1b7d86d-6233-4f15-a724-2355bfca3c20)


## To Test:

**Setup**
- Pull SG branch [bugfix/DCP-196-add-profile-claim-edit-styling](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/DCP-196-add-profile-claim-edit-styling) into SG directory
- Serve SG with `lando gulp serve`
- Pull branch [bugfix/DCP-196-add-profile-edit-view-classes](https://github.com/AmericanMedicalAssociation/dr-finder/tree/bugfix/DCP-196-add-profile-edit-view-classes) into root directory
- Link SG with `lando link-styleguides -a drfinder`
-Follow testing instructions in https://github.com/AmericanMedicalAssociation/dr-finder/pull/298

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
