### PR TITLE
EWL-11181: Remove bottom border from category/org nav.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_homepage.scss
+++ b/styleguide/source/assets/scss/05-pages/_homepage.scss
@@ -74,7 +74,6 @@
     @include breakpoint($bp-med) {
       display: flex;
       align-items: center;
-      border-bottom: .5px solid $purple;
       justify-content: space-between;
       padding: 0 40px;
       padding-top: 10px;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11181: Remove bottom border from Cat/Org Nav](https://ama-it.atlassian.net/browse/EWL-11181)


## Description
Remove bottom border styling from category nav on homepage.


## To Test
- link styleguide locally
- clear caches
- on homepage confirm no purple border appears between category/org nav and the homepage hero block


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
![Screenshot 2025-02-18 at 2 42 32 PM](https://github.com/user-attachments/assets/2b5b7aa7-942a-4a45-8fde-2b93205015b7)



## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
