### PR TITLE
EWL-11589: Replace 30/70 block subtitle field with body field

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -56,16 +56,18 @@
             color: $black;
             margin-bottom: calc($gutter / 2);
         }
-        p.ama__h5 {
-            @include type($kepler-std, $font-weight-light);
-            font-size: 16px;
-            line-height: 20px;
-            color: $date-olive;
-            margin-bottom: 21px;
-            @include breakpoint($bp-med) {
-                font-size: 18px;
-                line-height: 24px;
-            }
+        p {
+            line-height: 28px;
+            margin-bottom: 18px;
+        }
+        ul, ol {
+            margin-left: 20px;
+        }
+        li {
+            font-size: 18px;
+            line-height: 28px;
+            font-weight: 400;
+            
         }
         [class*=button-main-] {
             min-width: 100%;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11589: Landing Page | 30/70 block description uses rich text](https://ama-it.atlassian.net/browse/EWL-11589)


## Description
Adds body copy rich text field intended to replace subtitle field within 30/70 block.


## To Test:
- checkout ama-d8 pr: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5676
- link styleguide locally
- import latest config
- clear caches
- add/edit any 30/70 block and confirm Body field appears
- **NOTE** subtitle field will still appear in form, but will no longer appear on the page
- Add copy with atleast one bulleted list item to body field
- save and add block to a landing page using layout builder
- publish page and confirm styling matches the following figma: https://www.figma.com/design/YMTpSoOk2x0B9GholUEap6/Abstract---Poster-Component?node-id=1488-1043&m=dev


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
