### PR TITLE
EWL-11113: Update sign in menu to reduce white space.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -115,7 +115,7 @@
     max-width: 240px;
 
     @include breakpoint($bp-small) {
-      top: 49px;
+      top: 48px;
     }
 
     li {
@@ -134,7 +134,6 @@
    
 
     &__header {
-      @include gutter($padding-top-quarter...);
       @include gutter($padding-bottom-quarter...);
       @include font-size($h5-font-sizes--homepage);
       @include type($kepler-std, $font-weight-regular);


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


## JIRA Ticket(s)
- [EWL-11113: Reduce white space at top of sign in menu](https://ama-it.atlassian.net/browse/EWL-11113)


## Description:
Adjust template and styling of sign in menu to reduce white space between sign in menu and header.


## To Test:
- checkout ama-d8 pr locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5142
- clear caches
- while signed out open sign in menu, confirm white space between top of sign in menu header and main nav matches the following zeplin: https://www.figma.com/design/2thhU0U2OHdLbOQw1M1nS9/Post-Horizon-1-(Future)?node-id=2413-2637&node-type=frame&t=LXCRqw5lywBYfJX9-0


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
