### PR TITLE
DCP-230: Restore Current (PROD) Sign-In Dropdown

### DIFF
--- a/styleguide/source/_patterns/02-molecules/dr-finder-sign-in-dropdown/dr-finder-sign-in-dropdown.json
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-sign-in-dropdown/dr-finder-sign-in-dropdown.json
@@ -1,0 +1,6 @@
+{
+  "signInDropdown": {
+    "text": "Sign In",
+    "menuClass": "drfinder__sign-in-dropdown__menu"
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/dr-finder-sign-in-dropdown/dr-finder-sign-in-dropdown.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-sign-in-dropdown/dr-finder-sign-in-dropdown.twig
@@ -5,7 +5,6 @@
     <i class="drfinder__sign-in-dropdown__caret"></i>
   </div>
   <div class="{{ signInDropdown.menuClass }}" >
-    <div class="drfinder__sign-in-dropdown__menu__header">{{ signInDropdown.header }}</div>
     {% if signInDropdown.account is null %}
       {% for menuGroups in signInDropdown.menuGroups %}
         <ul class="drfinder__sign-in-dropdown__menu__group">

--- a/styleguide/source/_patterns/02-molecules/dr-finder-sign-in-dropdown/dr-finder-sign-in-dropdown.twig
+++ b/styleguide/source/_patterns/02-molecules/dr-finder-sign-in-dropdown/dr-finder-sign-in-dropdown.twig
@@ -1,0 +1,24 @@
+<div id="drfinder__sign-in-dropdown" class="drfinder__sign-in-dropdown">
+  <div class="drfinder__sign-in-dropdown__trigger">
+    <i class="drfinder__sign-in-dropdown__trigger__icon drfinder__sign-in-dropdown__trigger__icon__user icon--usermenu-outline"></i>
+    <span class="drfinder__sign-in-dropdown__trigger__text">{{ signInDropdown.text }}</span>
+    <i class="drfinder__sign-in-dropdown__caret"></i>
+  </div>
+  <div class="{{ signInDropdown.menuClass }}" >
+    <div class="drfinder__sign-in-dropdown__menu__header">{{ signInDropdown.header }}</div>
+    {% if signInDropdown.account is null %}
+      {% for menuGroups in signInDropdown.menuGroups %}
+        <ul class="drfinder__sign-in-dropdown__menu__group">
+          {% for item in menuGroups.group %}
+            {% set link = item.link %}
+            <li>
+              {% include "@atoms/link/link.twig" %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endfor %}
+    {% else %}
+      {{ signInDropdown.account }}
+    {% endif %}
+  </div>
+</div>

--- a/styleguide/source/_patterns/03-organisms/dr-finder-main-navigation/dr-finder-main-navigation.twig
+++ b/styleguide/source/_patterns/03-organisms/dr-finder-main-navigation/dr-finder-main-navigation.twig
@@ -6,6 +6,6 @@
   <div class="container">
     {% include '@molecules/dr-finder-explore-menu.twig' with { drFinderExploreMenu : drFinderMainNavigation.exploreMenu } %}
     {% include '@atoms/site-logo/site-logo.twig' with { siteLogo : drFinderMainNavigation.siteLogo } %}
-    {% include '@molecules/sign-in-dropdown.twig' with { signInDropdown : drFinderMainNavigation.signInDropdown } %}
+    {% include '@molecules/dr-finder-sign-in-dropdown.twig' with { signInDropdown : drFinderMainNavigation.signInDropdown } %}
   </div>
 </div>

--- a/styleguide/source/assets/js/dr-finder-sign-in-dropdown.js
+++ b/styleguide/source/assets/js/dr-finder-sign-in-dropdown.js
@@ -1,0 +1,113 @@
+/**
+ * @file
+ * Attaches behavior to interact with user sign in menu
+ */
+(function ($, Drupal) {
+    Drupal.behaviors.drfinderSignInMenu = {
+        attach: function (context, settings) {
+            const $dropdownBlock = $('.drfinder__sign-in-dropdown');
+            const $dropdownTrigger = $('.drfinder__sign-in-dropdown__trigger');
+            const $dropdownMenu = $('.drfinder__sign-in-dropdown__menu');
+            const $signInLink = $('.drfinder__sign-in-dropdown__trigger__text');
+            let isDropdownOpen = false;
+
+            function setupDropDown(dropdownBlock, triggerElement, menuElement) {
+                dropdownBlock.off('click').on('click', function (e) {
+                    e.stopPropagation();
+                    if (isDropdownOpen) {
+                        closeMenu(triggerElement, menuElement);
+                    } else {
+                        openMenu(triggerElement, menuElement);
+                    }
+                    isDropdownOpen = !isDropdownOpen;
+                });
+
+                $signInLink.on('click', function (e) {
+                    e.preventDefault();
+                });
+
+                $dropdownBlock.on('focusout', function () {
+                    if (!$dropdownBlock.has(event.relatedTarget).length) {
+                        closeMenu($dropdownTrigger, $dropdownMenu);
+                    }
+                });
+
+                $(document).on('click', function (e) {
+                    if (!dropdownBlock.is(e.target) && dropdownBlock.has(e.target).length === 0) {
+                        closeMenu(triggerElement, menuElement);
+                        isDropdownOpen = false;
+                    }
+                });
+
+                dropdownBlock.on('mouseenter', function () {
+                    clearTimeout(dropdownBlock.timeoutId);
+                }).on('mouseleave', function () {
+                    dropdownBlock.timeoutId = setTimeout(function () {
+                        closeMenu(triggerElement, menuElement);
+                        isDropdownOpen = false;
+                    }, 2000);
+                });
+
+                menuElement.on('click', function (e) {
+                    if (!$(e.target).is('a')) {
+                        e.stopPropagation();
+                    }
+                });
+            }
+
+            function openMenu(parentElement, menuElement) {
+                parentElement.addClass('open');
+                menuElement.show().addClass('drfinder__sign-in-dropdown__menu--open');
+            }
+
+            function closeMenu(parentElement, menuElement) {
+                if ( Cookies.get('signInCta') !== '1' ) Cookies.set('signInCta', '1');
+                parentElement.removeClass('open');
+                menuElement.hide().removeClass('drfinder__sign-in-dropdown__menu--open');
+            }
+
+            setupDropDown($dropdownBlock, $dropdownTrigger, $dropdownMenu);
+        }
+    };
+})(jQuery, Drupal);
+
+/**
+ * @file
+ * Attaches behavior to open dismissable sign-in menu when visiting the site
+ */
+(function ($, Drupal) {
+    Drupal.behaviors.signInCta = {
+        attach: function (context, settings) {
+
+            function hasNoCtaCookie() {
+                const signInCtaCookie = Cookies.get('signInCta');
+                return signInCtaCookie !== '1'
+            }
+            function setCtaCompleted(e){
+                Cookies.set('signInCta', '1');
+            }
+            function bindCompletedEvents(dropdownBlock){
+                $(document).on('click', setCtaCompleted);
+                dropdownBlock.on('click', setCtaCompleted);
+            }
+            function startCta(signInDropdown, signInDropdownMenu){
+                if (hasNoCtaCookie()) {
+                    signInDropdown.addClass('open');
+                    signInDropdownMenu.addClass('drfinder__sign-in-dropdown__menu--open');
+
+                    setTimeout(function () {
+                        signInDropdown.removeClass('open');
+                        signInDropdownMenu.removeClass('drfinder__sign-in-dropdown__menu--open');
+                        setCtaCompleted()
+                    }, 7000);
+                }
+            }
+            const $dropdownBlock = $('.drfinder__sign-in-dropdown');
+            const $signInDropdownTrigger = $('.drfinder__sign-in-dropdown__trigger');
+            const $signInDropdownMenu = $('.drfinder__sign-in-dropdown__menu');
+            bindCompletedEvents($dropdownBlock)
+            startCta($signInDropdownTrigger, $signInDropdownMenu)
+        }
+    };
+})(jQuery, Drupal);
+  

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-alert.scss
@@ -22,7 +22,7 @@
 
     &__text {
         // Override main font.
-        @include type($myriad-pro, $font-weight-bold);
+        @include type($myriad-pro, $font-weight-semibold);
         margin-bottom: 0;
         margin-right: 25px;
 

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-sign-in-dropdown.scss
@@ -1,0 +1,213 @@
+.drfinder__sign-in-dropdown {
+    display: flex;
+    position: relative;
+    background-color: $purple;
+    align-items: center;
+    border-left: 1px solid #E4E3E6;
+    margin-left: auto;
+    width: auto;
+    height: 60px;
+    &:hover {
+      cursor: default;
+    }
+    a {
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  
+    @include breakpoint($bp-small) {
+      display: flex;
+      height: 44px;
+      border-left: 0;
+    }
+  
+    &__user-icon {
+        background-size: 24px 25px;
+        min-height: 24px;
+        min-width: 25px;
+        max-height: 24px;
+        max-width: 25px;
+    }
+
+    &__caret {
+        margin-left: 21px;
+        margin-top: 2px;
+        width: 0;
+        height: 0;
+        border-left: 5px solid transparent;
+        border-right: 5px solid transparent;
+        border-top: 10px solid #ffffff;
+      }
+
+    &__trigger {
+      display: flex;
+      align-items: center;
+      height: 24px;
+      cursor: pointer;
+      margin: 0 auto;
+      
+      &.open &__icon {
+        &__arrow {
+          transform: rotate(180deg);
+          transition: transform .3s ease;
+        }
+      }
+  
+      &__icon {
+        display: inline-block;
+  
+        &__user {
+          background-size: 24px 25px;
+          min-height: 24px;
+          min-width: 24px;
+          max-height: 24px;
+          max-width: 25px;
+  
+          @include breakpoint($bp-small) {
+            @include gutter($padding-left-quarter...);
+          }
+        }
+  
+        &__arrow {
+          display: none;
+          padding-left: 4px;
+          
+          @include breakpoint($bp-large) {
+            display: block;
+            width: 20px;
+            height: 20px;
+            background-image: url('../icons/svg/icon-chevron.svg');
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: left top;
+            align-self: center;
+            transform: rotate(0deg);
+            transition: transform .3s ease;
+            position: absolute;
+            right: -23px;
+            top: 14px;
+          }
+        }
+      }
+  
+      &__text {
+        display: none;
+        text-align: right;
+  
+        @include breakpoint($bp-large) {
+          flex-grow: 1;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: inline-block;
+          margin-left: 14px;
+        }
+      }
+  
+      // Some css foo to make the focus outline work on the parent of the link element
+      &:has(.drfinder_sign-in-dropdown__trigger__text:focus-visible) {
+        outline: 2px solid $blue;
+        outline-offset: 3px;
+      }
+    }
+  
+    &__menu {
+      @include gutter($padding-left-half...);
+      @include gutter($padding-right-half...);
+      @include gutter($padding-top-half...);
+      @include gutter($padding-bottom-half...);
+      position: absolute;
+      top: 61px;
+      right: 0;
+      box-shadow: 0px 8px 20px -4px rgba(23, 24, 24, 0.12);
+      background-color: $white;
+      border-radius: 0 0 8px 8px;
+      border: 1px solid $gray-7;
+      border-top: 0;
+      color: $black;
+      text-align: left;
+      display: none;
+      flex-direction: column;
+      min-width: 210px;
+      max-width: 240px;
+  
+      @include breakpoint($bp-small) {
+        top: 54px;
+      }
+  
+      li {
+        list-style: none;
+        @include gutter($padding-top-quarter...);
+        @include gutter($padding-bottom-quarter...);
+        text-align: right;
+  
+        a {
+          display: block;
+          font-size: 18px;
+          line-height: 1.5;
+        }
+      }
+  
+      &--open {
+        display: block;
+      }
+     
+  
+      &__header {
+        @include gutter($padding-bottom-quarter...);
+        @include font-size($h5-font-sizes--homepage);
+        @include type($kepler-std, $font-weight-regular);
+        line-height: 24px;
+        color: $black;
+      }
+  
+      &__group {
+        @include gutter($padding-top-quarter...);
+        @include gutter($padding-bottom-quarter...);
+      }
+  
+      &__button {
+        &--sign-in {
+          text-transform: none;
+          border-radius: 6px;
+          height: 44px;
+          max-height: 44px;
+          @include gutter($padding-top-quarter...);
+          @include gutter($padding-bottom-quarter...);
+        }
+      }
+      &__create-account, &__become-member {
+        text-align: center
+      }
+      &__link {
+        &__user {
+          @include gutter($padding-bottom-quarter...);
+        }
+        text-align: left;
+      }      
+    }
+  }
+  
+  
+  // Here we will build new siogn-in menu styling that isn't dumb as hell.
+  .authenticated {
+    &.ama__sign-in-dropdown__menu {
+      padding-top: 0;
+      padding-bottom: 0;
+      padding-left: 0;
+      padding-right: 0;
+      &__header {
+        color: $black;
+      }
+      .ama__sign-in-dropdown__menu__group {
+        padding-left: calc($gutter / 2);
+        padding-right: calc($gutter / 2);
+        &:nth-child(2) {
+          border-top: 1px solid $gray-7;
+          border-bottom: 1px solid $gray-7;
+        }
+      }
+    }
+  }
+

--- a/styleguide/source/assets/scss/02-molecules/_dr-finder-sign-in-dropdown.scss
+++ b/styleguide/source/assets/scss/02-molecules/_dr-finder-sign-in-dropdown.scss
@@ -31,18 +31,24 @@
     }
 
     &__caret {
-        margin-left: 21px;
-        margin-top: 2px;
-        width: 0;
-        height: 0;
-        border-left: 5px solid transparent;
-        border-right: 5px solid transparent;
-        border-top: 10px solid #ffffff;
+        display: none;
+        @include breakpoint($bp-small) {
+            display: block;
+            margin-left: 21px;
+            margin-top: 2px;
+            width: 0;
+            height: 0;
+            border-left: 5px solid transparent;
+            border-right: 5px solid transparent;
+            border-top: 10px solid #ffffff;
+        }
       }
 
     &__trigger {
       display: flex;
+      width: 70px;
       align-items: center;
+      justify-content: center;
       height: 24px;
       cursor: pointer;
       margin: 0 auto;
@@ -68,27 +74,7 @@
             @include gutter($padding-left-quarter...);
           }
         }
-  
-        &__arrow {
-          display: none;
-          padding-left: 4px;
-          
-          @include breakpoint($bp-large) {
-            display: block;
-            width: 20px;
-            height: 20px;
-            background-image: url('../icons/svg/icon-chevron.svg');
-            background-size: contain;
-            background-repeat: no-repeat;
-            background-position: left top;
-            align-self: center;
-            transform: rotate(0deg);
-            transition: transform .3s ease;
-            position: absolute;
-            right: -23px;
-            top: 14px;
-          }
-        }
+
       }
   
       &__text {
@@ -109,6 +95,10 @@
       &:has(.drfinder_sign-in-dropdown__trigger__text:focus-visible) {
         outline: 2px solid $blue;
         outline-offset: 3px;
+      }
+
+      @include breakpoint($bp-small) {
+        width: auto;
       }
     }
   
@@ -153,33 +143,17 @@
         display: block;
       }
      
-  
-      &__header {
-        @include gutter($padding-bottom-quarter...);
-        @include font-size($h5-font-sizes--homepage);
-        @include type($kepler-std, $font-weight-regular);
-        line-height: 24px;
-        color: $black;
-      }
-  
       &__group {
         @include gutter($padding-top-quarter...);
         @include gutter($padding-bottom-quarter...);
-      }
-  
-      &__button {
-        &--sign-in {
-          text-transform: none;
-          border-radius: 6px;
-          height: 44px;
-          max-height: 44px;
-          @include gutter($padding-top-quarter...);
-          @include gutter($padding-bottom-quarter...);
+        padding-left: calc($gutter / 2);
+        padding-right: calc($gutter / 2);
+        &:nth-child(1) {
+          border-top: 1px solid $gray-7;
+          border-bottom: 1px solid $gray-7;
         }
       }
-      &__create-account, &__become-member {
-        text-align: center
-      }
+
       &__link {
         &__user {
           @include gutter($padding-bottom-quarter...);
@@ -188,26 +162,5 @@
       }      
     }
   }
-  
-  
-  // Here we will build new siogn-in menu styling that isn't dumb as hell.
-  .authenticated {
-    &.ama__sign-in-dropdown__menu {
-      padding-top: 0;
-      padding-bottom: 0;
-      padding-left: 0;
-      padding-right: 0;
-      &__header {
-        color: $black;
-      }
-      .ama__sign-in-dropdown__menu__group {
-        padding-left: calc($gutter / 2);
-        padding-right: calc($gutter / 2);
-        &:nth-child(2) {
-          border-top: 1px solid $gray-7;
-          border-bottom: 1px solid $gray-7;
-        }
-      }
-    }
-  }
+
 

--- a/styleguide/source/assets/scss/03-organisms/_dr-finder-main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_dr-finder-main-navigation.scss
@@ -13,9 +13,4 @@
       list-style: none;
     }
   }
-  // Send this to the right.
-  .ama__sign-in-dropdown {
-    margin-left: auto;
-  }
 }
-


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.

## JIRA Ticket(s)
[DCP-230: Override Latest AMA One SG Changes](https://ama-it.atlassian.net/browse/DCP-230)

## Description:
Recent SG changes for the AMA One header navigation (specifically the sign-in dropdown) has caused regression to the expected theme for Find A Doctor.  Rather than sync the site with the new changes, the business would like to keep the existing look of the navigation (what is currently on PROD).  This PR creates a seperate sign-in dropdown component with specific site classes and styling in order to slowly seperate away from the dependency on the AMA One SG.

## To Test:

**Setup**
- Pull branch [bugfix/DCP-230-add-site-specific-sign-in-dropdown](https://github.com/AmericanMedicalAssociation/ama-style-guide-2/tree/bugfix/DCP-230-add-site-specific-sign-in-dropdown) into SG directory
- Serve SG with `lando gulp serve`
- Link SG with `lando link-styleguides -a drfinder` in root directory
- Follow testing instructions at 


## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
