### PR TITLE
EWL-11611: 30 70 block video media styling

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -144,6 +144,15 @@
         @include breakpoint($bp-med) {
             margin: 0 0 0 20px;
         }
+
+        .ama__hub-hero__video {
+            @include breakpoint($bp-med max-width) {
+                min-height: 405px;
+            }
+            @include breakpoint($bp-small max-width) {
+                min-height: 265px;
+            }
+        }
     }
         &.image-left {
         &__aside {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


## JIRA Ticket(s)
- [EWL-11611: Landing Page | 30/70 block enhancements](https://ama-it.atlassian.net/browse/EWL-11611)


## Description:
Add option to place youtube and brightcove video media within 30-70 blocks. Add option to set cta style when a single cta is used.


## To Test
- checkout branch and follow instructions: https://github.com/AmericanMedicalAssociation/ama-d8/pull/5688


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
