### PR TITLE
EWL-11151: Footer CTAs not displaying correctly

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_hub-page.scss
+++ b/styleguide/source/assets/scss/05-pages/_hub-page.scss
@@ -83,11 +83,17 @@
       @include breakpoint($bp-med max-width) {
         min-height: unset;
         line-height: 1;
-        height: 78px;
+        height: auto;
         padding: 0;
-        > div:first-of-type {
-          margin-bottom: 0;
+        border-top: 1px solid $gray-30;
+        > div {
           min-height: unset;
+          margin: 14px 0;
+
+          &:first-of-type {
+            margin-bottom: 0;
+
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11151: Footer CTAs not displaying correctly](https://ama-it.atlassian.net/browse/EWL-11151)


## Description
Fixes mobile styling for hub page sticky banner at bottom.


## To Test
- Pull this branch and serve styleguide to AMAD8
- Go to a Campaign Landing Page with a Hub Page Banner or add a Hub Page Banner to an existing Campaign Landing Page
- example: https://ama-one.lndo.site/amaone/why-we-fight-reforming-medicare-payment
- View page on mobile and verify the banner styling matches the zeplin:
https://app.zeplin.io/project/64df68b2df6fee220c92edcf/screen/65033af4f77df067d0e3dbfb 


**BEFORE:**
<img width="502" alt="Screenshot 2024-10-23 at 2 38 35 PM" src="https://github.com/user-attachments/assets/416bedca-ea99-4141-bf78-0822dc01d00b" />

**AFTER:**
![image](https://github.com/user-attachments/assets/c9a6decd-186e-42d3-9010-e3239ea4ded1)



## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
