### PR TITLE
EWL-10854: Subcat Pills on Cat Pages

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -1,16 +1,16 @@
 .ama__subcategory-exploration {
   border: solid $purple;
-  border-width: 1px 0;
+  border-width: 0 0 1px 0;
   overflow: hidden;
   padding: calc($gutter/2) 0 calc($gutter/4) 0;
 
   @include breakpoint($bp-small) {
-    padding: calc($gutter/2) 0 calc($gutter/5) 0;
+    padding: calc($gutter/2) 0 calc($gutter/4) 0;
   }
 
   &__list {
     overflow: visible;
-    @include breakpoint($bp-med) {
+    @include breakpoint($bp-large) {
       height: auto;
     }
 
@@ -23,12 +23,20 @@
       flex-direction: row;
       flex-wrap: wrap;
       margin-bottom: 0;
-      justify-content:space-between;
+      justify-content: flex-start;
     }
 
     li {
       list-style-type: none;
-      margin: 0;
+      margin: 0 calc($gutter / 4) calc($gutter / 2) 0;
+      padding: 4px;
+      background-color: $gray-7;
+      border-radius: 4px;
+      border: solid 0 #000;
+
+      &:hover {
+        background-color: $gray-20;
+      }
       &:last-child a:after {
         content: "";
         padding: 0;
@@ -47,22 +55,21 @@
     h2 {
       color: $gray-80;
       text-decoration: none;
-      font-size: 12px;
+      font-size: 14px;
       font-weight: 300;
       display: flex;
-      text-transform: uppercase;
       margin-bottom: 0;
-      padding: 0 calc($gutter/2) calc($gutter/4) 0;
+      padding: 0;
 
-      @include breakpoint($bp-small) {
+      @include breakpoint($bp-med) {
         font-weight: 300;
         font-size: 18px;
-        padding: 0 calc($gutter/2) calc($gutter/4) 0;
+        padding: 0;
       }
 
       &:hover h2,
       &:hover {
-        text-decoration: underline;
+        text-decoration: none;
       }
     }
 

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -22,8 +22,14 @@
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      margin-bottom: 0;
+      margin-bottom: calc($gutter / 4);
       justify-content: flex-start;
+      @include breakpoint($bp-med) {
+        margin-bottom: calc($gutter/2);
+      }
+      @include breakpoint($bp-large) {
+        margin-bottom: 0;
+      }
     }
 
     li {
@@ -61,7 +67,7 @@
       margin-bottom: 0;
       padding: 0;
 
-      @include breakpoint($bp-med) {
+      @include breakpoint($bp-large) {
         font-weight: 300;
         font-size: 18px;
         padding: 0;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**
- [EWL-10854: Subcat Pills on Cat Pages](https://issues.ama-assn.org/browse/EWL-10854)

## Description
Redesign of the links on the category pages


## To Test
- [ ] Pull this branch and develop on amad8
- [ ] Link styleguides
- [ ] View a category page (https://ama-one.lndo.site/practice-management)
- [ ] Verify the newly designed subcat link listing looks like zeplins on all sizes
![image](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/assets/43501792/99c980b2-9e54-4c5b-b22c-44a8e00c24d8)

Zeplins
https://zpl.io/GnEnR1r
Desktop
https://zpl.io/9NqNzyA
Tablet
https://zpl.io/RmMm9Pv
Mobile
https://zpl.io/zw8wjnG

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
