### PR TITLE
EWL-11091: correct display of half-width partner promo inline blocks.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -560,6 +560,13 @@ a.ama__membership {
 .text-body {
   promo-embed {
     &.promo-size-full, &.promo-size-half {
+      .partner-promo-inline {
+        [data-size="half"] {
+          &.embedded-entity {
+            flex-direction: column-reverse;
+          }
+        }
+      }
       .embedded-entity {
         flex-direction: column;
         display: flex;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-11091: partner promo](https://ama-it.atlassian.net/browse/EWL-11091)


## Description
1/2 width partner promos are displaying in flex-direction: column, rather than column-reverse. This is breaking the padding and display.


## To Test
- inspect code.


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
