### PR TITLE
EWL-10917: Update page grouper styling to fix on focus styling.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -135,6 +135,9 @@
         line-height: 24px;
         margin-bottom: 14px;
         text-transform: capitalize;
+        // For focus outline offset
+        padding-left: 5px;
+        margin-left: -5px;
         @include breakpoint($bp-small) {
           font-size: 18px;
           line-height: 27px;

--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -145,6 +145,10 @@
           position: relative;
         }
 
+        &:focus-within {
+          outline: 1px solid $tab-focus-blue;
+        }
+
         a,
         &.active {
           text-decoration: none;
@@ -156,9 +160,6 @@
           color: $gating-block-link;
           &:hover {
             border-bottom: 1px solid $gating-block-link;
-          }
-          &:focus-visible {
-            outline: 1px solid $tab-focus-blue;
           }
         }
         &.active {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-10917: Shift Page Grouper to left nav on Article pages](https://issues.ama-assn.org/browse/EWL-10917)


## Description
Adjust styling to update focus state styling to match zeplins.


## To Test
- link styleguide locally
- clear caches
- on article with page grouper tab through and confirm focus state for page grouper links matches the following zeplin: https://app.zeplin.io/project/669176d013d8668028eff2cd/screen/669e7dab9af5f0fabbfcfd67


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
