### PR TITLE
EWL-11219: Hub Card Button Styling Updates

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -39,7 +39,6 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      height: 57px;
     }
 
     a {

--- a/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
+++ b/styleguide/source/assets/scss/02-molecules/hub/_hub-card.scss
@@ -39,6 +39,7 @@
       display: flex;
       justify-content: center;
       align-items: center;
+      height: 57px;
     }
 
     a {
@@ -63,7 +64,7 @@
   &__button-flex {
       flex-direction: column;
       a {
-        margin: 0 auto 15px auto;
+        margin: 0 0 15px 0;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -86,7 +87,7 @@
         align-items: center;
       }
       a:nth-child(2) {
-        margin: 0 0 0 16px;
+        margin: 0 0 15px 16px;
       }
     }
   }
@@ -140,7 +141,7 @@
   }
 
   &--no-image {
-    @include gutter($padding-bottom-full...);
+    //@include gutter($padding-bottom-full...);
     min-height: 0;
 
     .ama__hub-card__heading {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL11219: Hub Card button alignment on Campaign Landing Pages](https://ama-it.atlassian.net/browse/EWL-11219)

## Description:
On Campaign Landing pages (ex. https://www.ama-assn.org/amaone/why-we-fight-reforming-medicare-payment), if two CTA buttons are used on Hub Cards then the buttons are misaligned and sized differently.

![image](https://github.com/user-attachments/assets/4f3df42a-4642-46df-aa6d-ea880b71a5cf)


## To Test:

**Setup**
- Pull branch [feature/EWL-11219-hub-card-button-allignment](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-11219-hub-card-button-allignment)
- Serve and link SG
- Visit https://ama-one.lndo.site/amaone/why-we-fight-reforming-medicare-payment
- Verify the buttons on the last card are aligned and sized the same
![image](https://github.com/user-attachments/assets/c88e2e58-c638-4ba2-a5dd-beb61c800b80)
- Test other Campaign Landing pages updating cards in the Components section (ex. Text-Only  CTA, CTA 50/50) with two links
![image](https://github.com/user-attachments/assets/4b0e2fc7-585a-4a4f-876b-3cbd86fd223a)

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
