### PR TITLE
EWL-11172: Fix sign in drop down menu border clipping issue.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_product-nav.scss
+++ b/styleguide/source/assets/scss/03-organisms/_product-nav.scss
@@ -44,6 +44,7 @@
     @include breakpoint($bp-med) {
       position: static;
       height: auto;
+      min-height: 44px;
       border: 0;
     }
     &:focus-within {
@@ -109,7 +110,7 @@
       display: block;
       @include breakpoint($bp-med) {
         padding: calc($gutter/2) 0;
-        line-height: 16.8px;
+        line-height: 16px;
         font-size: 12px;
       }
       @include breakpoint($bp-large) {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11172: Sign in dropdown should appear behind border-bottom](https://ama-it.atlassian.net/browse/EWL-11172)


## Description
Adjust styling to display sign in dropdown menu "beneath" border main navigation, prevents clipping of sign in dropdown into main nav.


## To Test
- link styleguide locally
- clear caches
- open the sign in dropdown menu
- confirm it appears beneath/below the main navigation
- i.e the sign in menu appears beneath and doesnt clip the border element on the main navigation
- see attached for examples
- repeat as both signed in and anonymous user
- repeate for chrome, firefox and safari browsers

## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs

![1px](https://github.com/user-attachments/assets/6ab1cda1-79b5-4ee6-a007-4a1d6d8e2ea2)


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
