### PR TITLE
EWL-10904: Adjust Mobile Alert Banner Close Button

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_alert.scss
@@ -12,7 +12,9 @@
     &__wrap {
         opacity: 0;
         min-height: unset;
-        padding-right: 8.5px;
+        @include breakpoint($bp-small) {
+            padding-right: 8.5px;
+        }
     }
     &__text {
         margin-bottom: 0;
@@ -57,6 +59,7 @@
             display: none;
             @include breakpoint($bp-small) {
                 display: block;
+                padding-right: 14px;
             }
             a {
                 @include breakpoint($bp-small) {
@@ -75,7 +78,8 @@
             width: 27px;
             display: block;
             align-self: start;
-            margin-right: -9px;
+            margin-right: 0;
+            padding-top: 1px;
             @include breakpoint($bp-small) {
                 display: none;
             }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10904: Alert Banner custom block | Align Content With Menu Bar](https://ama-it.atlassian.net/browse/EWL-10914)

## Description:
Close button on mobile alert banner is not aligned properly.

![alert-banner-mobile-after](https://github.com/user-attachments/assets/b72c3bdb-5a44-40bb-a34e-48362e055eb4)

## To Test:

**Setup**
- Pull SG branch [bugfix/EWL-10904-fix-mobile-close-button](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-10904-fix-mobile-close-button) into SG directory
- Serve SG with `lando gulp serve`
- Link SG with `lando link-styleguides -a one` in root directory
- Run `lando drush @one.local cr`
- Go to https://ama-one.lndo.site/
- View the close button on the mobile alert banner is aligned per the zeplins

With Icon: Mobile
https://zpl.io/ezwAPxB 

![image](https://github.com/user-attachments/assets/74834755-024f-4a82-b167-7cff66785ab3)

Without Icon: Mobile
https://zpl.io/1MyO34E

![alert-banner-mobile-icon-after](https://github.com/user-attachments/assets/cf68e17b-5ea1-45c6-a374-dc406dc943ba)

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
