### PR TITLE
EWL-10920: Update homepage cta styling when using single cta

### DIFF
--- a/styleguide/source/assets/js/mobile-homepage-cta.js
+++ b/styleguide/source/assets/js/mobile-homepage-cta.js
@@ -10,9 +10,6 @@
           // Remove the 'column' class if it exists
           container.removeClass('column');
 
-          // Remove the 'single' class if it exists
-          container.find('a').removeClass('single');
-
           // Find all anchor elements within the ama__mobile-homepage-cta container
           var anchors = container.find('a');
 

--- a/styleguide/source/assets/scss/03-organisms/_homepage_mobile_cta.scss
+++ b/styleguide/source/assets/scss/03-organisms/_homepage_mobile_cta.scss
@@ -41,6 +41,12 @@
     }
   }
 
+  &.single {
+    a {
+      flex: 0;
+    }
+  }
+
   &.column {
     padding: 14px 0;
     a {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


## JIRA Ticket(s)
- [EWL-10920: Mobile homepage CTA enhancements](https://ama-it.atlassian.net/browse/EWL-10920)


## Description:
Adjust styling to display a single cta correctly. Adds config for acquia personalization


## To Test:
- checkout ama-d8 pr: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5114
- import latest config
- clear caches
- add a Mobile Homepage CTA using only one cta
- confirm styling matches the following zeplin: https://app.zeplin.io/project/66aa9cd7fe1e36cba943f003/screen/66aa9ce451f926899d5915b9


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
