### PR TITLE
EWL-11284: set event details to flex start and 100% width.

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -312,7 +312,9 @@
       display: flex;
       flex-direction: column;
       flex: 1;
-      align-self: auto;
+      align-self: flex-start;
+      width: 100%;
+      padding-left: calc($gutter * .75);
       @include breakpoint($bp-small) {
         padding-left: calc($gutter/2);
         flex: .39;
@@ -350,7 +352,7 @@
       flex-direction: row;
       margin-top: 28px;
       flex-wrap: wrap;
-      gap: 14px;
+      gap: 14px;\
       .article-event-link {
         @include ama-button ("rounded", "homepage");
         padding: 12.5px 16px;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-11284: Ticket Title](https://ama-it.atlassian.net/browse/EWL-11284)


## Description
event details were center aligned on mobile.
Set to flex-start, 100% width and 21px left padding per figma

## To Test
-pull and serve
- go to an article and add all event info.
- verify that on mobile the event details are left aligned per figma


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
