### PR TITLE
EWL-11640: Article header breadcrumb focus state fix

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_news.scss
+++ b/styleguide/source/assets/scss/05-pages/_news.scss
@@ -21,7 +21,7 @@
           padding: 0;
           margin-bottom: calc($gutter * .5);
           display: inline-block;
-          &:focus {
+          &:focus-visible {
             outline: 2px solid $blue;
             outline-offset: 5px;
             text-decoration: none;


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11640: Article Header | Breadcrumb focus state appears on incorrect trigger](https://ama-it.atlassian.net/browse/EWL-11640)


## Description
Adjust styling of breadcrumbs on articles to only activate focus state on tab through.


## To Test
- link styleguide locally
- on any article click on the subcat breadcrumb, confirm no focus state appears
- reload article, confirm on tab through of content, focus state activates on subcat breadcrumb


## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
