### PR TITLE
EWL-10924: Update mobile alert banner padding.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_alert.scss
@@ -4,7 +4,7 @@
     color: $gray-64;
     width: 100%;
     align-items: center;
-    padding: 5px calc($gutter * .75) 5px $gutter;
+    padding: 0 calc($gutter * .75) 0 $gutter;
     flex-direction: row;
     position: relative;
     @include breakpoint($bp-med) {
@@ -44,7 +44,7 @@
             display:block;
             line-height: 15px;
             padding-top: calc($gutter *.25);
-            padding-bottom: calc($gutter * .25);
+            padding-bottom: 8px;
             a,
             p {
                 font-size: 14px;
@@ -77,7 +77,7 @@
             width: 27px;
             display: block;
             align-self: start;
-            margin-right: -5px;
+            margin-right: -15px;
         }
         &.desktop {
             display: none;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**
- [EWL-10924: Mobile Alert Banner | CTA & Padding/Alignment](https://ama-it.atlassian.net/browse/EWL-10924)

## Description
Adjust mobile styling of Alert Banner.


## To Test
- link styleguide locally
- clear caches
- if not present add/edit an alert banner and set it to display on the homepage, make sure a CTA is present
- confirm the following using this zeplin as reference: https://app.zeplin.io/project/662aaea07c9fd0c43438babf/screen/662ab164e692ac15a2a2322a
- CTA text on mobile alert banner is #025785.
- Padding on bottom of mobile alert banner displays as per the Zeplins.
- Alignment of the X on the mobile alert banner matches the Zeplins. 

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
