### PR TITLE
EWL-11100: Sign in menu button focus and tab fix

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -326,10 +326,6 @@ header {
       &:hover {
         text-decoration: underline;
       }
-      &:focus-visible {
-        outline: 2px solid $pg-lt-blue;
-        outline-offset: 3px;
-      }
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


## JIRA Ticket(s)
- [EWL-11100: Sign in menu button has only one click/focus target](https://ama-it.atlassian.net/browse/EWL-11100)


## Description:
Adjust templating and styling to fix tab sequence for sign in dropdown menu.


## To Test:
- link ama-d8 PR locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5197
- clear caches
- on any page tab through main navigation until you get to sign in menu
- confirm you can use enter to open the menu 
- confirm you can tab through the menu as normal


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
