### PR TITLE
EWL-10853: 30/70 block desktop sizing fix.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -24,7 +24,10 @@
         justify-content: center;
         flex-direction: column;
         margin-top: 0;
-        flex-basis: 45%;
+        @include breakpoint($bp-med) {
+            flex-basis: 50%;
+            max-width: 396px;
+        }
         .spacer {
             height: $gutter;
             display: block;
@@ -158,7 +161,7 @@
         position: relative;
         overflow: hidden;
         @include breakpoint($bp-small) {
-            padding-bottom: 66.67%;
+            padding-bottom: 66.667%;
         }
         @include breakpoint($bp-small $bp-med) {
             min-height: 480px;
@@ -194,11 +197,9 @@
         padding-top: 0;
         @include breakpoint($bp-med) {
             width: 90%;
+            max-width: 956px;
             margin: 0 auto 0;
             padding-top: $gutter;
-        }
-        @include breakpoint($bp-large) {
-            width: 80%;
         }
     }
 }


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10853: 30/70 Promo Design Update](https://issues.ama-assn.org/browse/EWL-10853)

## Description
Adjust sizing of homepage 30/70 block on desktop.


## To Test
- link styleguide locally
- on desktop confirm the 30/70 block on homepage matches the following zeplin: https://app.zeplin.io/project/6569fc6b0b3784671e3acd9b/screen/665e2e1ed995aa08b5e66816
- this should include content width (396px)
- and image size/ratio 480px x 320 px (3:2)
- confirm stying has not changed on category and article instances

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
