### PR TITLE
DCP-210: Add Find A Doctor Overrides for Recent SG Font Change

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
@@ -21,7 +21,8 @@
     }
 
     &__text {
-        font-weight: $font-weight-bold;
+        // Override main font.
+        @include type($myriad-pro, $font-weight-bold);
         margin-bottom: 0;
         margin-right: 25px;
 

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -647,6 +647,11 @@ a.ama__membership {
 
   .ama__membership-content {
     background: none;
+
+    li {
+      // Override main ul/ol font.
+      @include type($myriad-pro, $font-weight-regular);
+    }
   }
 
   .ama__membership_cta_container {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[DCP-210: Recent SG Update Font Regression Issues](https://ama-it.atlassian.net/browse/DCP-210)

## Description:
Recent font changes for AMA One within the SG caused two areas of regression on the Find A Doctor site.

 - The text within the alert banner was changed to "kepler-std"
 - The text within the list items of the membership promo blocks was changed to "kepler-std"

![image](https://github.com/user-attachments/assets/e5d63fd4-caab-405d-b457-e9fdb3b73164)

![image](https://github.com/user-attachments/assets/e66297ae-3cf9-43e1-90f5-4b7e86269f96)

 This PR adds overrides to return the font for the text in those areas back to Myriad Pro for the Find A Doctor site.

## To Test:

**Setup**
- Pull SG branch [bugfix/DCP-210-fix-font-regression-after-sg-change](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/DCP-210-fix-font-regression-after-sg-change) into SG directory
- Serve SG with `lando gulp serve`
- Link SG with `lando link-styleguides -a drfinder` in root directory
- Run `lando drush @drfinder.local cr`
- Go to http://drfinder.lndo.site/
- Verify the Alert block text matches PROD (Myriad Pro)

![image](https://github.com/user-attachments/assets/5bf21c5a-ff01-4f8f-8ba5-607ce0fd519d)


- In the search form enter "a" for Name and "Chicago, IL" for City/State
- Verify the list item text in the membership promo block matches PROD (Myriad Pro)

![image](https://github.com/user-attachments/assets/71cdabce-946e-4018-a98b-17cb4b2684f1)


## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
