### PR TITLE
bugfix/fix issue where search connector is overlapped by footer on mobile.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
+++ b/styleguide/source/assets/scss/02-molecules/search-result/_search-connector.scss
@@ -81,14 +81,12 @@
     }
   }
   .search-connector-results {
-    float: left;
     display: flex;
     align-items: center;
     width: 100%;
     overflow-x: scroll;
     @include breakpoint($bp-med min-width) {
       overflow-x: hidden;
-      float: none;
       display: block;
     }
     &:after{


### PR DESCRIPTION
**Jira Ticket**
N/A


## Description
Removed float: left from the search connector because why is it there.


## To Test
- check search page at every viewport and make sure search connector displays correctly on mobile, not at the bottom of the page overlapped by the footer.


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
