### PR TITLE
EWL-11240: Update Share Bar Height and Scroll Margins

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_social-share.scss
+++ b/styleguide/source/assets/scss/03-organisms/_social-share.scss
@@ -250,7 +250,9 @@
   position: relative;
   .share-row {
     .share {
-
+      @include breakpoint($bp-small) {
+        height: 36px;
+      }
       &.is-sticky {
         .share-wrapper {
           display: flex;

--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -207,9 +207,9 @@
   h2[id],
   h3[id],
   .ckeditor-accordion-container > dl dt > a > h2 {
-    scroll-margin-top: 210px;
+    scroll-margin-top: 203px;
     @include breakpoint($bp-small) {
-      scroll-margin-top: 110px;
+      scroll-margin-top: 103px;
     }
   }
   // Update margin for logged in users
@@ -217,7 +217,7 @@
     h2[id],
     h3[id],
     .ckeditor-accordion-container > dl dt > a > h2 {
-      scroll-margin-top: 180px; 
+      scroll-margin-top: 173px; 
     }
   }
 


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWL11240: Article Action Bar](https://ama-it.atlassian.net/browse/EWL-11240)

## Description:
Restore height restriction on share bar `height: 36px` to prevent sticky wrapper from affecting position of anchors on page.  Also updated `scroll-margin-top` values to match new share bar height.

**BEFORE (Contact h2/anchor in middle of page)**
![image](https://github.com/user-attachments/assets/9cbea049-00bf-4332-ade9-189e01413bb6)

****AFTER  (Contact h2/anchor at top of page)**
![image](https://github.com/user-attachments/assets/3c872c6c-5cd9-4d85-9425-6e91ef2a20be)


## To Test:

**Setup**
- Pull branch [bugfix/EWL-11240-fix-share-bar-height](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/EWL-11240-fix-share-bar-height)
- Serve and link SG
- Visit any Article page on the site with TOC links
- Click the TOC links and verify the position of the resulting anchor matches current PROD positioning

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
