### PR TITLE
EWL-11722: Search bar keyboard functionality tab and reload fix.

### DIFF
--- a/styleguide/source/assets/js/main-navigation.js
+++ b/styleguide/source/assets/js/main-navigation.js
@@ -179,6 +179,7 @@
       $($mobileSearchTrigger).on('keydown', function(e) {
         // Check if Enter or Space is pressed and focus is on the button itself
         if ((e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) && e.target === this) {
+          e.preventDefault();
           $mobileSearch.slideToggle("fast", "linear");
           $mobileSearchTrigger.toggleClass('open');
           $('#edit-search').focus();

--- a/styleguide/source/assets/js/search-suggestions.js
+++ b/styleguide/source/assets/js/search-suggestions.js
@@ -31,6 +31,8 @@
             var $searchWrapper = context.querySelector('.search-suggestions-wrapper');
             var $searchBlock = context.querySelector('.search-suggestions-block');
             var $input = context.querySelector('.ama__global-search form input#edit-search, .ama__global-search form input[id^="edit-search--"]');
+            var $mobileSearchTrigger = context.querySelector('.global-search-trigger');
+            var $mobileSearch = context.querySelector('.ama__global-search');
 
             if (!$searchWrapper || !$searchBlock || !$input) {
                 return;
@@ -96,6 +98,9 @@
                 } else if ($searchWrapper.classList.contains('show')) {
                     $searchWrapper.classList.remove('show');
                     setTabIndex(false);
+                    $mobileSearchTrigger.classList.remove('open');
+                    $mobileSearchTrigger.focus();
+                    $mobileSearch.style.display = "none";
                 }
             }, true);
 


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [ ] Make this code secure.
- [ ] Make this code null and empty safe.
- [ ] Make this functionality accessible.
- [ ] Make this code more efficient.
- [ ] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


**Jira Ticket**
- [EWL-11722: A11Y | Search cannot be opened with keyboard on mobile/tablet](https://ama-it.atlassian.net/browse/EWL-11722)


## Description
Adjust scripts to fix keyboard navigation issues, prevent reload on enter key and close search bar after tabbing through the search suggestions menu.


## To Test
- link styleguide locally
- clear caches
- on mobile screen size tab through main navigation
- when focused on search icon, confirm on enter key press the search bar opens and focus is changed to the search input
- confirm the page does not reload
- continue to tab through search suggestions lists
- confirm once you finish tabbing through search suggestions the search suggestions menu and search bar closes and the focus returns to the search icon

## Visual Regressions
Ensure any available regression testing has been run.


## Relevant Screenshots/GIFs
Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks



## Additional Notes
Anything more to add?

---

[Guidelines for Contribution](CONTRIBUTING.md)
[SG2 Standards](ama-style-guide-2/docs/standards.md)
