### PR TITLE
EWL-11306: hide block before padding overflow

### DIFF
--- a/styleguide/source/assets/js/search-suggestions.js
+++ b/styleguide/source/assets/js/search-suggestions.js
@@ -34,7 +34,8 @@
             const searchSuggestionsBlock = document.querySelector('.search-suggestions-block');
             const inputElement = context.querySelector('.ama__global-search form input#edit-search, .ama__global-search form input[id^="edit-search--"]');
 
-            if (!searchSuggestionsWrapper || !searchSuggestionsBlock || !inputElement) {
+            const shouldShow = inputElement.value.trim() === '';
+            if (shouldShow && (!searchSuggestionsWrapper || !searchSuggestionsBlock || !inputElement)) {
                 console.log('search-suggestions.js - One or more required elements are missing.');
                 return; // Exit the function if any required element is missing
             }

--- a/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
@@ -1,10 +1,10 @@
 .search-suggestions-wrapper {
     display: none;
     &.show {
-      @media (min-width: 600px) and (max-width: 720px) {
+      @media (min-width: 600px) and (max-width: 740px) {
         display: none;
       }
-      @media (min-width: 720px) and (max-width: 768px) {
+      @media (min-width: 740px) and (max-width: 768px) {
         overflow: hidden;
       }
         display: block;

--- a/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
@@ -4,6 +4,9 @@
       @media (min-width: 600px) and (max-width: 720px) {
         display: none;
       }
+      @media (min-width: 720px) and (max-width: 768px) {
+        overflow: hidden;
+      }
         display: block;
         border-top: 1px solid $search-suggestions-white;
         z-index: 600;

--- a/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
+++ b/styleguide/source/assets/scss/02-molecules/_search-suggestions.scss
@@ -1,6 +1,9 @@
 .search-suggestions-wrapper {
     display: none;
     &.show {
+      @media (min-width: 600px) and (max-width: 720px) {
+        display: none;
+      }
         display: block;
         border-top: 1px solid $search-suggestions-white;
         z-index: 600;
@@ -9,9 +12,12 @@
         top: 52px;
         @include breakpoint($bp-small) {
             margin-left: 0;
-            width: 88%;
+            width: 83%;
             top: 43px;
         }
+      @include breakpoint($bp-med) {
+        width: 88%;
+      }
         // This media query was very intentional so im keeping it just incase
         // @media (min-width: 900px) and (max-width: 991px) {
         //     width: 284px;


### PR DESCRIPTION
**Jira Ticket**
- [EWL-11306: header redesign](https://ama-it.atlassian.net/browse/EWL-11306)


## Description
Hide the block from 600px (mobile) to 720px, the moment the padding is past.
in case of long words, hide the overflow from the moment the block starts to shrink to the moment it's hidden
adjust tablet width of block
fix search suggestions console message so it only fires if the block should be shown but isn't there.


## To Test
- pull and serve
- check the behavior of the search suggestions block as the page is resized.


## Visual Regressions
N/A


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
