### PR TITLE
EWL-10907: Add Pinned Comments

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_forum-comments.scss
+++ b/styleguide/source/assets/scss/02-molecules/_forum-comments.scss
@@ -227,6 +227,11 @@ section.ama__forum_comments {
   @include breakpoint($bp-med) {
     padding: 15px 42px;
   }
+  h2 {
+    &.pinned-comment + div {
+      margin-bottom: 30px;
+    }
+  }
 }
 #block-ama-one-forums-content {
   > .indented {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10907: Add Pinned Comments](https://ama-it.atlassian.net/browse/EWL-10907)

## Description:
Add the ability for forum administrators to pin a comment to the top of comment lists with the following criteria:

1) When editing a comment, forum admins see an option to pin or unpin the comment
2) The pinned comment displays between the topic and the comments
3) The section has an H2 “📌 Pinned Comment”
4) The option to reply to the pinned comment
5) Any existing replies to the pinned comment do not display - only the one comment displays
6) If no comment is pinned on a topic, then the “Pinned Comment” section does not display
7) If more than one comment is pinned, the topic should load without errors
8) Only one pinned comment (latest updated if multiple pinned comments) will display at a time

## To Test:

**Setup**
- Pull branch [feature/EWL-10907-add-pinned-comments](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-10907-add-pinned-comments)
- Serve and link SG
- Follow testing instructions from https://github.com/AmericanMedicalAssociation/ama-d8/pull/4997

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
