### PR TITLE
EWL-10994: Set active state on Page Grouper anchor links

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
+++ b/styleguide/source/assets/scss/02-molecules/_page-grouping.scss
@@ -252,8 +252,10 @@
             outline: 1px solid $tab-focus-blue;
           }
         }
-        &.active {
+        &.active a {
           color: $purple;
+          pointer-events: none;
+          cursor: not-allowed;
           @include type($myriad-pro, $font-weight-regular);
         }
 


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


## JIRA Ticket(s)
- [EWL-10994: Page Grouper | Show grouper link as selected when the link is on the same page as the grouper instance](https://ama-it.atlassian.net/browse/EWL-10994)


## Description:
Set active state/styling on anchor links within the Page Grouper block.


## To Test:
- checkout ama-d8 PR: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5010
- clear caches
- Add/edit a Page Grouper block with anchor links to an Article page 
- Confirm when an anchor link is clicked it becomes 'active' i.e turns purple and prevents clicking on that link, same as an active link on page load
- Add/edit a second anchor link to the block
- Confirm on click of second anchor link the first active state is removed and added to the currently selected anchor link


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
