### PR TITLE
EWL-11089: Fix related coverage link styling on mobile.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_related_coverage.scss
+++ b/styleguide/source/assets/scss/03-organisms/_related_coverage.scss
@@ -34,16 +34,17 @@ promo-embed {
     .link {
       margin-bottom: calc($gutter * .5);
       p {
-        font-size: calc($gutter/2);
+        font-size: 14px;
         @include breakpoint($bp-small) {
-          font-size: 20px;
-        }
-        @include breakpoint($bp-med) {
           font-size: 18px;
         }
         a {
           color: $blue;
           text-decoration: none;
+          font-size: 14px;
+          @include breakpoint($bp-small) {
+            font-size: 18px;
+          }
           &:hover {
             text-decoration: underline;
           }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11089: Article | Related Coverage custom block fonts displaying in two different sizes on mobile](https://ama-it.atlassian.net/browse/EWL-11089)


## Description
Adjust styling of links within related coverage blocks on mobile.


## To Test
- link styleguide locally
- clear caches
- navigate to article with related coverage block (ex: /practice-management/sustainability/pearl-week-add-flexibility-patient-scheduling)
- confirm on both mobile and desktop the font sizes match the following zeplin: https://app.zeplin.io/project/6455149a09779f23db97e23e/screen/64a70dcb958d86515895b411


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
