### PR TITLE
EWL-10954: Remove focus outline from search box.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -89,11 +89,6 @@
     &::placeholder {
       font-style: italic;
     }
-
-    &:focus-visible {
-      outline: 2px solid $pg-lt-blue;
-      outline-offset: 3px;
-    }
   }
 
   .form-actions {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-10954: Remove blue box from search field in header](https://issues.ama-assn.org/browse/EWL-10954)


## Description
Remove outline from search bar on focus.


## To Test
-  link styleguide locally
- clear caches
- on any page click into search bar, confirm no blue outline appears
- confirm on desktop and mobile


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
