### PR TITLE
EWL-11126: Adjust spacing on forum author listing.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_forum-listing.scss
+++ b/styleguide/source/assets/scss/02-molecules/_forum-listing.scss
@@ -111,7 +111,7 @@
         }
         .author {
           display: flex;
-          a {
+          [property="schema:name"] {
             margin-left: 4px;
           }
           span {
@@ -343,7 +343,7 @@ table[id^="forum-topic"] {
   tbody tr {
     td {
       &[data-th^="Report"],
-      &[data-th^="Resolution"],{
+      &[data-th^="Resolution"] {
         text-align: left;
         @include breakpoint($bp-large) {
           display: table-cell;
@@ -509,9 +509,6 @@ table {
         text-align: center;
         line-height: 1.3;
         padding: 0 calc($gutter/4);
-      }
-      .glyph {
-
       }
     }
   }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11126: Space missing between "By" and comment author name](https://ama-it.atlassian.net/browse/EWL-11126)


## Description
Adjust styling to preserve spacing between text and author name in reply column on forum listings for non-member users.


## To Test
- link styleguide locally
- clear caches
- as a non-member user (or anonymous) navigate to a forum listing page (ex: /orc/house-delegates?sort=asc&order=Topic)
- confirm there is space between the word "by" and author name


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
