### PR TITLE
EWL-10917: set bottom border 100% on desktop, as wide as widest link on mobile.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -102,7 +102,9 @@
 .ama_page_grouping_news {
   margin: 0 0 $gutter;
   padding: 0;
+  border-bottom: none;
   @include breakpoint($bp-small) {
+    border-bottom: 1px solid $gray-30;
     margin: 0 0 28px 0;
     position: -webkit-sticky; /* For Safari */
     position: sticky;
@@ -132,6 +134,9 @@
       display: inline-block;
       list-style-type: none;
       border-bottom: 1px solid $gray-30;
+      @include breakpoint($bp-small) {
+        border-bottom: none;
+      }
       .ama_page_grouping_link {
         font-size: 16px;
         line-height: 24px;
@@ -189,4 +194,3 @@
     }
   }
 }
-


### PR DESCRIPTION
**Jira Ticket**
- [EWL-10917: grouper](https://ama-it.atlassian.net/browse/EWL-10917)


## Description
bottom border of page grouper on article pages is 100% width on desktop and as wide as the widest link on mobile.


## To Test
- pull and serve
- check against zeplins


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
