### PR TITLE
EWL-10991: Fix offset of toc and page grouper anchor links.

### DIFF
--- a/styleguide/source/assets/js/anchor_links.js
+++ b/styleguide/source/assets/js/anchor_links.js
@@ -4,12 +4,15 @@
       $(document).ready(function () {
         // Function to handle scrolling to anchor
         function scrollToAnchor(hash) {
-          // Determine the offset based on the presence of the toolbar-horizontal class
-          var offset;
-          if ($(window).width() < 601) {
-            offset = 210;
+          // Get the height of the header to determine the initial offset
+          var offset = $('header').outerHeight() || 0;
+
+          // Add the height of the page grouper if it exists
+          if ($(window).width() < 601 && $('.ama_page_grouping_news').length) {
+            offset += $('.ama_page_grouping_news').outerHeight();
           } else {
-            offset = $('body').hasClass('toolbar-horizontal') ? 180 : 110;
+            // Determine the desktop offset based on the presence of the toolbar-horizontal class
+            offset = $('body').hasClass('toolbar-horizontal') ? offset + 80 : offset;
           }
 
           var target = $(hash);


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-10991: Ticket Title](https://ama-it.atlassian.net/browse/EWL-10991)


## Description
Adjust script for anchor links to calculate offset based on present header/sticky elements.


## To Test
- link styleguide locally
- clear caches
- confirm on select of anchor links within TOC that the selected section is scrolled to without title being cut off
- repeat for Page Grouper anchor links
- confirm on both desktop and mobile


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
