### PR TITLE
EWL-11454: Hamburger menu keyboard accessibility

### DIFF
--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -111,9 +111,33 @@
       // Closes menu on doc load
       $('#global-menu').prop('checked', false);
 
-      $('.ama__global-menu').click(function (e) {
+      function handleGlobalMenuActivate(e) {
+        // For keydown, only act on Enter or Space
+        if (e.type === 'keydown') {
+          if (!(e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32)) {
+            return;
+          }
+          e.preventDefault();
+          var $checkbox = $('#global-menu');
+          $checkbox.prop('checked', !$checkbox.prop('checked'));
+        }
+        // For click, just toggle if not already handled
+        if (e.type === 'click') {
+          var $checkbox = $('#global-menu');
+          $checkbox.prop('checked', !$checkbox.prop('checked'));
+        }
         hideShow();
         e.stopPropagation();
+      }
+
+      $('.ama__global-menu').on('click keydown', handleGlobalMenuActivate);
+
+      $('.ama_category_navigation_menu__group > .ama_category_navigation_menu__section a').on('keydown', function(e) {
+        // Check if Escape is pressed and focus is on the ul itself
+        if ((e.key === 'Escape' || e.keyCode === 27) && document.activeElement === this) {
+          $('#global-menu').prop('checked', false);
+          hideShow();
+        }
       });
 
       $(document).ready(function () {

--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -140,6 +140,16 @@
         }
       });
 
+      // When the element or any child loses focus
+      $categoryNavigationMenuGroup.on('focusout', function(e) {
+        // relatedTarget is the element gaining focus
+        // If it's not a descendant of this group, close the menu
+        if (!this.contains(e.relatedTarget)) {
+          $('#global-menu').prop('checked', false);
+          hideShow();
+        }
+      });
+
       $(document).ready(function () {
         // Clear search input on main nav on search page
         if(window.location.href.includes("/search")) {

--- a/styleguide/source/assets/scss/01-atoms/_menu-icon.scss
+++ b/styleguide/source/assets/scss/01-atoms/_menu-icon.scss
@@ -19,7 +19,7 @@
     + label.ui-button:active,
     + label.ui-button:active,
     + label.ui-button.ui-state-active:hover {
-      width: 30px;
+      width: 44px;
       display: block;
       padding: 0;
       cursor: pointer;
@@ -34,6 +34,7 @@
       .ama__global-menu__burger {
         content: '';
         width: 100%;
+        max-width: 30px;
         height: 3px;
         display: block;
         background-color: $purple;

--- a/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
+++ b/styleguide/source/assets/scss/03-organisms/_main-navigation.scss
@@ -85,6 +85,9 @@ header {
     @include breakpoint($bp-small) {
       margin-right: 28px;
     }
+    &:focus-visible {
+      outline: 2px solid $blue;
+    }
   }
 
   .ama_category_navigation_wrapper {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.

## JIRA Ticket(s)
- [EWL-11454: A11Y | Hamburger menu cannot be opened by keyboard](https://ama-it.atlassian.net/browse/EWL-11454)


## Description:
Adjust script and markup to enable users to activate the hamburger menu and navigate the menu with keyboard.


## To Test:
- checkout ama-d8 pr: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5509
- clear caches
- link styleguide locally
- confirm the following:
- Hamburger menu can be tabbed to and has focus state (see designs: https://www.figma.com/design/fp5pEZFkk8kxtwNtqgUWkc/AMAOne-Primary-Nav?node-id=2001-2364&t=4Yx20HzWEQlv8UDi-0)
- Confirm on enter/return key menu opens
- confirm menu can then be tabbed through
- confirm once all top level menu items are tabbed through focus moved to ama logo and menu closes
- Re-open menu through keyboard navigation and confirm pressing escape key closes menu

## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
