### PR TITLE
EWL-11043: Update subcat pill button markup

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
+++ b/styleguide/source/assets/scss/03-organisms/_subcategory-exploration.scss
@@ -57,11 +57,11 @@
         }
       }
     }
-    h2 {
+    div {
       a {
+        @include type($kepler-std, $font-weight-regular);
         line-height: 1;
         font-size: 14px;
-        font-weight: $font-weight-regular;
         @include breakpoint($bp-small) {
           font-size: 18px;
         }
@@ -69,18 +69,17 @@
     }
 
     a,
-    h2 {
+    div {
       color: $black;
       text-decoration: none;
       display: flex;
       margin-bottom: 0;
-      &:hover h2,
       &:hover {
         text-decoration: none;
       }
     }
 
-    h2 {
+    div {
       line-height: 26px;
     }
   }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.

## JIRA Ticket(s)
- [EWL-11043: Subcat exploration pills on category pages should not be marked as headings](https://ama-it.atlassian.net/browse/EWL-11043)


## Description:
Adjust the markup of subcategory exploration pill links to remove heading markup while preserving styling and functionality.


## To Test:
- checkout ama-d8 pr locally: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5425
- link styleguide locally
- import latest config
- clear caches
- Navigate to category page (i.e https://ama-one.lndo.site/health-care-advocacy)
- confirm subcat pill link appears with as expected with no visual changes
- inspect pill links
- confirm there is no h2 headings within the subcat pill link markup


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
