### PR TITLE
EWL-10923: Fix vertical padding issue on 30-70 mobile CTA.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -63,12 +63,12 @@
             width:100%;
             //Fix for overriding jquery widget
             .ama__button {
-                padding: 8px 12px;
+                padding: 4.5px 12px;
                 color: $white;
                 font-weight: $font-weight-regular;
                 width: 100%;
                 font-size: 16px;
-                line-height: 1;
+                line-height: 16px;
                 @include breakpoint($bp-med) {
                     width: auto;
                 }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-10923: 30/70 Custom Block | CTA Button Padding](https://issues.ama-assn.org/browse/EWL-10923)


## Description
Adjust the padding of the 30/70 CTA to fix vertical positioning and alignment. VERY IMPORTANT!


## To Test
- link styleguide locally
- on homepage confirm the dimensions the height of the cta is 27px with a padding of 12px on the left and right of the text
- compare to zeplin to ensure dimensions are correct


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
