### PR TITLE
AWMEE-685: AMAOne: Safari mobile view for V2 Quick links

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_discover-ama-cta.scss
+++ b/styleguide/source/assets/scss/03-organisms/_discover-ama-cta.scss
@@ -97,6 +97,7 @@ $block-padding: 16px 16px 8px 16px;
       display: grid;
       gap: $gap-sm;
       grid-template-columns: repeat(2, 1fr);
+      align-items: stretch;
 
       @include breakpoint($bp-small) {
         grid-template-columns: repeat(3, 1fr);

--- a/styleguide/source/assets/scss/03-organisms/_personalized-account-hub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_personalized-account-hub.scss
@@ -238,8 +238,7 @@ $quicklink-icons: (
 
       &--compact {
         display: flex;
-        justify-content: flex-start;
-        height: 100%;
+        justify-content: flex-start;        
         @include breakpoint($bp-med) {
           min-width: 100px;
         }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [x] Make this code secure.
- [x] Make this code null and empty safe.
- [x] Make this functionality accessible.
- [x] Make this code more efficient.
- [x] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [AWMEE-685: AMAOne: Safari mobile view for V2 Quick links](https://ama-it.atlassian.net/browse/AWMEE-685)
- [EWL-11163: iOS/Mac display issue for 'Compact Quick Links' WM block](https://ama-it.atlassian.net/browse/EWL-11163)


## Description
Updates styling for issue with Safari mobile (100% height divs were covering article content)


## To Test
- Build and deploy, observe fix on Safari Mobile (or safari browser in a narrow view)

## Visual Regressions
N/A

## Relevant Screenshots/GIFs
Sample running locally:

<img width="538" alt="Screenshot 2024-11-05 at 12 48 48 PM" src="https://github.com/user-attachments/assets/1f1bbc39-4ef6-45ed-8f28-29729afc1df0">



## Remaining Tasks
N/A


## Additional Notes
N/A
---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
