### PR TITLE
EWL-11292: Update Promo as Inline block CTA Focus States

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -99,6 +99,11 @@
             background-color: $hoverPurple;
             color: $white;
           }
+          &:focus-visible {
+            color: $white;
+            border-color: $purple;
+            background-color: $hoverPurple;
+          }
         }
         @include breakpoint($bp-small) {
           width: auto;
@@ -111,8 +116,9 @@
         }
 
         &:focus-visible {
-          background-color: initial;
-          border-color: initial;
+          color: $purple;
+          border: 1px solid #E4E3E6;
+          background-color: $white;
           outline: 2px solid $blue;
           outline-offset: 3px;
         }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.

## JIRA Ticket(s)
[EWL-11292: Allow selection of primary or secondary CTA styling for inline promos](https://ama-it.atlassian.net/browse/EWL-11292)

## Description:
Based on QA feedback, the focus state for Promo as Inline block CTAs does not match current FIGMA design.  This PR updates styling to sync focus states for CTAs set as either primary or secondary with the FIGMA design.



## To Test:

**Setup**
- Pull branch [feature/EWL-11292-fix-focus-background-color](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-11292-fix-focus-background-color) into SG directory
- Serve SG with `lando gulp serve`
- Link SG with `lando link-styleguides -a one` in root directory
- Run `lando drush @one.local cr`
- Go to https://ama-one.lndo.site/
- Add a new Promo as Inline block with "CTA Styling" set to "Primary CTA"
- Add block to body of Article page
- View Article and confirm focus state of block CTA (primary) matches the following Figma:
https://www.figma.com/design/kYbeZku68uhCuAgajqg5Fs/Article-Page?node-id=40002975-1378&m=devCan't find link 
![image](https://github.com/user-attachments/assets/df636f32-6e0d-4ac1-a65c-a49edf902fbc)
- Edit the same block, and save with the "Secondary CTA" option selected
- View Article and confirm focus state of block CTA (secondary) matches the following Figma:
https://www.figma.com/design/OdVVDlbNphsgBBbccrapbs/AMA-Design-System?node-id=110-14&p=f&t=ADmjde5AEex48jGa-0
![image](https://github.com/user-attachments/assets/aaf46764-a65f-4e12-ad7d-c6edc1fd4d46)


## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)






