### PR TITLE
EWL-11006: Update my subscriptions form to load page in same position.

### DIFF
--- a/styleguide/source/assets/js/form-items.js
+++ b/styleguide/source/assets/js/form-items.js
@@ -338,6 +338,10 @@
           // make the entire subscribe button clickable.
           $('form.salesforce-subscribe-form, .ama__input-wrapper--subscribe-news').on('click', function(e) {
             if ($(this).hasClass('salesforce-subscribe-form')) {
+              // If on subscriptions page, save the scroll position before submitting the form
+              if($('div.view-my-subscription').length) {
+                localStorage.setItem('scrollPos', $(window).scrollTop());
+              };
               $(this).submit();
             }
             else {
@@ -345,6 +349,16 @@
               location.href = link;
             }
           });
+
+          // For subcriptions page, on subscribe button click, reload the page at the same location (i.e offset from top)
+          if($('div.view-my-subscription').length) { 
+            $(window).on('load', function() {
+              if (localStorage.getItem('scrollPos')) {
+                $(window).scrollTop(localStorage.getItem('scrollPos'));
+                localStorage.removeItem('scrollPos');
+              }
+            });
+          };
 
           if($('.paragraph--type--form-50-50 div.success_message').length) {
             $('.paragraph--type--form-50-50').find('.form-content').addClass('success');


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11006: My Subscriptions | Toggle of Subscribe CTA causes page to reload at the top](https://ama-it.atlassian.net/browse/EWL-11006)


## Description
Update form item script to maintain the same top offset when subscribing/unsubscribing to an item on the my subscriptions page.


## To Test
- link styleguide locally.
- clear caches
- while logged in navigate to /my-subscriptions page
- **NOTE** If no content there subscribe to atleast one article/item and refresh the my-subscriptions page
- scroll down and select "Unsubscribe" from one item
- Once page reload confirm the page is in the same vertical position (i.e same amount "scrolled to")
- Confirm item selected is still shown with the button changing to "Subscribe"
- Select subscribe and confirm page reloads with same position again.


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
