### PR TITLE
EWL-11101: Close sign in drop down after tab through

### DIFF
--- a/styleguide/source/assets/js/sign-in-dropdown.js
+++ b/styleguide/source/assets/js/sign-in-dropdown.js
@@ -26,6 +26,12 @@
                     e.preventDefault();
                 });
 
+                $dropdownBlock.on('focusout', function () {
+                    if (!$dropdownBlock.has(event.relatedTarget).length) {
+                        closeMenu($dropdownTrigger, $dropdownMenu);
+                    }
+                });
+
                 $(document).on('click', function (e) {
                     if (!dropdownBlock.is(e.target) && dropdownBlock.has(e.target).length === 0) {
                         closeMenu(triggerElement, menuElement);


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11101: Close sign in dropdown when user tabs away](https://ama-it.atlassian.net/browse/EWL-11101)


## Description
Adjust script for sign in menu to close sign in menu after tabbing through it.


## To Test
- link styleguide locally
- clear caches
- load site, begin tabbing through until getting to "sign in", select enter to open menu
- continue tabbing and verify you can tab through all links in the menu
- confirm after tabbing through all links and tabbing again the menu closes


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
