### PR TITLE
EWL-11292: Update Promo as Inline Primary Button Focus State

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_promo.scss
+++ b/styleguide/source/assets/scss/02-molecules/_promo.scss
@@ -81,7 +81,6 @@
       padding: 0 !important;
       .ama__button {
         @extend .ama__button--homepage-secondary;
-        border: 1px solid #E4E3E6;
         border-radius: 8px;
         text-transform: none;
         padding: 12px 16px 12px 16px;
@@ -92,17 +91,19 @@
         font-weight: 700;
         max-width: 100%;
         width: 100%;
+        &:not(.primary) {
+          border: 1px solid #E4E3E6;
+        }
         &.primary {
-          background-color: $homepagePurple;
           color: $white;
+          background-color: $homepagePurple;
           &:hover {
-            background-color: $hoverPurple;
             color: $white;
+            background-color: $purple;
           }
           &:focus-visible {
             color: $white;
-            border-color: $purple;
-            background-color: $hoverPurple;
+            background-color: $homepagePurple;
           }
         }
         @include breakpoint($bp-small) {
@@ -111,13 +112,11 @@
 
         &:hover {
           color: $purple;
-          border: 1px solid #E4E3E6;
           background-color: $gray-4;
         }
 
         &:focus-visible {
           color: $purple;
-          border: 1px solid #E4E3E6;
           background-color: $white;
           outline: 2px solid $blue;
           outline-offset: 3px;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [x] Make this code secure.
- [x] Make this code null and empty safe.
- [x] Make this functionality accessible.
- [x] Make this code more efficient.
- [x] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.

## JIRA Ticket(s)
[EWL-11292: Allow selection of primary or secondary CTA styling for inline promos](https://ama-it.atlassian.net/browse/EWL-11292)

## Description:
Previous [PR](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/pull/1901) updated primary and secondary button focus states for Promo As Inline blocks to current brand styling (PROD).  That ticket passed QA but may get pushed back in UAT because business wants the new brand styling applied.

Please Note: The #44197D color code called for in the FIGMA for the Primary hover state is not part of our current SG.  The SG variable $purple provides the color code #46166B.  Discussed with Chrissy and this PR will implement the darker color on hover but with the current #46166B.  The update to the new color (#44197D) will be part of a separate ticket once that color is introduced into the SG.

**Currnent Focus and Hover States:**

![image](https://github.com/user-attachments/assets/df636f32-6e0d-4ac1-a65c-a49edf902fbc)

![image](https://github.com/user-attachments/assets/c20ed591-5c6d-4842-a765-5cbcb88650de)


**Expected Focus and Hover States (new styling):**

![image](https://github.com/user-attachments/assets/e6e77cbe-6994-48be-9e9a-5dacdf6218c8)

![image](https://github.com/user-attachments/assets/a0ec72cc-d875-4fdc-af6c-df5e1152422d)

## To Test:

**Setup**
- Pull branch [feature/EWL-11292-update-primary-focus-state-to-new-styling](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/feature/EWL-11292-update-primary-focus-state-to-new-styling) into SG directory
- Serve SG with `lando gulp serve`
- Link SG with `lando link-styleguides -a one` in root directory
- Run `lando drush @one.local cr`
- Go to https://ama-one.lndo.site/
- Edit an existing or add a new Promo as Inline block with "CTA Styling" set to "Primary CTA"
- Add block to body of Article page (if new)
- View Article and confirm focus and hover states of block CTA (primary) matches the following Figma:
https://www.figma.com/design/kYbeZku68uhCuAgajqg5Fs/Article-Page?node-id=40002975-1378&m=devCan't find link 

- Edit the same block, and save with the "Secondary CTA" option selected
- View Article and confirm focus and hover states of block CTA (secondary) matches the following Figma:
https://www.figma.com/design/OdVVDlbNphsgBBbccrapbs/AMA-Design-System?node-id=110-14&p=f&t=ADmjde5AEex48jGa-0
![image](https://github.com/user-attachments/assets/aaf46764-a65f-4e12-ad7d-c6edc1fd4d46)
![image](https://github.com/user-attachments/assets/4f96d342-c4dd-4367-9360-ac4ba9f629cc)


## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)






