### PR TITLE
EWL-10917: Update Article Page Grouper position and design.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -122,29 +122,22 @@
       padding-bottom: 12px;
       margin-bottom: 14px;
       border-bottom: 1px solid $gray-30;
-      width: 370px;
       @include breakpoint($bp-small) {
         font-size: 22px;
-        width: 280px;
       }
     }
 
     .link-list {
       display: inline-block;
       list-style-type: none;
-      max-width: 260px;
-      @include breakpoint($bp-small) {
-        max-width: 274px;
-      }
       .ama_page_grouping_link {
         font-size: 16px;
         line-height: 24px;
-        margin-bottom: 15px;
+        margin-bottom: 14px;
         text-transform: capitalize;
         @include breakpoint($bp-small) {
           font-size: 18px;
           line-height: 27px;
-          margin-bottom: 18px;
         }
 
         &.heading {
@@ -174,7 +167,6 @@
         }
 
         &:last-child {
-          margin-bottom: 10px;
           &.active {
             &::after {
               content: "";

--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -90,31 +90,46 @@
 
 //News Article Page Grouping Block
 
+// Sticky top offset for logged in user w/ admin bar
+@include breakpoint($bp-small) {
+  body.toolbar-horizontal {
+    .ama_page_grouping_news {
+      top: 202px;
+    }
+  }
+}
+
 .ama_page_grouping_news {
   margin: 0 0 $gutter;
-  max-width: 380px;
   padding: 0;
+  border-bottom: 1px solid $gray-30;
   @include breakpoint($bp-small) {
     display: flex;
     margin: 0 0 28px 0;
+    position: -webkit-sticky; /* For Safari */
+    position: sticky;
+    top: 83px;
+  }
+  @include breakpoint($bp-med) {
+    top: 123px;
   }
 
   .links {
     .ama_page_grouping_title {
+      font-family: kepler-std, serif;
       font-size: 20px;
-      font-weight: 600;
       line-height: 32px;
       padding-bottom: 12px;
       margin-bottom: 14px;
       border-bottom: 1px solid $gray-30;
-      width: 372px;
+      width: 370px;
       @include breakpoint($bp-small) {
-        width: 380px;
+        font-size: 22px;
+        width: 280px;
       }
     }
 
     .link-list {
-      margin-top: 4px;
       display: inline-block;
       list-style-type: none;
       max-width: 260px;
@@ -122,16 +137,14 @@
         max-width: 274px;
       }
       .ama_page_grouping_link {
-        line-height: 27px;
-        text-transform: capitalize;
         font-size: 16px;
-        min-height: 31px;
-        padding-bottom: 4px;
-        margin-bottom: 4.5px;
-        border-bottom: .5px solid $gray-30;
-        @include breakpoint($bp-med) {
+        line-height: 24px;
+        margin-bottom: 15px;
+        text-transform: capitalize;
+        @include breakpoint($bp-small) {
           font-size: 18px;
           line-height: 27px;
+          margin-bottom: 18px;
         }
 
         &.heading {
@@ -145,20 +158,23 @@
           position: relative;
         }
         a {
+          font-family: "myriad-pro-light", "Helvetica", "Arial", "Open Sans", sans-serif;
+          font-weight: 300;
           color: $gating-block-link;
           &:hover {
-            text-decoration: underline;
+            border-bottom: 1px solid $gating-block-link;
           }
           &:focus-visible {
             outline: 1px solid $tab-focus-blue;
           }
         }
         &.active {
-          font-weight: $font-weight-bold;
           color: $purple;
+          @include type($myriad-pro, $font-weight-regular);
         }
 
         &:last-child {
+          margin-bottom: 10px;
           &.active {
             &::after {
               content: "";

--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -1,19 +1,21 @@
 .ama__layout--two-column--left {
-  display: grid;
-  grid-template-columns: 2.5fr 6fr;
-  grid-template-rows: auto auto auto;
   min-height: 30em;
+  @include breakpoint($bp-small) {
+    display: grid;
+    grid-template-rows: auto auto auto;
+    grid-template-columns: 2.5fr 6fr;
+  }
 
   &__content-top {
     grid-column: 1 / 5;
     grid-row: 1;
 
-    @include breakpoint($bp-small min-width) {
+    @include breakpoint($bp-small) {
       grid-column: 1 / 5;
       grid-row: 1;
     }
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       @include gutter($padding-right-full...);
       @include gutter($padding-left-full...);
       grid-column: 1 / 5;
@@ -27,21 +29,24 @@
     grid-column: 1 / 5;
     grid-row: 3;
 
-    @include breakpoint($bp-small min-width) {
+    @include breakpoint($bp-small) {
       @include gutter($padding-right-full...);
       grid-column: 1 / 4;
       grid-row: 3;
     }
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       grid-column: 2;
       grid-row: 2 / 4;
     }
 
     &.ama__news {
       padding-right: 0;
-      @include breakpoint($bp-small min-width) {
-        grid-column: 2 / 2;
+      padding-top: 0;
+      @include breakpoint($bp-small) {
+        grid-column: 1 / 2;
+        grid-row: 1;
+        max-width: 280px;
       }
     }
   }
@@ -51,7 +56,7 @@
     grid-column: 1 / 5;
     grid-row: 4;
     overflow-x: hidden;
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       @include gutter($padding-right-full...);
       @include gutter($padding-left-full...);
       overflow-x: hidden;
@@ -61,10 +66,10 @@
     }
   }
   &.news_article {
-    @include breakpoint($bp-small min-width) {
+    @include breakpoint($bp-small) {
       grid-template-columns: 2fr 6fr;
     }
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       grid-template-columns: 3fr 8.5fr;
     }
   }
@@ -80,7 +85,7 @@
     grid-column: 1 / 5;
     grid-row: 2 ;
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       @include gutter($padding-right-full...);
       @include gutter($padding-left-full...);
       grid-column: 1;

--- a/styleguide/source/assets/scss/04-templates/_two_column-right.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-right.scss
@@ -1,6 +1,6 @@
 .ama__layout--two-column--right {
   display: grid;
-  grid-template-columns: 1fr 6fr 2.5fr;
+  grid-template-columns: 2.5fr 6fr;
   grid-template-rows: auto auto auto;
   min-height: 30em;
   overflow: hidden;
@@ -13,30 +13,30 @@
     grid-column: 1 / 5;
     grid-row: 1;
 
-    @include breakpoint($bp-small min-width) {
+    @include breakpoint($bp-small) {
       grid-column: 1 / 5;
       grid-row: 1;
     }
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       grid-column: 1 / 5;
-      grid-row: 1;
+      grid-row: 1 / 2;
     }
   }
 
   &__page-content {
     @include gutter($padding-top-full...);
     position: relative;
-    grid-column: 1 / 5;
+    grid-column: 1 / 4;
     grid-row: 2;
     word-wrap: break-word;
 
-    @include breakpoint($bp-small min-width) {
-      grid-column: 1 / 5;
-      grid-row: 2;
+    @include breakpoint($bp-small) {
+      grid-column: 1 / 2;
+      grid-row: 2 / 2;
     }
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       @include gutter($padding-top-full...);
       padding: $gutter 0 0 0;
       grid-column:  1 / 3;
@@ -49,12 +49,12 @@
     grid-column: 1 / 5;
     grid-row: 2;
 
-    @include breakpoint($bp-small min-width) {
+    @include breakpoint($bp-small) {
       grid-column: 1 / 4;
       grid-row: 2;
     }
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       @include gutter($padding-right-full...);
       grid-column: 1 / 3;
       grid-row: 2;
@@ -73,22 +73,26 @@
     grid-column: 1 / 5;
     grid-row: 2;
 
-    @include breakpoint($bp-med min-width) {
+    @include breakpoint($bp-med) {
       grid-column: 1;
       grid-row: 1 / 4;
     }
   } // end aside.primary
 
   &--secondary {
-    padding-top: $gutter;
-    grid-column: 1 / 5;
-    grid-row: 3 / 4;
+    // padding-top: $gutter;
+    grid-column: 2 / 2;
+    grid-row: 1;
 
-    @include breakpoint($bp-med min-width) {
-      @include gutter($padding-top-full...);
-      @include gutter($padding-left-full...);
-      grid-column: 3;
-      grid-row: 2 / auto;
+    @include breakpoint($bp-small) {
+      padding-left: calc($gutter * .75);
+      grid-column: 2 /4;
+      grid-row: 2 / 2;
     }
   } // end aside.secondary
+}
+
+// Article only ovveride
+.ama__news + .ama__layout--two-column--right__sidebar--secondary {
+  grid-row: 1 / 2;
 }

--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -2,7 +2,10 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  margin-bottom: $gutter;
+  margin-bottom: calc($gutter / 2);
+  @include breakpoint($bp-small) {
+    margin-bottom: $gutter;
+  }
   .article-header-row {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
<!-- NOTE: Put "N/A" for any section below that isn't applicable to the work you've done, **do not omit entirely**. Before submitting a Pull Request ensure that your work complies with the [Guidelines for Contributions](CONTRIBUTING.md) and the [SG2 Standards](ama-style-guide-2/docs/standards.md). -->

## Ticket(s)
**Do not** submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

## JIRA Ticket(s)
- [EWL-10917: Shift Page Grouper to left nav on Article pages](https://ama-it.atlassian.net/browse/EWL-10917)


## Description:
Adjust positioning and styling of article page groupers to display to the left of article content. Article page grouper on non-mobile viewports is sticky on scroll.


## To Test:
- checkout ama-d8 PR locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/4975
- link styleguide locally
- import latest config
- clear caches
- go to article with a page grouper block or edit and add a page grouper block to any article
- confirm the block position and styling match the following zeplins:
Desktop:
Article https://zpl.io/dRxX6mR 

Event https://zpl.io/dRxXWBl 

Focus https://zpl.io/9NqKJYW 

Tablet:
Article https://zpl.io/xnm64Gk 

Event https://zpl.io/JQEG35E 

Focus https://zpl.io/p01MQZJ 

Mobile:
Article / Event https://zpl.io/WQ4j63K 

Focus https://zpl.io/o01Mgrv

- confirm the page grouper is sticky on scroll while on non-mobile viewports

## Visual Regressions

_Please provide the pull request ID below. This will then reference the automated VRT report after it has been generated._

A report is available [here](http://htmlpreview.github.io/?https://github.com/AmericanMedicalAssociation/ama-style-guide-2/blob/visual-regression-testing-artifact/[PULL_REQUEST_ID]/html_report/index.html).

**Before proceeding:** Run visual regression tests locally to ensure new work does not introduce new bugs.

_The visual regression tests always compare against the production version of the style guide. Changes and new work will show up as test failures. Please describe your work so that the report can be reviewed by the team._

If you are creating or updating a pattern be sure you have created or updated the [scenario in `backstop.json`](ama-style-guide-2/styleguide/backstop.json).

_After changes in the report are documented and demonstrate your desired changes, please mark the pull request as `ready for review`.

For more information on visual regression testing review the [How do I run tests?](https://issues.ama-assn.org:8446/confluence/pages/viewpage.action?pageId=23298568) document in Confluence.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks
Things relevant to here may be updating [The Glossary](https://issues.ama-assn.org:8446/confluence/display/DTD/Glossary?src=contextnavpagetreemode) with the latest naming changes or review of the relative [D8](https://github.com/AmericanMedicalAssociation/ama-d8) work.


## Additional Notes
Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
