### PR TITLE
EWL-11140: switch colors back. Convert promo h2s to h3s

### DIFF
--- a/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
+++ b/styleguide/source/assets/scss/00-base/__01.mixins/_ama-button.scss
@@ -34,7 +34,7 @@
     &:hover {
       background-color: $hoverComplementary;
       border-color: $hoverComplementary;
-      color: $gray-64;
+      color: $black;
     }
   }
 

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -4,7 +4,7 @@ body {
   -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
   /* stylelint-enable */
-  color: $gray-64;
+  color: $black;
   @include type($myriad-pro, $font-weight-regular);
   @include font-size($p-font-sizes);
 }

--- a/styleguide/source/assets/scss/01-atoms/_display-switch.scss
+++ b/styleguide/source/assets/scss/01-atoms/_display-switch.scss
@@ -45,7 +45,7 @@
       @include type($myriad-pro, $font-weight-semibold);
       border: solid 1px $purple;
       border-radius: 5px;
-      color: $gray-64;
+      color: $black;
       font-size: 18px;
       line-height: 1.5;
       margin-right: 0;

--- a/styleguide/source/assets/scss/01-atoms/_links.scss
+++ b/styleguide/source/assets/scss/01-atoms/_links.scss
@@ -1,7 +1,7 @@
 /* Links */
 a {
   //@include type($myriad-pro, $font-weight-regular);
-  color: $gray-64;
+  color: $black;
   text-decoration: underline;
   outline: 0;
 }
@@ -28,12 +28,12 @@ a {
 
   &:link,
   &:visited {
-    color: $gray-80;
+    color: $black;
   }
   &:active,
   &:hover,
   &:focus {
-    color: $gray-80;
+    color: $black;
     text-decoration: underline;
     background-color: transparent;
   }
@@ -118,7 +118,7 @@ a {
 
   &:link,
   &:visited {
-    color: $gray-80;
+    color: $black;
   }
 
   &:active,

--- a/styleguide/source/assets/scss/01-atoms/_listicle.scss
+++ b/styleguide/source/assets/scss/01-atoms/_listicle.scss
@@ -24,7 +24,7 @@
     &::before {
       content: counter(ama-listicle);
       position: relative;
-      color: $gray-80;
+      color: $black;
       top: 0;
       text-align: center;
       @include type($myriad-pro, $font-weight-semibold);

--- a/styleguide/source/assets/scss/01-atoms/_search-field.scss
+++ b/styleguide/source/assets/scss/01-atoms/_search-field.scss
@@ -25,7 +25,7 @@
     &:active {
       border: 0;
       border-bottom: 1px solid $light-blue;
-      color: $gray-80;
+      color: $black;
       font-style: normal;
     }
   }

--- a/styleguide/source/assets/scss/01-atoms/_select-menu.scss
+++ b/styleguide/source/assets/scss/01-atoms/_select-menu.scss
@@ -8,7 +8,7 @@
   border-radius: 0;
   background: $white;
   font-weight: $font-weight-regular;
-  color: $gray-80;
+  color: $black;
 
   .ama__search-header__options & {
     border: 1px solid $purple;

--- a/styleguide/source/assets/scss/02-molecules/_alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_alert.scss
@@ -1,6 +1,7 @@
 .ama__alert {
     display: flex;
     background-color: $white;
+   color: $gray-64;
     width: 100%;
     align-items: center;
     flex-direction: row;

--- a/styleguide/source/assets/scss/02-molecules/_category-hero.scss
+++ b/styleguide/source/assets/scss/02-molecules/_category-hero.scss
@@ -109,7 +109,7 @@ Styles for the new Category Featured Content Custom Block.
   }
   a.block-wrapper-link,
   a.description-wrapper-link {
-    color: $gray-64;
+    color: $text-navy;
     text-decoration: none;
     display: block;
     &:hover {

--- a/styleguide/source/assets/scss/02-molecules/_global-search.scss
+++ b/styleguide/source/assets/scss/02-molecules/_global-search.scss
@@ -80,7 +80,7 @@
 
     &:focus,
     &:active {
-      color: $gray-80;
+      color: $black;
       font-style: normal;
       border: 1px solid $white;
     }

--- a/styleguide/source/assets/scss/02-molecules/_jama.scss
+++ b/styleguide/source/assets/scss/02-molecules/_jama.scss
@@ -120,7 +120,7 @@
         }
 
         .ama__image__text__subtitle {
-          color: $gray-64;
+          color: $black;
         }
       }
     }

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -13,8 +13,6 @@
   }
 
   &__heading {
-    font-weight: $font-weight-semibold;
-    line-height: 1em;
     color: $white;
   }
 
@@ -28,7 +26,7 @@
     @include gutter-all($padding-all-half...);
     background: $gray-7;
     color: $gray-64;
-    .ama__h2 {
+    .ama__h3 {
       &.partner-embed {
         @include type($myriad-pro, $font-weight-semibold);
       }
@@ -102,7 +100,7 @@
     @include breakpoint($bp-med) {
       padding-right: 119px;
     }
-    h2.ama__h2 {
+    h3.ama__h3 {
       color: $blue;
     }
     p,
@@ -162,7 +160,7 @@
     margin-top: $gutter;
     flex-direction: row-reverse;
     .ama__partner-promo__text {
-      h2.ama__h2 {
+      h3.ama__h3 {
         color: $purple;
       }
     }
@@ -178,7 +176,7 @@
   }
   .ama__partner-promo__text {
     margin-right: 0;
-    h2.ama__h2 {
+    h3.ama__h3 {
       color: $blue;
     }
   }
@@ -217,7 +215,7 @@
     @include breakpoint($bp-small) {
       flex: .34;
     }
-    h2.ama__h2 {
+    h3.ama__h3 {
       color: $blue;
     }
     p {
@@ -257,7 +255,7 @@
   @include gutter($margin-top-full...);
   @include gutter($padding-top-full...);
 
-  .ama__h2 {
+  .ama__h3 {
     color: $purple;
   }
 }    

--- a/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_partner-promo.scss
@@ -107,7 +107,7 @@
     }
     p,
     ul {
-      color: $gray-64;
+      color: $black;
     }
 
     .ama__button {
@@ -221,7 +221,7 @@
       color: $blue;
     }
     p {
-      color: $gray-64;
+      color: $black;
     }
     .ama__button {
       font-weight: $font-weight-bold;

--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -40,7 +40,7 @@
     width: 100%;
     display: grid;
     grid-template-rows: auto auto auto;
-    grid-template-columns: 1fr 6fr 2.5fr;
+    grid-template-columns: 6fr;
     background-color: $bg-gray;
 
     &.align-right,

--- a/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
@@ -34,7 +34,7 @@
                 a {
                     text-decoration: none;
                     position: relative;
-                    color: $gray-64;
+                   color: $black;
                     font-weight: $font-weight-light;
                     display: inline-block;
                     padding-left: 24px;

--- a/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_sign-in-dropdown.scss
@@ -108,6 +108,7 @@
     border-radius: 0 0 8px 8px;
     border: 1px solid $gray-7;
     border-top: 0;
+    color: $black;
     text-align: left;
     display: none;
     flex-direction: column;
@@ -138,6 +139,7 @@
       @include font-size($h5-font-sizes--homepage);
       @include type($kepler-std, $font-weight-regular);
       line-height: 24px;
+      color: $gray-64;
     }
 
     &__group {

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -338,7 +338,7 @@
     font-weight: $font-weight-regular;
     line-height: 1;
   }
-  .ama__h2 {
+  .ama__h3 {
     color: $purple;
   }
   .ama__subscribe-promo__form .ama__checkbox {

--- a/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_subscribe-promo.scss
@@ -360,7 +360,7 @@
 
   .ama__subscribe-promo__form .ama__button {
     background-color: $orange;
-    color: $gray-80;
+    color: $black;
     font-weight: $font-weight-bold;
     width: 100%;
     margin: 0;
@@ -376,7 +376,7 @@
   }
 
   .form-item--error-message.active-error {
-    color: $gray-80;
+    color: $black;
   }
 }
 
@@ -499,7 +499,7 @@
 
   .ama__subscribe-promo__form .ama__button {
     background-color: $orange;
-    color: $gray-80;
+    color: $black;
     font-weight: $font-weight-bold;
     width: 100%;
     max-width: 220px;

--- a/styleguide/source/assets/scss/02-molecules/_table-of-contents.scss
+++ b/styleguide/source/assets/scss/02-molecules/_table-of-contents.scss
@@ -35,7 +35,7 @@
       &:not(:last-child) {
         &:after {
           content: "|";
-          color: $gray-80;
+          color: $black;
           display: inline-block;
           font-weight: $font-weight-light;
           font-size: 16px;

--- a/styleguide/source/assets/scss/02-molecules/_tags.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags.scss
@@ -55,6 +55,7 @@ article[class*='__page-content'] .ama__tags {
     background: $gray-7;
     border: 1px solid transparent;
     border-radius: 16px;
+    color: $black;
     white-space: nowrap;
     height: 34px;
     padding: 5px 15px 4px calc($gutter/2);

--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -45,6 +45,7 @@
             display: block;
         }
         h2 {
+          color: $black;
           margin-bottom: calc($gutter / 2);
         }
         p.ama__h5 {

--- a/styleguide/source/assets/scss/02-molecules/_trending-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_trending-block.scss
@@ -110,7 +110,7 @@
       margin: 0 calc($gutter/2) calc($gutter/4) 0;
       font-size: 18px;
       font-weight: $font-weight-semibold;
-      color: $gray-64;
+      color: $black;
       line-height: 1.11;
       text-decoration: none;
       &:hover {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-form.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-form.scss
@@ -109,6 +109,7 @@
       label {
         font-size: calc($gutter/2);
         text-transform: uppercase;
+        color: $black;
         font-weight: normal;
         &:after {
           content: '';

--- a/styleguide/source/assets/scss/03-organisms/_category-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-nav.scss
@@ -25,7 +25,7 @@
       margin-left: 0;
 
       a {
-        color: $gray-64;
+        color: $black;
         font-size: .66em;
         text-decoration: none;
         margin-right: (calc($gutter/2));
@@ -43,12 +43,12 @@
 
           &:link,
           &:visited {
-            color: $gray-80;
+            color: $black;
           }
           &:active,
           &:hover,
           &:focus {
-            color: $gray-80;
+            color: $black;
             text-decoration: underline;
             background-color: transparent;
           }

--- a/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_category-page-article-stub.scss
@@ -149,6 +149,7 @@
 
   .ama__article-stub__title {
     padding: 0;
+    color: $black;
   }
 
   .ama__article-stub__copy {

--- a/styleguide/source/assets/scss/03-organisms/_discover-ama-cta.scss
+++ b/styleguide/source/assets/scss/03-organisms/_discover-ama-cta.scss
@@ -68,6 +68,7 @@ $block-padding: 16px 16px 8px 16px;
 
   &__title {
     align-self: stretch;
+    color: $black;
     @include type($kepler-std, $font-weight-semibold);
     font-style: normal;
     line-height: normal;

--- a/styleguide/source/assets/scss/03-organisms/_featured-links.scss
+++ b/styleguide/source/assets/scss/03-organisms/_featured-links.scss
@@ -4,7 +4,7 @@
     line-height: calc($gutter * 1.5);
     margin-bottom: calc($gutter / 2);
     padding-left: 0;
-
+    color: $gray-64;
     @include breakpoint($bp-small) {
       font-size: 36px;
       padding-left: 11px;
@@ -39,6 +39,7 @@
           content: attr(data-list);
           font-size: 20px;
           line-height: 26px;
+          color: $black;
           font-weight: $font-weight-semibold;
           position: absolute;
           left: 0;

--- a/styleguide/source/assets/scss/03-organisms/_filter.scss
+++ b/styleguide/source/assets/scss/03-organisms/_filter.scss
@@ -48,6 +48,7 @@
       background: transparent;
       border: 0;
       border-radius: 0;
+      color: $black;
       text-transform: uppercase;
       font-size: 22px;
       line-height: 26px;

--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -120,7 +120,7 @@
        .ama__button {
         @extend %ama__button;
         text-transform: capitalize;
-        color: $gray-80;
+         color: $black;
         background: $orange-medium;
         line-height: 1;
       }

--- a/styleguide/source/assets/scss/03-organisms/_home-page-hero.scss
+++ b/styleguide/source/assets/scss/03-organisms/_home-page-hero.scss
@@ -48,6 +48,7 @@
       font-size: calc($gutter/2);
       line-height: normal;
       margin-bottom: calc($gutter/2);
+      color: $gray-64;
       text-transform: uppercase;
     }
     .ama__video__container {

--- a/styleguide/source/assets/scss/03-organisms/_homepage-social-modual.scss
+++ b/styleguide/source/assets/scss/03-organisms/_homepage-social-modual.scss
@@ -134,6 +134,7 @@
     font-size: 26px;
     line-height: 31px;
     background: unset;
+    color: $black;
     margin-top: 28px;
     margin-bottom: 24px;
     padding: 0;

--- a/styleguide/source/assets/scss/03-organisms/_masthead.scss
+++ b/styleguide/source/assets/scss/03-organisms/_masthead.scss
@@ -207,6 +207,7 @@
   }
 
   .ama__subtitle {
+    color: $black;
     font-weight: normal;
     padding-top: calc($gutter/2);
     font-size: calc($gutter/2);

--- a/styleguide/source/assets/scss/03-organisms/_membership.scss
+++ b/styleguide/source/assets/scss/03-organisms/_membership.scss
@@ -226,7 +226,7 @@ a.ama__membership {
       flex-grow: 2;
     }
   }
-  h2.ama__h2 {
+  h3.ama__h3 {
     margin-top: calc($gutter/2);
     margin-bottom: 0;
     padding-left: 16%;
@@ -364,7 +364,7 @@ a.ama__membership {
         margin-bottom: calc($gutter / 2);
         @include breakpoint($bp-small) {
           margin-top: 0;
-          margin-bottom: 0;
+          margin-bottom: $gutter;
         }
       }
 

--- a/styleguide/source/assets/scss/03-organisms/_personalized-account-hub.scss
+++ b/styleguide/source/assets/scss/03-organisms/_personalized-account-hub.scss
@@ -161,6 +161,7 @@ $quicklink-icons: (
     letter-spacing: 0.5px;
     @include font-size($h3-font-sizes--homepage);
     text-transform: uppercase;
+    color: $gray-64;
     display: flex;
     flex-direction: column;
     gap: $gap-xs;

--- a/styleguide/source/assets/scss/03-organisms/_social-share.scss
+++ b/styleguide/source/assets/scss/03-organisms/_social-share.scss
@@ -112,7 +112,7 @@ a.index-page  {
       left: 0;
     }
     &.copy {
-      color: $gray-64;
+      color: $black;
       padding-top: 0;
       padding-bottom: 0;
       border: none;

--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -70,7 +70,7 @@
 
     a,
     h2 {
-      color: $gray-64;
+      color: $black;
       text-decoration: none;
       display: flex;
       margin-bottom: 0;

--- a/styleguide/source/assets/scss/05-pages/_glossary.scss
+++ b/styleguide/source/assets/scss/05-pages/_glossary.scss
@@ -257,7 +257,7 @@
         margin-right: 12px;
         margin-bottom: calc($gutter/2);
         text-decoration: none;
-        color: $gray-64;
+        color: $black;
         &:hover {
           background: $purple;
           color: $white;
@@ -313,7 +313,7 @@
       }
       &:nth-of-type(even) {
         background-color: $hoverGrayBlue;
-        color: $gray-64;
+        color: $black;
       }
       &:hover,
       &:focus {

--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -145,6 +145,7 @@
         font-size: calc($gutter/2);
         margin-bottom: calc($gutter/4);
         text-transform: uppercase;
+        color: $gray-64;
       }
     }
 

--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -43,7 +43,7 @@
         }
         a.hub_banner_link {
           background: $complementary;
-          color: $gray-64;
+          color: $black;
           &:hover,
           &:focus-visible {
             text-decoration: underline;

--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -50,6 +50,7 @@
       [data-region="date"] {
         font-size: calc($gutter/2);
         padding-right: $gutter;
+        color: $gray-64;
         @include breakpoint($bp-small) {
           padding-bottom: calc($gutter * .5);
         }
@@ -258,6 +259,7 @@
     flex-direction: column;
     justify-content: flex-start;
     align-items: flex-start;
+    color: $gray-64;
     border-bottom: solid .5px $gray-64;
     @include breakpoint($bp-small) {
       flex-direction: row;


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-11140: font updates](https://ama-it.atlassian.net/browse/EWL-11140)


## Description
roll back color changes to black
switch promo blocks from h2s to h3s


## To Test
- pull and serve
- verify fonts are black and promo blocks have h3s


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
