### PR TITLE
EWL-11060: Sort order displaying on mobile for every topic

### DIFF
--- a/styleguide/source/assets/js/forum-styling.js
+++ b/styleguide/source/assets/js/forum-styling.js
@@ -1,9 +1,9 @@
 (function (Drupal) {
-    
+
     // Define a new behavior for Drupal
     Drupal.behaviors.ama_tableStyling = {
         attach: function (context, settings) {
-            
+
             // Object to store original data-th values
             var originalDataThValues = {};
 
@@ -12,7 +12,7 @@
 
                 // Get current window width
                 var windowWidth = window.innerWidth;
-                
+
                 // Select all td elements with data-th attribute
                 var tableCells = document.querySelectorAll('td[data-th]');
 
@@ -22,10 +22,10 @@
 
                     // If window width is less than 1200px
                     if (windowWidth < 1200) {
-                        
+
                         // Check if data-th contains "Sort ascending" or "Sort descending"
                         if (dataTh.includes('Sort ascending') || dataTh.includes('Sort descending')) {
-                            
+
                             // Store the original data-th value
                             originalDataThValues[cell] = dataTh;
                             // Remove "Sort ascending" and "Sort descending" and trim
@@ -33,26 +33,32 @@
                             if(newDataTh === 'Item Type by Item Type') {
                                 newDataTh = 'Item Type';
                             }
+                            if(newDataTh === 'Item Types by Item Types') {
+                                newDataTh = 'Item Types';
+                            }
                             if(newDataTh === 'Comment by Comment') {
                                 newDataTh = 'Comment';
+                            }
+                            if(newDataTh === 'Comments by Comments') {
+                                newDataTh = 'Comments';
                             }
                             if(newDataTh === 'Recent by Recent') {
                                 newDataTh = 'Recent';
                             }
-                             // Set the new data-th value
+                            // Set the new data-th value
                             cell.setAttribute('data-th', newDataTh);
-                            
+
                             // Mark the cell as changed
-                            cell.setAttribute('data-changed', 'true'); 
+                            cell.setAttribute('data-changed', 'true');
                         }
                     } else {
-                        
+
                         // If window width is 1200px or more
                         if (cell.getAttribute('data-changed') === 'true') {
-                            
+
                             // Restore the original data-th value
                             cell.setAttribute('data-th', originalDataThValues[cell]);
-                            
+
                             // Remove the data-changed attribute
                             cell.removeAttribute('data-changed');
                         }

--- a/styleguide/source/assets/scss/02-molecules/_forum-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_forum-listing.scss
@@ -126,6 +126,7 @@
       [data-th="Posts"],
       [data-th^="Resolution"],
       [data-th^="Comments"],
+      [data-th^="Comment"],
       [data-th^="Report"],
       [data-th="Replies"],
       [data-th="Last post"],


### PR DESCRIPTION
**Jira Ticket**
- [EWL-11060: Sort order displaying on mobile for every topic](https://ama-it.atlassian.net/browse/EWL-11060)


## Description
Reset comment header when sorting by comments


## To Test
- pull and serve
- go to https://wwwtest.ama-assn.org/orc/house-delegates/ref-comm-j?sort=asc&order=Replies and verify you're seeing the issue "Comments by Comments" on each line.
- go to ref-comm-j locally, open the topics for comments and leave some.
- view it on mobile and verify that only the word "Comments" remains.


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
