### PR TITLE
EWL-10853: Add Styling Fixes for PR Feedback

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -24,9 +24,6 @@
         justify-content: center;
         flex-direction: column;
         margin-top: 0;
-        @include breakpoint($bp-med) {
-            margin-top: $gutter;
-        }
         flex-basis: 45%;
         .spacer {
             height: $gutter;
@@ -63,7 +60,7 @@
             width:100%;
             //Fix for overriding jquery widget
             .ama__button {
-                padding: 5px 12px;
+                padding: 8px 12px;
                 color: $white;
                 font-weight: $font-weight-regular;
                 width: 100%;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10853: 30/70 Promo Design Update](https://issues.ama-assn.org/browse/EWL-10853)

## Description:
Add fixes for the following PR feedback issues:

**Vertical Alignment of Elements**
ISSUE: Design notes "Vertical elements should align center on desktop and mobile" 
FIX: Removed top margin from left column of block.  Flex container already has items vertically aligned but top margin was overriding it.

**CTA Button Padding**
ISSUE: Design notes that button should be 8px top/bottom
FIX: Adjusted button padding from 5px to 8px for top/bottom

These issues are per Zeplin https://app.zeplin.io/project/6569fc6b0b3784671e3acd9b/screen/665e2e1ed995aa08b5e66816 comment numbers 2 and 5.

## To Test:

**Setup**
- Pull branch [feature/EWL-10853-address-styling-feedback](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-10853-address-styling-feedback) into SG directory
- Serve and link SG
- Access https://ama-one.lndo.site/
- Verify that the top margin above the header is removed and the items in the left column of block are aligned vertically center
- Verify that the CTA button padding has been increased from 5px to 8px

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)

