### PR TITLE
EWL-11155: exclude links with a /#/ component from acting as anchor links.

### DIFF
--- a/styleguide/source/assets/js/anchor_links.js
+++ b/styleguide/source/assets/js/anchor_links.js
@@ -29,11 +29,9 @@
 
         // On click of any anchor link
         $('a[href^="#"], a[href*="#"]').bind('click', function (e) {
-          // Don't anchor social links.
-          if (this.getAttribute('data-ga-site_events') == 'social_click') return;
-
-          e.preventDefault(); // prevent hard jump, the default behavior
-
+            // Don't anchor social links. or urls with a /#/ component
+            if (this.getAttribute('data-ga-site_events') == 'social_click' || this.hash.includes('#/')) return;
+            e.preventDefault(); // prevent hard jump, the default behavior
           // Perform animated scrolling
           scrollToAnchor(this.hash);
         });


### PR DESCRIPTION
**Jira Ticket**
- [EWL-11155: exclude links with a /#/ component from acting as anchor links.](https://ama-it.atlassian.net/browse/EWL-11155)


## Description
exclude links with a /#/ component from acting as anchor links.


## To Test
- pull and serve
- click the top right link in the tools and resources block here: https://www.ama-assn.org/practice-management/ama-store
- verify that the link works.


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
