### PR TITLE
EWL-11095: don't scroll when accordions are opened on desktop.

### DIFF
--- a/styleguide/source/assets/js/anchor_links.js
+++ b/styleguide/source/assets/js/anchor_links.js
@@ -30,7 +30,7 @@
         // On click of any anchor link
         $('a[href^="#"], a[href*="#"]').bind('click', function (e) {
             // Don't scroll to anchor social links, urls with a /#/ component, or accordion headings on desktop.
-            if (this.getAttribute('data-ga-site_events') == 'social_click' || this.hash.includes('#/') || ($(this).parent().is('dt') && $(window).width() > 900)) return;
+            if (this.getAttribute('data-ga-site_events') == 'social_click' || this.hash.includes('#/') || ($(this).parent().is('dt') && $(window).width() > 992)) return;
             e.preventDefault(); // prevent hard jump, the default behavior
           // Perform animated scrolling
           scrollToAnchor(this.hash);

--- a/styleguide/source/assets/js/anchor_links.js
+++ b/styleguide/source/assets/js/anchor_links.js
@@ -2,6 +2,7 @@
   Drupal.behaviors.ama_anchors = {
     attach: function (context, settings) {
       $(document).ready(function () {
+          console.log('script loaded');
         // Function to handle scrolling to anchor
         function scrollToAnchor(hash) {
           // Get the height of the header to determine the initial offset
@@ -18,19 +19,26 @@
           var target = $(hash);
           target = target.length ? target : $('[name="' + hash.slice(1) + '"]');
           if (target.length) {
-            $('html, body').animate(
-              {
-                scrollTop: target.offset().top - offset,
-              },
-              500
-            );
+              // Check if the clicked element is within a <dt> and the window width is above 992px
+              if ($(this).closest('dt').length && $(window).width() > 992) {
+                  console.log('returning');
+                  return;
+              }
+              else {
+                  $('html, body').animate(
+                      {
+                          scrollTop: target.offset().top - offset,
+                      },
+                      500
+                  );
+              }
           }
         }
 
         // On click of any anchor link
         $('a[href^="#"], a[href*="#"]').bind('click', function (e) {
             // Don't scroll to anchor social links, urls with a /#/ component, or accordion headings on desktop.
-            if (this.getAttribute('data-ga-site_events') == 'social_click' || this.hash.includes('#/') || (this.tagName.toLowerCase() === 'dt' && $(window).width() > 900)) return;
+            if (this.getAttribute('data-ga-site_events') == 'social_click' || this.hash.includes('#/') || ($(this).parent().is('dt') && $(window).width() > 900)) return;
             e.preventDefault(); // prevent hard jump, the default behavior
           // Perform animated scrolling
           scrollToAnchor(this.hash);

--- a/styleguide/source/assets/js/anchor_links.js
+++ b/styleguide/source/assets/js/anchor_links.js
@@ -2,7 +2,6 @@
   Drupal.behaviors.ama_anchors = {
     attach: function (context, settings) {
       $(document).ready(function () {
-          console.log('script loaded');
         // Function to handle scrolling to anchor
         function scrollToAnchor(hash) {
           // Get the height of the header to determine the initial offset
@@ -19,19 +18,12 @@
           var target = $(hash);
           target = target.length ? target : $('[name="' + hash.slice(1) + '"]');
           if (target.length) {
-              // Check if the clicked element is within a <dt> and the window width is above 992px
-              if ($(this).closest('dt').length && $(window).width() > 992) {
-                  console.log('returning');
-                  return;
-              }
-              else {
-                  $('html, body').animate(
-                      {
-                          scrollTop: target.offset().top - offset,
-                      },
-                      500
+              $('html, body').animate(
+                  {
+                      scrollTop: target.offset().top - offset,
+                  },
+                  500
                   );
-              }
           }
         }
 


### PR DESCRIPTION
**Jira Ticket**
- [EWL-11095: desktop accordion scroll](https://ama-it.atlassian.net/browse/EWL-11095)


## Description
keep accordions from scrolling top on desktop.


## To Test
- open an accordion on desktop.
- Open on mobile
- verify it scrolls on mobile but not desktop


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
