### PR TITLE
EWL-111680: Remove 30/70 block border styling.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
+++ b/styleguide/source/assets/scss/02-molecules/_thirty-seventy-block.scss
@@ -1,6 +1,3 @@
-.thirty-seventy-wrapper {
-    border-bottom: 1px solid $gray-7;
-}
 .thirty-seventy-block {
     display: flex;
     flex-flow: column-reverse wrap;
@@ -217,11 +214,7 @@
 
 .layout.section.ama__category__row {
     .thirty-seventy-wrapper {
-        border-bottom:  none;
         padding-bottom: 0;
-        @include breakpoint($bp-med) {
-            //padding-bottom: $gutter;
-        }
     }
     .thirty-seventy-block {
         width: 100%;
@@ -248,7 +241,6 @@
 }
 
 .layout.section.ama__category__row .thirty-seventy-block {
-    border-bottom: none;
     @include breakpoint($bp-med) {
         padding-bottom: 0;
     }
@@ -269,8 +261,6 @@ a.thirty-seventy-wrapper,
 
 // Article Embed Styles
 .thirty-seventy-block-embed {
-    border-top: 1px solid $gray-7;
-    border-bottom: 1px solid $gray-7;
     padding-top: $gutter;
     padding-bottom: $gutter;
     @include breakpoint($bp-med) {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11680: 3070 | Remove bottom boarder on 3070 block](https://ama-it.atlassian.net/browse/EWL-11680)


## Description
Remove top and bottom border styling from 30/70 blocks.


## To Test
- link styleguide locally
- Confirm both top and bottom borders do not appear on 30/70 blocks for the following content/term types:
1. Homepage
2. Category
3. Subcategory
4. Landing Page
5. Article/WYSIWYG


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
