### PR TITLE
EWL-10904: Prevent Alert Banner Close Button Clipping

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_alert.scss
@@ -73,6 +73,7 @@
         width: 20px;
         overflow: hidden;
         margin-left: auto;
+        flex-shrink: 0;
         &.mobile {
             height: 27px;
             width: 27px;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL-10904: Alert Banner custom block | Align Content With Menu Bar](https://ama-it.atlassian.net/browse/EWL-10904)

## Description:
If the Alert Banner text is rather long then close button is getting clipped on the right side in tablet viewport.

## To Test:

**Setup**
- Pull SG branch [bugfix/EWL-10904-fix-close-btn-clipping](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-10904-fix-close-btn-clipping) into SG directory
- Serve SG with `lando gulp serve`
- Link SG with `lando link-styleguides -a one` in root directory
- Run `lando drush @one.local cr`
- Go to https://ama-one.lndo.site/
- Edit the banner to have enough text to push to two lines
- Verify the close button does not get clipped when viewport is between 600px and 991px

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
**BEFORE**
![image](https://github.com/user-attachments/assets/e925ac91-1019-4662-b33f-3ed38191fa1a)

**AFTER**
![image](https://github.com/user-attachments/assets/201a60b6-644c-4ab8-a384-f34e9061e605)


## Additional Notes
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
