### PR TITLE
EWL-10720: Update 30-70 and homepage partner promo markup for better …

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -45,7 +45,7 @@
             color: $black;
             margin-bottom: calc($gutter / 2);
         }
-        h5 {
+        p.ama__h5 {
             font-weight: $font-weight-regular;
             line-height: 24px;
             color: #424242;


### PR DESCRIPTION
…ADA compliance

<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

## JIRA Ticket(s)
- [EWL-10720: Homepage text should not be marked as heading](https://issues.ama-assn.org/browse/EWL-10720)


## Description:
Update markup and styling fro 30-70 block and homepage partner promo to better comply with ADA standards.


## To Test:
- checkout ama-d8 pr locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4899
- link styleguide locally
- clear caches
- on homepage confirm 30/70 block subheading is a p with class ama__h5 tag
- confirm the styling/functionality has not changed
- confirm the same with 30/70 block instances on articles, category and subcategory
- confirm the homepage partner promo heading text that reads "Save, rank, take notes, download and compare programs." is wrapped in a p tag and not a heading tag
- confirm the styling/functionality has not changed

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
